### PR TITLE
Adds einops dependency in hf text generation Photon

### DIFF
--- a/leptonai/photon/hf/hf.py
+++ b/leptonai/photon/hf/hf.py
@@ -318,7 +318,7 @@ def _get_generated_text(res):
 
 class HuggingfaceTextGenerationPhoton(HuggingfacePhoton):
     hf_task: str = "text-generation"
-    requirement_dependency: Optional[List[str]] = ["ctransformers"]
+    requirement_dependency: Optional[List[str]] = ["ctransformers", "einops"]
 
     @Photon.handler(
         "run",


### PR DESCRIPTION
**Title:** Add 'einops' dependency for 'microsoft/phi-1_5' model support in Huggingface Photon

**Description:**
This PR addresses the need for an additional dependency, 'einops,' to enable support for the 'microsoft/phi-1_5' model in Huggingface Photon's text generation capabilities.

**Changes Made:**
In the leptonai/photon/hf/hf.py file, I've modified the HuggingfaceTextGenerationPhoton class by adding the 'einops' dependency to the requirement_dependency list. 

