### PR TITLE
chore: rename repo from leptonai-sdk to leptonai

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
           python -c "import leptonai; print(leptonai)"
 
           echo "Run unittests"
-          pytest -x leptonai-sdk
+          pytest -x leptonai
           cd -
       - name: Run End-To-End Tests
         if: inputs.run_e2e

--- a/.github/workflows/test-cp310.yaml
+++ b/.github/workflows/test-cp310.yaml
@@ -39,5 +39,5 @@ jobs:
         run: |
           pip install .[test]
           cd ..
-          pytest -x leptonai-sdk
+          pytest -x leptonai
           cd -

--- a/.github/workflows/test-cp38.yaml
+++ b/.github/workflows/test-cp38.yaml
@@ -34,5 +34,5 @@ jobs:
           fi
           pip install .[test]
           cd ..
-          pytest -x leptonai-sdk
+          pytest -x leptonai
           cd -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,13 @@ First and foremost, thank you for considering contributing to leptonai! We appre
 First clone the source code from Github
 
 ```
-git clone https://leptonai/leptonai-sdk.git
+git clone https://leptonai/leptonai.git
 ```
 
 Use `pip` to install `leptonai` from source
 
 ```shell
-cd leptonai-sdk
+cd leptonai
 pip install -e .
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/leptonai/leptonai-sdk/main/assets/logo.svg" height=100>
+<img src="https://raw.githubusercontent.com/leptonai/leptonai/main/assets/logo.svg" height=100>
 
 # LeptonAI SDK
 
@@ -54,7 +54,7 @@ print(c.run(inputs="I enjoy walking with my cute dog"))
 
 Fully managed Llama2 models and CodeLlama models can be found in the [playground](https://dashboard.lepton.ai/playground).
 
-Many standard HuggingFace pipelines are supported - find out more details in the [documentation](https://www.lepton.ai/docs/advanced/prebuilt_photons#hugging-face-photons). Not all HuggingFace models are supported though, as many of them contain custom code and are not standard pipelines. If you find a popular model you would like to support, please [open an issue or a PR](https://github.com/leptonai/leptonai-sdk/issues/new).
+Many standard HuggingFace pipelines are supported - find out more details in the [documentation](https://www.lepton.ai/docs/advanced/prebuilt_photons#hugging-face-photons). Not all HuggingFace models are supported though, as many of them contain custom code and are not standard pipelines. If you find a popular model you would like to support, please [open an issue or a PR](https://github.com/leptonai/leptonai/issues/new).
 
 ## Checking out more examples
 
@@ -126,7 +126,7 @@ For more details, checkout the [documentation](https://lepton.ai/docs/) and the 
 
 ## Contributing
 
-Contributions and collaborations are welcome and highly appreciated. Please check out the [contributor guide](https://github.com/leptonai/leptonai-sdk/blob/main/CONTRIBUTING.md) for how to get involved.
+Contributions and collaborations are welcome and highly appreciated. Please check out the [contributor guide](https://github.com/leptonai/leptonai/blob/main/CONTRIBUTING.md) for how to get involved.
 
 ## License
 

--- a/leptonai/photon/hf/hf.py
+++ b/leptonai/photon/hf/hf.py
@@ -162,7 +162,7 @@ class HuggingfacePhoton(Photon):
                 f'Unsupported Huggingface model: "{model_str}" (task: {hf_task}). This'
                 " task is not supported by LeptonAI SDK yet. If you would like us to"
                 " add support for this task type, please let us know by opening an"
-                " issue at https://github.com/lepton/leptonai-sdk/issues/new/choose."
+                " issue at https://github.com/lepton/leptonai/issues/new/choose."
                 f"\nCurrently supported HF tasks are: {cls.supported_tasks()}."
             )
 
@@ -257,7 +257,7 @@ class HuggingfacePhoton(Photon):
                 f"Lepton currently does not support the specified task: {hf_task}. If"
                 " you would like us to support this task, please let us know by"
                 " opening an issue"
-                " at https://github.com/leptonai/leptonai-sdk/issues/new/choose, and"
+                " at https://github.com/leptonai/leptonai/issues/new/choose, and"
                 " kindly include the specific model that you are trying to run for"
                 " debugging purposes: {model_str}"
             )

--- a/leptonai/photon/hf/hf_utils.py
+++ b/leptonai/photon/hf/hf_utils.py
@@ -266,10 +266,10 @@ def hf_missing_package_error_message(
         " may be different, and you may need to search pypi for the correct package"
         " name)\n\n2. If you are using LeptonAI SDK, we maintain a mapping from known"
         " HuggingFace pipelines to their dependencies. We appreciate if you can send a"
-        " PR to https://github.com/leptonai/leptonai-sdk/ to add the missing"
+        " PR to https://github.com/leptonai/leptonai/ to add the missing"
         f' dependencies.Specifically, it looks like this:\n\n"{pipeline_name}":[\n   '
         f' "{separator.join(missing_packages)}"\n]\n\n(please refer to'
-        " [https://github.com/leptonai/leptonai-sdk/blob/main/leptonai/photon/hf/hf_dependencies.py]"
+        " [https://github.com/leptonai/leptonai/blob/main/leptonai/photon/hf/hf_dependencies.py]"
         " for more details)"
     )
 


### PR DESCRIPTION
Since this actually is the main repo and not a sdk.