### PR TITLE
feat(sdk): make all @Photon.handler calls async in its own pool.

### DIFF
--- a/leptonai/photon/background.py
+++ b/leptonai/photon/background.py
@@ -13,17 +13,12 @@ def create_limiter(max_concurrency):
 # custom limiter (we use it to control max concurrency)
 class BackgroundTask:
     def __init__(self, func, *args, **kwargs):
-        self.func = func
-        self.args = args
-        self.kwargs = kwargs
+        if inspect.iscoroutinefunction(func):
+            raise ValueError("Background tasks cannot be async functions.")
+        self.func = functools.partial(func, *args, **kwargs)
 
     async def __call__(self, limiter=None):
         try:
-            if inspect.iscoroutinefunction(self.func):
-                return await self.func(*self.args, **self.kwargs)
-            else:
-                # anyio.to_thread.run_sync doesn't accept kwargs
-                func = functools.partial(self.func, **self.kwargs)
-                return await anyio.to_thread.run_sync(func, *self.args, limiter=limiter)
+            return await anyio.to_thread.run_sync(self.func, limiter=limiter)
         except Exception as e:
             logger.exception(e)

--- a/leptonai/photon/background.py
+++ b/leptonai/photon/background.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 import functools
 
@@ -20,7 +19,7 @@ class BackgroundTask:
             logger.debug(f"Running background task with {self.func}")
             async with semaphore:
                 result = await anyio.to_thread.run_sync(self.func)
+                logger.debug(f"Finished background task with {self.func}")
                 return result
-            logger.debug(f"Finished background task with {self.func}")
         except Exception as e:
             logger.exception(e)

--- a/leptonai/photon/batcher.py
+++ b/leptonai/photon/batcher.py
@@ -6,7 +6,7 @@ import time
 from typing import List, Optional
 from uuid import uuid4
 
