### PR TITLE
fix(sdk): rename self.name and self.model to names with underscore

### DIFF
--- a/leptonai/photon/base.py
+++ b/leptonai/photon/base.py
@@ -45,8 +45,8 @@ class BasePhoton:
             type_str_registry.register(cls.photon_type, cls.load)
 
     def __init__(self, name: str, model: str):
-        self.name = name
-        self.model = model
+        self._photon_name = name
+        self._photon_model = model
 
     def save(self, path: Optional[str] = None):
         """
@@ -59,14 +59,14 @@ class BasePhoton:
             # assuming maximum 1000 versions for now
             for version in range(1000):
                 if version == 0:
-                    path = str(CACHE_DIR / f"{self.name}.photon")
+                    path = str(CACHE_DIR / f"{self._photon_name}.photon")
                 else:
-                    path = str(CACHE_DIR / f"{self.name}.{version}.photon")
+                    path = str(CACHE_DIR / f"{self._photon_name}.{version}.photon")
                 if not os.path.exists(path):
                     break
             else:
                 raise ValueError(
-                    f"Can not find a valid path for creating photon {self.name}"
+                    f"Can not find a valid path for creating photon {self._photon_name}"
                 )
         with zipfile.ZipFile(path, "w") as f:
             metadata = self.metadata
@@ -93,7 +93,7 @@ class BasePhoton:
                     )
 
         # use path as local id for now
-        add_photon(str(path), self.name, self.model, str(path))
+        add_photon(str(path), self._photon_name, self._photon_model, str(path))
         return path
 
     @staticmethod
@@ -129,7 +129,11 @@ class BasePhoton:
 
     @property
     def metadata(self) -> Dict[str, Any]:
-        return {"name": self.name, "model": self.model, "type": self.photon_type}
+        return {
+            "name": self._photon_name,
+            "model": self._photon_model,
+            "type": self.photon_type,
+        }
 
     @property
     def _extra_files(self):
@@ -160,7 +164,7 @@ class BasePhoton:
         return res
 
     def __str__(self):
-        return f"Photon(name={self.name}, model={self.model})"
+        return f"Photon(name={self._photon_name}, model={self._photon_model})"
 
 
 def add_photon(id: str, name: str, model: str, path: str):

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -485,11 +485,13 @@ class Photon(BasePhoton):
         )
 
     def _create_app(self, load_mount):
-        title = self.name.replace(".", "_")
+        title = self._photon_name.replace(".", "_")
         app = FastAPI(
             title=title,
             description=(
-                self.__doc__ if self.__doc__ else f"Lepton AI Photon API {self.name}"
+                self.__doc__
+                if self.__doc__
+                else f"Lepton AI Photon API {self._photon_name}"
             ),
         )
 

--- a/leptonai/photon/tests/test_sdk.py
+++ b/leptonai/photon/tests/test_sdk.py
@@ -29,11 +29,11 @@ class TestPhotonSdk(unittest.TestCase):
             ph = photon.create(name=name, model=model_id)
         else:
             ph = photon.create(name=name, model=f"{model_id}@{revision}")
-        self.assertEqual(ph.name, name)
+        self.assertEqual(ph._photon_name, name)
         if revision is not None:
             min_len = min(len(revision), len(ph.hf_revision))
             self.assertEqual(ph.hf_revision[:min_len], revision[:min_len])
-        self.assertEqual(ph.model, f"{model_id}@{ph.hf_revision}")
+        self.assertEqual(ph._photon_model, f"{model_id}@{ph.hf_revision}")
         self.assertEqual(ph.photon_type, "hf")
 
     def test_create(self):
@@ -53,8 +53,8 @@ class TestPhotonSdk(unittest.TestCase):
         revision = ph.hf_revision
         path = photon.save(ph)
         ph = photon.load(path)
-        self.assertTrue(ph.name == "abcdef")
-        self.assertTrue(ph.model == f"{self.test_hf_model_id}@{ph.hf_revision}")
+        self.assertTrue(ph._photon_name == "abcdef")
+        self.assertTrue(ph._photon_model == f"{self.test_hf_model_id}@{ph.hf_revision}")
         self.assertEqual(ph.hf_revision, revision)
         ph.run("a cat")
 
@@ -64,7 +64,7 @@ class TestPhotonSdk(unittest.TestCase):
 
         ph = photon.create(name=random_name(), model=model)
 
-        self.assertTrue(ph.model == f"hf:{model_id}@{ph.hf_revision}")
+        self.assertTrue(ph._photon_model == f"hf:{model_id}@{ph.hf_revision}")
         ph.run("a cat")
 
     def test_create_from_transformers_pipeline(self):
@@ -73,7 +73,7 @@ class TestPhotonSdk(unittest.TestCase):
 
         ph = photon.create(name=random_name(), model=pipe)
 
-        self.assertTrue(ph.model == f"hf:{model_id}@{ph.hf_revision}")
+        self.assertTrue(ph._photon_model == f"hf:{model_id}@{ph.hf_revision}")
         ph.run("a cat")
 
     def test_load_metadata(self):


### PR DESCRIPTION
This avoids users to accidentally specify `name` and `model` member variables in their photons.

This does not incur any functional change to any existing photon, other than display issues (like `model` becoming the user's object instead of the model string).