### PR TITLE
feat: add fields in photon metadata.json to support running custom image

### DIFF
--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -106,8 +106,14 @@ BASE_IMAGE_REPO = f"{BASE_IMAGE_REGISTRY}/lepton"
 BASE_IMAGE = f"{BASE_IMAGE_REPO}:photon-py{sys.version_info.major}.{sys.version_info.minor}-runner-{BASE_IMAGE_VERSION}"
 BASE_IMAGE_ARGS = ["--shm-size=1g"]
 
+# By default, platform runs lep ph run -f ${photon_file_path}
+BASE_IMAGE_CMD = None
+
 # Default port used by the Lepton deployments.
 DEFAULT_PORT = 8080
+
+# Default health check path used by photon server.
+DEFAULT_HEALTH_CHECK_PATH = "/healthz"
 
 # Current API path to resolve a workspace url. When we calls the URL with a json
 # body {"id": <workspace_id>}, it returns the workspace url.

--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -112,9 +112,6 @@ BASE_IMAGE_CMD = None
 # Default port used by the Lepton deployments.
 DEFAULT_PORT = 8080
 
-# Default health check path used by photon server.
-DEFAULT_HEALTH_CHECK_PATH = "/healthz"
-
 # Current API path to resolve a workspace url. When we calls the URL with a json
 # body {"id": <workspace_id>}, it returns the workspace url.
 WORKSPACE_URL_RESOLVER_API = "https://portal.lepton.ai/api/workspace"

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -42,7 +42,6 @@ from leptonai.config import (
     BASE_IMAGE_CMD,
     BASE_IMAGE_ARGS,
     DEFAULT_PORT,
-    DEFAULT_HEALTH_CHECK_PATH,
     ALLOW_ORIGINS_URLS,
     PYDANTIC_MAJOR_VERSION,
 )
@@ -179,7 +178,6 @@ class Photon(BasePhoton):
     args: List[str] = BASE_IMAGE_ARGS
     cmd: Optional[List[str]] = BASE_IMAGE_CMD
     exposed_port: int = DEFAULT_PORT
-    health_check_path: str = DEFAULT_HEALTH_CHECK_PATH
 
     # Required python dependencies that you usually install with `pip install`. For example, if
     # your photon depends on `numpy`, you can set `requirement_dependency=["numpy"]`. If your
@@ -351,7 +349,6 @@ class Photon(BasePhoton):
                 "image": self.image,
                 "args": self.args,
                 "exposed_port": self.exposed_port,
-                "health_check_path": self.health_check_path,
             }
         )
 
@@ -506,7 +503,7 @@ class Photon(BasePhoton):
         class LogFilter(logging.Filter):
             def filter(self, record: logging.LogRecord) -> bool:
                 return (
-                    record.getMessage().find(f"{self.health_check_path} ") == -1
+                    record.getMessage().find(f"/healthz ") == -1
                     and record.getMessage().find("/metrics ") == -1
                 )
 
@@ -596,7 +593,7 @@ class Photon(BasePhoton):
 
             # /healthz added at this point will be at the end of `app.routes`,
             # so it will act as a fallback
-            @app.get(self.health_check_path, include_in_schema=False)
+            @app.get("/healthz", include_in_schema=False)
             def healthz():
                 return {"status": "ok"}
 

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -504,7 +504,7 @@ class Photon(BasePhoton):
         class LogFilter(logging.Filter):
             def filter(self, record: logging.LogRecord) -> bool:
                 return (
-                    record.getMessage().find(f"/healthz ") == -1
+                    record.getMessage().find("/healthz ") == -1
                     and record.getMessage().find("/metrics ") == -1
                 )
 

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -498,7 +498,8 @@ class Photon(BasePhoton):
         self._collect_metrics(app)
         return app
 
-    def _uvicorn_log_config(self):
+    @staticmethod
+    def _uvicorn_log_config():
         # Filter out /healthz and /metrics from uvicorn access log
         class LogFilter(logging.Filter):
             def filter(self, record: logging.LogRecord) -> bool:

--- a/leptonai/photon/tests/test_photon.py
+++ b/leptonai/photon/tests/test_photon.py
@@ -316,14 +316,12 @@ class Counter(Photon):
             image = "a:b"
             exposed_port = 8765
             cmd = ["python", "-m", "http.server", str(exposed_port)]
-            health_check_path = "/status"
 
         ph = CustomImage(name=random_name())
         path = ph.save()
         metadata = load_metadata(path)
         self.assertEqual(metadata["image"], CustomImage.image)
         self.assertEqual(metadata["exposed_port"], CustomImage.exposed_port)
-        self.assertEqual(metadata["health_check_path"], CustomImage.health_check_path)
         self.assertEqual(metadata["cmd"], CustomImage.cmd)
 
     def test_custom_dependency(self):

--- a/leptonai/photon/tests/test_photon.py
+++ b/leptonai/photon/tests/test_photon.py
@@ -276,6 +276,9 @@ class Counter(Photon):
         self.assertEqual(metadata["model"], "CustomPhoton")
         self.assertTrue("image" in metadata)
         self.assertTrue("args" in metadata)
+        self.assertFalse("cmd" in metadata)  # no cmd is specified to indicates default
+        self.assertTrue("exposed_port" in metadata)
+        self.assertTrue("health_check_path" in metadata)
 
         # check for openapi schema
         self.assertTrue("openapi_schema" in metadata)
@@ -300,6 +303,21 @@ class Counter(Photon):
             metadata["py_obj"]["py_version"],
             f"{sys.version_info.major}.{sys.version_info.minor}",
         )
+
+    def test_custom_image_photon_metadata(self):
+        class CustomImage(Photon):
+            image = "a:b"
+            exposed_port = 8765
+            cmd = ["python", "-m", "http.server", str(exposed_port)]
+            health_check_path = "/status"
+
+        ph = CustomImage(name=random_name())
+        path = ph.save()
+        metadata = load_metadata(path)
+        self.assertEqual(metadata["image"], CustomImage.image)
+        self.assertEqual(metadata["exposed_port"], CustomImage.exposed_port)
+        self.assertEqual(metadata["health_check_path"], CustomImage.health_check_path)
+        self.assertEqual(metadata["cmd"], CustomImage.cmd)
 
     def test_custom_dependency(self):
         name = random_name()

--- a/leptonai/photon/tests/test_photon.py
+++ b/leptonai/photon/tests/test_photon.py
@@ -285,7 +285,6 @@ class Counter(Photon):
         self.assertTrue("args" in metadata)
         self.assertFalse("cmd" in metadata)  # no cmd is specified to indicates default
         self.assertTrue("exposed_port" in metadata)
-        self.assertTrue("health_check_path" in metadata)
 
         # check for openapi schema
         self.assertTrue("openapi_schema" in metadata)


### PR DESCRIPTION
```py
from leptonai import Photon


class CustomImage(Photon):
    image = "a:b"
    exposed_port = 8765
    cmd = ["python", "-m", "http.server", str(exposed_port)]
```


metadata.json:
```
{
...
  "image": "a:b",
  "exposed_port": 8765,
  "cmd": [
    "python",
    "-m",
    "http.server",
    "8765"
  ]
...
}
```