### PR TITLE
Pin cloudpickle version to 2.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 anyio
 click
-cloudpickle
+cloudpickle==2.2.1
 fastapi
 httpx
 limits


### PR DESCRIPTION
there is a new version of cloudpickle released today, we have run into errors in e2e tests when local cloudpickle version is new (3.0.0) and remote cloudpickle version is old (2.2.1).

```
got /opt/lepton/venv/bin/lep
Failed to launch photon: Can't get attribute '_class_setstate' on <module
'cloudpickle.cloudpickle' from
'/opt/lepton/venv/lib/python3.10/site-packages/cloudpickle/cloudpickle.py'>
```

Not sure if it's an issue in new version of it's a version mismatch. Pin to old version for now to unbreak.