### PR TITLE
feat(sdk): set default timeout to 1 hour for all deployments

### DIFF
--- a/leptonai/cloudrun/remote.py
+++ b/leptonai/cloudrun/remote.py
@@ -16,7 +16,7 @@ from loguru import logger
 
 from leptonai.photon import Photon
 from leptonai.photon.util import create as create_photon
-from leptonai import api
+from leptonai import api, config
 from leptonai.api import APIError
 from leptonai.client import Client, current
 
@@ -40,7 +40,9 @@ class Remote(object):
 
     _MAX_WAIT_TIME = 600  # In the Remote class, we wait for at most 10 minutes for the photon to be ready.
     _MAX_CLIENT_WAIT_TIME = 30  # In the Remote class, we wait for at most 30 seconds for DNS and other propagation between the deployment being ready and the client being accessable.
-    _DEFAULT_TIMEOUT = 1200  # In the Remote class, we set the timeout for the deployments to be 10 minutes by default.
+    _DEFAULT_TIMEOUT = (
+        config.CLOUDRUN_DEFAULT_TIMEOUT
+    )  # Similar to the default timeout in the deployment class, we will set the default timeout to 1 hour.
     _DEFAULT_WAIT_INTERVAL = 1  # In the Remote class, we wait for 1 second between each check for the photon to be ready.
 
     # A best-effort global variable for Remote objects, and a best-effort cleanup function.

--- a/leptonai/cloudrun/tests/test_cloudrun.py
+++ b/leptonai/cloudrun/tests/test_cloudrun.py
@@ -64,13 +64,13 @@ class TestInline(unittest.TestCase):
         "No timeout support",
     )
     def test_timeout(self):
-        remote_run = Remote(MyPhoton(), no_traffic_timeout=10)
+        remote_run = Remote(MyPhoton(), no_traffic_timeout=60)
         self.assertTrue(remote_run.healthz())
         self.assertEqual(remote_run.foo(), "hello world!")
 
         # The tiemout check is done with +- 30 second margin, so we wait for
         # a sufficiently long time.
-        time.sleep(60)
+        time.sleep(90)
         # Test if it is actually shut down
         deployment_id = remote_run.deployment_id
         self.assertIsNotNone(deployment_id)

--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -7,6 +7,86 @@ import sys
 
 import pydantic.version
 
