### PR TITLE
feat: add support to hf question answering models

### DIFF
--- a/leptonai/photon/hf/hf.py
+++ b/leptonai/photon/hf/hf.py
@@ -883,6 +883,30 @@ class HuggingfaceFeatureExtractionPhoton(HuggingfacePhoton):
         return res
 
 
+class HuggingfaceQuestionAnsweringPhoton(HuggingfacePhoton):
+    hf_task: str = "question-answering"
+
+    @Photon.handler(
+        example={
+            "question": "How many programming languages does BLOOM support?",
+            "context": (
+                "BLOOM has 176 billion parameters and can generate text in 46 languages"
+                " natural languages and 13 programming languages."
+            ),
+        }
+    )
+    def run(
+        self,
+        inputs: Union[Dict[str, str], List[Dict[str, str]]],
+        **kwargs,
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        res = self._run_pipeline(
+            inputs,
+            **kwargs,
+        )
+        return res
+
+
 def register_hf_photon():
     schema_registry.register(
         HUGGING_FACE_SCHEMAS, HuggingfacePhoton.create_from_model_str

--- a/leptonai/photon/hf/hf_utils.py
+++ b/leptonai/photon/hf/hf_utils.py
@@ -245,6 +245,7 @@ for task in [
     "text-classification",
     "text-generation",
     "text2text-generation",
+    "question-answering",
 ]:
     pipeline_registry.register(
         task,

--- a/leptonai/photon/tests/test_photon_cli.py
+++ b/leptonai/photon/tests/test_photon_cli.py
@@ -37,6 +37,7 @@ depth_estimation_model = "hf:hf-tiny-model-private/tiny-random-GLPNForDepthEstim
 microsoft_phi_model = "hf:microsoft/phi-1_5"
 image_to_text_model = "hf:Salesforce/blip-image-captioning-base"
 feature_extraction_model = "hf:hf-tiny-model-private/tiny-random-RobertaModel"
+question_answering_model = "hf:deepset/tinyroberta-squad2"
 
 
 class TestPhotonCli(unittest.TestCase):
@@ -146,6 +147,7 @@ class TestPhotonCli(unittest.TestCase):
             (microsoft_phi_model,),
             (image_to_text_model,),
             (feature_extraction_model,),
+            (question_answering_model,),
         ]
     )
     def test_photon_run(self, model):


### PR DESCRIPTION
This PR is to incorporate Huggingface question answering model support.  Please review to determine its necessity and whether any crucial changes are absent.

eg, run: `lep ph run -n tiny-roberta-squad -m hf:deepset/tinyroberta-squad2`