-from leptonai.util import asyncfy
+from leptonai.util import asyncfy_with_semaphore
 
 
 def batch(
@@ -31,7 +31,7 @@ def batch(
         raise ValueError("max_wait_time should be greater than 0")
 
     def decorator(func):
-        func = asyncfy(func, semaphore)
+        func = asyncfy_with_semaphore(func, semaphore)
 
         # list of (request_id, args, kwargs)
         # using list here is a hack to make it mutable inside closures

--- a/leptonai/photon/batcher.py
+++ b/leptonai/photon/batcher.py
@@ -9,7 +9,11 @@ from uuid import uuid4
 from leptonai.util import asyncfy
 
 
-def batch(max_batch_size: int, max_wait_time: float, semaphore: Optional[anyio.Semaphore] = None):
+def batch(
+    max_batch_size: int,
+    max_wait_time: float,
+    semaphore: Optional[anyio.Semaphore] = None,
+):
     """Decorator that batches calls to a function
 
     Args:

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -12,7 +12,6 @@ import logging
 import os
 import re
 import sys
-import time
 import traceback
 from typing import Callable, Any, List, Optional, Set, Iterator, Type
 from typing_extensions import Annotated

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -149,7 +149,7 @@ class Photon(BasePhoton):
 
     # The maximum number of concurrent requests that the photon can handle. In default when the photon
     # concurrency is 1, all the endpoints defined by @Photon.handler is mutually exclusive, and at any
-    # time only one endpoint is running. This does not include system generated endpoints such as 
+    # time only one endpoint is running. This does not include system generated endpoints such as
     # /openapi.json, /metrics, /healthz, /favicon.ico, etc.
     #
     # This parameter does not apply to any async endpoints you define. In other words, if you define
@@ -159,7 +159,7 @@ class Photon(BasePhoton):
     #       ...
     # then the endpoint is not subject to the photon concurrency limit. You will need to manually
     # limit the concurrency of the endpoint yourself.
-    # 
+    #
     # Note that, similar to the standard multithreading design pattens, the Photon class cannot guarantee
     # thread safety when handler_max_concurrency > 1. The lepton ai framework itself is thread safe, but the
     # thread safety of the methods defines in the Photon class needs to be manually guaranteed by the
@@ -203,10 +203,14 @@ class Photon(BasePhoton):
 
         # TODO(Yangqing): add sanity check to see if the user has set handler_max_concurrency too high to
         # be handled by the default anyio number of threads.
-        self._handler_semaphore: anyio.Semaphore = anyio.Semaphore(self.handler_max_concurrency)
+        self._handler_semaphore: anyio.Semaphore = anyio.Semaphore(
+            self.handler_max_concurrency
+        )
 
         self._background_tasks: Set[BackgroundTask] = set()
-        self._background_task_semaphore: anyio.Semaphore = anyio.Semaphore(self.background_tasks_max_concurrency)
+        self._background_task_semaphore: anyio.Semaphore = anyio.Semaphore(
+            self.background_tasks_max_concurrency
+        )
 
     def _on_background_task_done(self, task):
         """
@@ -234,7 +238,7 @@ class Photon(BasePhoton):
             in_event_loop = True
         except RuntimeError:
             in_event_loop = False
-        
+
         def _run_background_task():
             co = BackgroundTask(func, *args, **kwargs)
             task = asyncio.create_task(co(self._background_task_semaphore))
@@ -480,7 +484,12 @@ class Photon(BasePhoton):
 
     def _create_app(self, load_mount):
         title = self.name.replace(".", "_")
-        app = FastAPI(title=title, description=self.__doc__ if self.__doc__ else f"Lepton AI Photon API {self.name}")
+        app = FastAPI(
+            title=title,
+            description=(
+                self.__doc__ if self.__doc__ else f"Lepton AI Photon API {self.name}"
+            ),
+        )
 
         # web hosted cdn and inference api have different domains:
         # https://github.com/leptonai/lepton/issues/358

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+import anyio
 import asyncio
 from collections import OrderedDict
 import copy
@@ -145,6 +146,24 @@ class Photon(BasePhoton):
     obj_pkl_filename: str = "obj.pkl"
     py_src_filename: str = "py.py"
 
+    # The maximum number of concurrent requests that the photon can handle. In default when the photon
+    # concurrency is 1, all the endpoints defined by @Photon.handler is mutually exclusive, and at any
+    # time only one endpoint is running. This does not include system generated endpoints such as 
+    # /openapi.json, /metrics, /healthz, /favicon.ico, etc.
+    #
+    # This parameter does not apply to any async endpoints you define. In other words, if you define
+    # an endpoint like
+    #   @Photon.handler
+    #   async def foo(self):
+    #       ...
+    # then the endpoint is not subject to the photon concurrency limit. You will need to manually
+    # limit the concurrency of the endpoint yourself.
+    # 
+    # Note that, similar to the standard multithreading design pattens, the Photon class cannot guarantee
+    # thread safety when handler_max_concurrency > 1. The lepton ai framework itself is thread safe, but the
+    # thread safety of the methods defines in the Photon class needs to be manually guaranteed by the
+    # author of the photon.
+    handler_max_concurrency: int = 1
     background_tasks_max_concurrency: int = 1
 
     # The docker base image to use for the photon. In default, we encourage you to use the
@@ -181,6 +200,10 @@ class Photon(BasePhoton):
         self._init_called = False
         self._init_res = None
 
+        # TODO(Yangqing): add sanity check to see if the user has set handler_max_concurrency too high to
+        # be handled by the default anyio number of threads.
+        self._handler_semaphore: anyio.Semaphore = anyio.Semaphore(self.handler_max_concurrency)
+
         self._background_tasks: Set[BackgroundTask] = set()
         self._background_tasks_limiter = None
 
@@ -199,7 +222,9 @@ class Photon(BasePhoton):
         number of concurrent background tasks to 1.
 
         Args:
-            func: the Callable function to run.
+            func: the Callable function to run. It should be a sync function to not
+                block the main event loop. This function will be called in a separate
+                thread.
             *args, **kwargs: the args and kwargs to pass to the function.
         """
         if self._background_tasks_limiter is None:
@@ -445,7 +470,7 @@ class Photon(BasePhoton):
 
     def _create_app(self, load_mount):
         title = self.name.replace(".", "_")
-        app = FastAPI(title=title, description=self.__doc__)
+        app = FastAPI(title=title, description=self.__doc__ if self.__doc__ else f"Lepton AI Photon API {self.name}")
 
         # web hosted cdn and inference api have different domains:
         # https://github.com/leptonai/lepton/issues/358
@@ -635,14 +660,14 @@ class Photon(BasePhoton):
             raise
 
         try:
-            import gradio as gr
+            import gradio as gr  # type: ignore
 
             has_gradio = True
         except ImportError:
             has_gradio = False
 
         try:
-            from flask import Flask
+            from flask import Flask  # type: ignore
 
             has_flask = True
         except ImportError:
@@ -690,11 +715,12 @@ class Photon(BasePhoton):
 
         if kwargs.get("max_batch_size") is not None:
             method = batch(
-                max_batch_size=kwargs["max_batch_size"],
-                max_wait_time=kwargs["max_wait_time"],
+                kwargs["max_batch_size"],
+                kwargs["max_wait_time"],
+                self._handler_semaphore,
             )(method)
         else:
-            method = asyncfy(method)
+            method = asyncfy(method, self._handler_semaphore)
 
         if kwargs.get("rate_limit") is not None:
             rate_limiter = RateLimiter(kwargs["rate_limit"])

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -54,7 +54,7 @@ from leptonai.photon.types import (  # noqa: F401
     PNGResponse,
     WAVResponse,
 )
-from leptonai.util import switch_cwd, patch, asyncfy
+from leptonai.util import switch_cwd, patch, asyncfy_with_semaphore
 from .base import BasePhoton, schema_registry
 from .batcher import batch
 from .background import BackgroundTask
@@ -738,7 +738,7 @@ class Photon(BasePhoton):
                 self._handler_semaphore,
             )(method)
         else:
-            method = asyncfy(method, self._handler_semaphore)
+            method = asyncfy_with_semaphore(method, self._handler_semaphore)
 
         if kwargs.get("rate_limit") is not None:
             rate_limiter = RateLimiter(kwargs["rate_limit"])

--- a/leptonai/photon/tests/test_photon.py
+++ b/leptonai/photon/tests/test_photon.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import time
 
 # Set cache dir to a temp dir before importing anything from leptonai
 tmpdir = tempfile.mkdtemp()
@@ -788,7 +789,6 @@ class CustomPhoton2(Photon):
             model=custom_py.name,
         )
 
-    @async_test
     def test_batch_handler(self):
         class BatchPhoton(Photon):
             @Photon.handler(max_batch_size=2, max_wait_time=5)
@@ -850,7 +850,6 @@ class CustomPhoton2(Photon):
         self.assertEqual(res.status_code, 200, res.text)
         self.assertEqual(res.json(), {"hello": ans})
 
-    @async_test
     def test_batch_with_get(self):
         class BatchGetPhoton(Photon):
             @Photon.handler(max_batch_size=2, max_wait_time=5, method="GET")
@@ -945,8 +944,8 @@ class CustomPhoton2(Photon):
             client.openapi["info"]["description"], "This is a well documented photon"
         )
 
-    @async_test
-    async def test_background_task(self):
+    def test_background_task(self):
+        # self.assertTrue(False)
         class BackgroundTaskPhoton(Photon):
             def init(self):
                 self.counter = 0
@@ -970,10 +969,10 @@ class CustomPhoton2(Photon):
         client = Client(f"http://127.0.0.1:{port}")
         self.assertEqual(client.val(), 0)
         self.assertEqual(client.add_later(x=3), 0)
-        await asyncio.sleep(0.1)
+        time.sleep(0.1)
         self.assertEqual(client.val(), 3)
 
-    @async_test
+
     async def test_background_max_concurrency(self):
         class BackgroundTaskPhoton(Photon):
             def init(self):

--- a/leptonai/photon/tests/test_photon.py
+++ b/leptonai/photon/tests/test_photon.py
@@ -32,7 +32,6 @@ import concurrent.futures
 from io import BytesIO
 import inspect
 from textwrap import dedent
-import threading
 import shutil
 import subprocess
 import sys

--- a/leptonai/photon/tests/test_photon.py
+++ b/leptonai/photon/tests/test_photon.py
@@ -983,7 +983,9 @@ class CustomPhoton2(Photon):
                 # TODO: we should write a more complete test.
                 if self.running_task:
                     raise RuntimeError(
-                        "background tasks is having a concurrency, which should not happen.")
+                        "background tasks is having a concurrency, which should not"
+                        " happen."
+                    )
                 self.running_task = 1
                 time.sleep(0.1)
                 self._val += 1

--- a/leptonai/photon/tests/test_photon_concurrency.py
+++ b/leptonai/photon/tests/test_photon_concurrency.py
@@ -64,6 +64,15 @@ class SimpleAsyncPhoton(Photon):
 
 
 class TestPhotonConcurrencyBasic(unittest.TestCase):
+    def setUp(self):
+        # pytest imports test files as top-level module which becomes
+        # unavailable in server process
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            import cloudpickle
+            import sys
+
+            cloudpickle.register_pickle_by_value(sys.modules[__name__])
+
     def test_simple_photon(self):
         name = random_name()
         ph = SimplePhoton(name=name)

--- a/leptonai/photon/tests/test_photon_concurrency.py
+++ b/leptonai/photon/tests/test_photon_concurrency.py
@@ -14,9 +14,15 @@ Specifically, the following are tested:
 
 import asyncio
 import concurrent.futures
+import os
+import tempfile
 import threading
 import time
 import unittest
+
+# Set cache dir to a temp dir before importing anything from leptonai
+tmpdir = tempfile.mkdtemp()
+os.environ["LEPTON_CACHE_DIR"] = tmpdir
 
 from leptonai import Photon
 from leptonai.client import Client, local

--- a/leptonai/photon/tests/test_photon_concurrency.py
+++ b/leptonai/photon/tests/test_photon_concurrency.py
@@ -1,0 +1,146 @@
+"""
+This file is used to test the concurrency of the photon module.
+
+Specifically, the following are tested:
+- For synchronous endpoints defined with @Photon.handler, they
+  can be called concurrently.
+- When the endpoints are being called, the photon server can
+  still accept new connections.
+- For asynchronous endpoints defined with @Photon.handler, we
+  are not automatically making them parallel, but as long as
+  the user is using async primitives (e.g. async with, await),
+  they can be called concurrently.
+"""
+
+import asyncio
+import concurrent.futures
+import threading
+import time
+import unittest
+
+from leptonai import Photon
+from leptonai.client import Client, local
+
+from utils import random_name, photon_run_local_server
+
+
+class SimplePhoton(Photon):
+    handler_max_concurrency = 5
+
+    @Photon.handler
+    def return_time(self, seconds: float) -> float:
+        time.sleep(seconds)
+        return time.time()
+
+    @Photon.handler
+    def return_thread_id(self) -> int:
+        # sleep for a small amount time to make sure that thread stays longer than map()
+        # overhead.
+        time.sleep(0.01)
+        return threading.get_ident()
+
+
+class SimpleAsyncPhoton(Photon):
+    handler_max_concurrency = 5
+
+    @Photon.handler
+    async def return_time(self, seconds: float) -> float:
+        """
+        This is an async endpoint
+        """
+        await asyncio.sleep(seconds)
+        return time.time()
+
+    @Photon.handler
+    async def return_time_with_sync_sleep(self, seconds: float) -> float:
+        time.sleep(seconds)
+        return time.time()
+
+
+class TestPhotonConcurrencyBasic(unittest.TestCase):
+    def test_simple_photon(self):
+        name = random_name()
+        ph = SimplePhoton(name=name)
+        path = ph.save()
+
+        proc, port = photon_run_local_server(path=path)
+
+        client = Client(local(port=port))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            trials = [0.1] * 5
+            start = time.time()
+            return_times = list(
+                executor.map(lambda v: client.return_time(seconds=v), trials)
+            )
+            # assert that all tasks are executed in parallel
+            self.assertTrue(all([t - start < 0.15 for t in return_times]))
+
+            trials = [0.1] * 10
+            start = time.time()
+            return_times = list(
+                executor.map(lambda v: client.return_time(seconds=v), trials)
+            )
+            # it should be taking a total of ~ 0.2 seconds, with the first 5 finishing in 0.15 seconds.
+            self.assertEqual(sum([t - start < 0.15 for t in return_times]), 5)
+
+            trials = [1] + [0.1] * 40
+            start = time.time()
+            return_times = list(
+                executor.map(lambda v: client.return_time(seconds=v), trials)
+            )
+            # All the "waiting for 0.1s" jobs should finish by the first second.
+            self.assertTrue(all([t - start < 1.1 for t in return_times]))
+
+            trials = range(5)
+            thread_ids = list(executor.map(lambda v: client.return_thread_id(), trials))
+            # the thread ids should be different
+            self.assertEqual(len(set(thread_ids)), 5)
+
+        proc.kill()
+
+    def test_simple_async_photon(self):
+        name = random_name()
+        ph = SimpleAsyncPhoton(name=name)
+        path = ph.save()
+
+        proc, port = photon_run_local_server(path=path)
+
+        client = Client(local(port=port))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            trials = [0.1] * 5
+            start = time.time()
+            return_times = list(
+                executor.map(lambda v: client.return_time(seconds=v), trials)
+            )
+            # assert that all tasks are executed in parallel
+            self.assertTrue(all([t - start < 0.15 for t in return_times]))
+
+            trials = [0.1] * 10
+            start = time.time()
+            return_times = list(
+                executor.map(lambda v: client.return_time(seconds=v), trials)
+            )
+            # it should be taking a total of ~ 0.2 seconds, with the first 5 finishing in 0.15 seconds.
+            self.assertEqual(sum([t - start < 0.15 for t in return_times]), 5)
+
+            trials = [1] + [0.1] * 40
+            start = time.time()
+            return_times = list(
+                executor.map(lambda v: client.return_time(seconds=v), trials)
+            )
+            # All the "waiting for 0.1s" jobs should finish by the first second.
+            self.assertTrue(all([t - start < 1.1 for t in return_times]))
+
+            # But, when using return_time_with_sync_sleep, it should be blocking
+            trials = [0.1] * 5
+            start = time.time()
+            return_times = list(
+                executor.map(
+                    lambda v: client.return_time_with_sync_sleep(seconds=v), trials
+                )
+            )
+            self.assertGreaterEqual(max([t - start for t in return_times]), 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/photon/tests/utils.py
+++ b/leptonai/photon/tests/utils.py
@@ -95,6 +95,6 @@ def async_test(f):
 
     @functools.wraps(f)
     def wrapped(*args, **kwargs):
-        return asyncio.run(asyncfy(f)(*args, **kwargs))
+        return asyncio.run(asyncfy(f, None)(*args, **kwargs))
 
     return wrapped

--- a/leptonai/photon/tests/utils.py
+++ b/leptonai/photon/tests/utils.py
@@ -95,6 +95,6 @@ def async_test(f):
 
     @functools.wraps(f)
     def wrapped(*args, **kwargs):
-        return asyncio.run(asyncfy(f, None)(*args, **kwargs))
+        return asyncio.run(asyncfy(f)(*args, **kwargs))
 
     return wrapped

--- a/leptonai/util/__init__.py
+++ b/leptonai/util/__init__.py
@@ -8,6 +8,7 @@ from .util import (
     switch_cwd,
     check_photon_name,
     patch,
+    asyncfy,
     asyncfy_with_semaphore,
     _is_local_url,
     _is_valid_url,

--- a/leptonai/util/__init__.py
+++ b/leptonai/util/__init__.py
@@ -8,7 +8,7 @@ from .util import (
     switch_cwd,
     check_photon_name,
     patch,
-    asyncfy,
+    asyncfy_with_semaphore,
     _is_local_url,
     _is_valid_url,
 )

--- a/leptonai/util/util.py
+++ b/leptonai/util/util.py
@@ -77,12 +77,10 @@ def asyncfy(func, semaphore: Optional[anyio.Semaphore]):
     @wraps(func)
     async def async_func(*args, **kwargs):
         if semaphore is None:
-            return await anyio.to_thread.run_sync(
-                partial(func, *args, **kwargs))
+            return await anyio.to_thread.run_sync(partial(func, *args, **kwargs))
         else:
             async with semaphore:
-                return await anyio.to_thread.run_sync(
-                    partial(func, *args, **kwargs))
+                return await anyio.to_thread.run_sync(partial(func, *args, **kwargs))
 
     return async_func
 


### PR DESCRIPTION
In the past, when we do
```
@Photon.handler
def foo(self):
    ...
```
The code runs in the main uvicorn event loop, and blocks the uvicorn server (during which time basic things like "/openapi.json" and "healthz" are not accessible).

This PR adds two functionalities:
- All endpoints defined in @Photon.handler, when deployed, now run in a separate thread, so the uvicorn main event loop is not blocked.
- In default, the number of endpoint calls being run concurrently is 1, which is the same as before. With `handler_max_concurrency`, one can control the concurrency so that multiple endpoints can be run at the same time in different thread. NOTE THAT, the photon framework does not guarantee thread safety of user code - lepton's scaffolding code is thread safe, but any user code's thread safety is owned by the author of the code.
- The `handler_max_concurrency` and `background_job_max_concurrency` do not share the same pool. One is responsibile for the user code that runs handler endpoints and background jobs concurrently.

This does not apply to endpoints that are defined with async def. In other words, if we defined
```
@Photon.handler
async def foo(self):
    ...
```
Then this async function still runs in the main uvicorn loop, and one is expected to manage one's own threading and async behaviors.

It is highly unrecommended to use both sync and async handlers - just sayin'.