### PR TITLE
feat(sdk): utility functions for images

### DIFF
--- a/leptonai/photon/__init__.py
+++ b/leptonai/photon/__init__.py
@@ -13,7 +13,7 @@ from .photon import (  # noqa: F401
     FileParam,
     StaticFiles,
 )
-from .types import get_file_content  # noqa: F401
+from .types import get_file_content, make_png_response  # noqa: F401
 import leptonai.photon.hf  # noqa: F401
 import leptonai.photon.vllm  # noqa: F401
 

--- a/leptonai/photon/types/__init__.py
+++ b/leptonai/photon/types/__init__.py
@@ -9,6 +9,6 @@ from .pickled import (
     LeptonPickled,
 )
 
-from .util import get_file_content
+from .util import get_file_content, make_png_response
 
 from .responses import PNGResponse, WAVResponse

--- a/leptonai/photon/types/util.py
+++ b/leptonai/photon/types/util.py
@@ -1,17 +1,33 @@
 import base64
+from io import BytesIO
 import os
 import re
-from typing import Union
+import tempfile
+from typing import Union, IO
 
+from PIL.Image import Image
 import requests
 
 from . import FileParam
 from leptonai.util import _is_valid_url
+from .responses import PNGResponse
+
+
+def _make_temp_file(content: bytes) -> IO:
+    """
+    A utility function to write bytes to a temporary file. This is useful
+    if one needs to pass a file object to a function, but only has bytes.
+    """
+    f = tempfile.NamedTemporaryFile()
+    f.write(content)
+    return f
 
 
 def get_file_content(
-    src: Union[FileParam, str, bytes], allow_local_file: bool = False
-) -> bytes:
+    src: Union[FileParam, str, bytes],
+    allow_local_file: bool = False,
+    return_file: bool = False,
+) -> Union[bytes, IO]:
     """
     Gets the file content from a source.
 
@@ -26,8 +42,11 @@ def get_file_content(
 
     Inputs:
         src: the source of the file content.
+        allow_local_file: if True, we will allow reading from local file system.
+        return_file: if True, we will return a file object instead of bytes. If False (default),
+            we will return bytes.
     Returns:
-        content: the file content in bytes.
+        content: the file content in bytes, or a file object if return_file is True.
     """
     if isinstance(src, FileParam):
         return src.content
@@ -38,10 +57,13 @@ def get_file_content(
                 content = requests.get(src).content
             except Exception:
                 raise ValueError(f"Failed to download content from url: {src}")
-            return content
+            return _make_temp_file(content) if return_file else content
         elif os.path.exists(src) and allow_local_file:
-            with open(src, "rb") as f:
-                return f.read()
+            if return_file:
+                return open(src, "rb")
+            else:
+                with open(src, "rb") as f:
+                    return f.read()
         elif src.startswith("data:"):
             # Extract the leading base64 string, and decode it.
             # See https://tools.ietf.org/html/rfc2397 for the RFC 2397 standard.
@@ -60,12 +82,13 @@ def get_file_content(
         elif len(src) % 4 == 0 and re.match(r"^[A-Za-z0-9+/]*={0,2}$", src):
             # Last resort: we will try to decode the string as a base64 string.
             try:
-                return base64.b64decode(src)
+                content = base64.b64decode(src)
             except Exception:
                 raise ValueError(
                     "Failed to decode base64 string:"
                     f" {src if len(src) < 100 else src[:100] + '...'}"
                 )
+            return _make_temp_file(content) if return_file else content
         # If any of the above fails, we will raise an error.
         raise ValueError(
             "Failed to get file content from source:"
@@ -73,9 +96,19 @@ def get_file_content(
         )
     elif isinstance(src, bytes):
         # Fallback: if the content is already bytes, do nothing.
-        return src
+        return _make_temp_file(src) if return_file else src
     # Anything not covered above is not supported.
     raise TypeError(
         "src must be a FileParam, a url, a local file path, a base64-encoded string,"
         f" or raw bytes. Got {type(src)}"
     )
+
+
+def make_png_response(img: Image) -> PNGResponse:
+    """
+    Convert an image to a PNG response.
+    """
+    img_byte_array = BytesIO()
+    img.save(img_byte_array, format="PNG")
+    img_byte_array.seek(0)
+    return PNGResponse(img_byte_array)


### PR DESCRIPTION
Added the following utility functions:
- Added a parameter `return_file` to the `get_file_content` function to return a file-like object. This is useful when e.g. opencv requires a file rather than string or byteio.
- Added a `make_png_response` utility function to return a PIL Image. In theory, we might be able to just allow users to return a PIL image and automatically convert that to a PNGResponse, but we can do that later.