+# Cache directory for Lepton's local configurations.
+# Usually, you should not need to change this. In cases like unit testing, you
+# can change this to a directory that is available via the environment variable
+# `LEPTON_CACHE_DIR`, BEFORE IMPORTING LEPTONAI.
+#
+# Implementation note: cache directory is not always created, and this is by design.
+# In some cases such as function compute, you may not have a directory to write
+# cache into. As a result, we create the cache directory when we need to write to it.
+CACHE_DIR = Path(os.environ.get("LEPTON_CACHE_DIR", Path.home() / ".cache" / "lepton"))
+
+################################################################################
+# Configurations you can change to customize Lepton's behavior.
+################################################################################
+
+# Whether to trust remote code. This is often used in model repositories such as
+# HuggingFace's tokenizer. In default, we will allow users to trust remote code
+# and run such tokenizers. Set the environment variable `LEPTON_TRUST_REMOTE_CODE`
+# to `false` to disable this behavior.
+TRUST_REMOTE_CODE = os.environ.get("LEPTON_TRUST_REMOTE_CODE", "true").lower() in (
+    "true",
+    "1",
+    "t",
+    "on",
+)
+
+# Whether to set deployments to have a default timeout of 1 hour. This is often
+# preferred in a development environment. Set the environment variable `LEPTON_DEFAULT_TIMEOUT`
+# to `false` to disable this behavior.
+_DEFAULT_TIMEOUT_IF_NOT_SPECIFIED = 3600
+if os.environ.get(
+    "LEPTON_DEFAULT_TIMEOUT", str(_DEFAULT_TIMEOUT_IF_NOT_SPECIFIED)
+).lower() in ("f", "off", "false", "0"):
+    # Do not set a default timeout.
+    DEFAULT_TIMEOUT = None
+else:
+    timeout_str = os.environ.get(
+        "LEPTON_DEFAULT_TIMEOUT", str(_DEFAULT_TIMEOUT_IF_NOT_SPECIFIED)
+    )
+    try:
+        DEFAULT_TIMEOUT = int(timeout_str)
+    except ValueError:
+        DEFAULT_TIMEOUT = 3600
+        print(
+            f"You have set an invalid value for LEPTON_DEFAULT_TIMEOUT {timeout_str}."
+            f" Using default value of {DEFAULT_TIMEOUT} seconds."
+        )
+
+
+# In cloudrun, the default timeout is also set to 1 hour. However, even if we set
+# LEPTON_DEFAULT_TIMEOUT to false, we still want to set the default timeout inside
+# cloudrun, because it was expected to be in-process.
+CLOUDRUN_DEFAULT_TIMEOUT = 3600
+if os.environ.get("LEPTON_CLOUDRUN_DEFAULT_TIMEOUT", None) is not None:
+    try:
+        CLOUDRUN_DEFAULT_TIMEOUT = int(
+            os.environ.get("LEPTON_CLOUDRUN_DEFAULT_TIMEOUT")
+        )
+    except ValueError:
+        print(
+            "You have set an invalid value for LEPTON_CLOUDRUN_DEFAULT_TIMEOUT"
+            f" {os.environ.get('LEPTON_CLOUDRUN_DEFAULT_TIMEOUT')}. Using default value"
+            f" of {CLOUDRUN_DEFAULT_TIMEOUT} seconds."
+        )
+
+
+################################################################################
+# Automatically generated constants. You do not need to change these.
+################################################################################
+
+if pydantic.version.VERSION < "2.0.0":
+    PYDANTIC_MAJOR_VERSION = 1
+else:
+    PYDANTIC_MAJOR_VERSION = 2
+
+
+################################################################################
+# Lepton internals. Do not change these as they will change the behavior of the
+# library and APIs.
+################################################################################
+
 # Cache directory for Lepton's local storage: database, logs, etc.
 # To change the cache directory, set the environment variable LEPTON_CACHE_DIR before importing leptonai.
 # User note: cache directory is not directly created, and this is by design - in some cases such as
@@ -56,15 +136,3 @@ LEPTON_WORKSPACE_URL = LEPTON_DASHBOARD_URL + "/workspace/{workspace_id}"
 # LEPTON_DEPLOYMENT_URL is used to get the web url for the deployment.
 # Append "/demo", "/api", "/metrics", "/events", "/replicas/list" for the deployment dashboard functions.
 LEPTON_DEPLOYMENT_URL = LEPTON_WORKSPACE_URL + "/deployments/detail/{deployment_name}"
-
-if pydantic.version.VERSION < "2.0.0":
-    PYDANTIC_MAJOR_VERSION = 1
-else:
-    PYDANTIC_MAJOR_VERSION = 2
-
-TRUST_REMOTE_CODE = os.environ.get("LEPTON_TRUST_REMOTE_CODE", "true").lower() in (
-    "true",
-    "1",
-    "t",
-    "on",
-)

--- a/leptonai/photon/prebuilt/echo.py
+++ b/leptonai/photon/prebuilt/echo.py
@@ -1,0 +1,26 @@
+from leptonai.photon import Photon
+
+
+class Echo(Photon):
+    """
+    A very simple example photon for demo and debugging purposes. It exposes one
+    endpoint `/echo` that returns the input string as the response. If you are
+    using the Lepton CLI, you can run this photon with the following command:
+
+    ```bash
+    lepton photon run -n echo -m leptonai.photon.prebuilt.echo.Echo
+    ```
+
+    And you can use the client to call the endpoint:
+
+    ```python
+    client.echo(input="Hello World!")
+    ```
+    """
+
+    @Photon.handler
+    def echo(self, input: str) -> str:
+        """
+        Echo the input string.
+        """
+        return input


### PR DESCRIPTION
Per offline discussion - this allows a more efficient usage for development use cases by avoiding dangling deployments.