### PR TITLE
feat(sdk): allow passing use_raw_args=True to Photon.handler to not wrap args in json but directly to fastapi

### DIFF
--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import traceback
+import types
 from typing import Callable, Any, List, Optional, Set, Iterator, Type
 from typing_extensions import Annotated
 import uuid
@@ -437,7 +438,7 @@ class Photon(BasePhoton):
                     src_str = inspect.getsource(self.__class__)
                 except Exception:
                     pass
-            if src_str is not None:
+            else:
                 with photon_file.open(self.py_src_filename, "w") as src_file_out:
                     src_file_out.write(src_str)
         return path
@@ -732,7 +733,7 @@ class Photon(BasePhoton):
             method, func_name=self.__class__.__name__ + "_" + path
         )
 
-        if http_method.lower() == "post":
+        if http_method.lower() == "post" and request_model is not None:
             if "example" in kwargs:
                 request_model = Annotated[
                     request_model, Body(example=kwargs["example"])
@@ -765,9 +766,46 @@ class Photon(BasePhoton):
             rate_limiter = None
 
         if http_method.lower() == "post":
-            vd = pydantic.decorator.validate_arguments(method).vd
+            # In the post mode, we do the following:
+            # - If the handler specifies "use_raw_args", then we don't wrap the args to a
+            # json body, but instead just pass the raw args up to fastapi.
+            # - Otherwise, we wrap the args to a json body, and use the request_model
+            # as the pydantic model to validate the json body.
+            # - If no args are specified, we don't wrap anything.
+            if kwargs.get("use_raw_args"):
 
-            if request_model is not None:
+                async def wrapped_method(*args, **kwargs):
+                    if rate_limiter is not None:
+                        check_rate_limit()
+                    try:
+                        res = await method(*args, **kwargs)
+                    except Exception as e:
+                        logger.error(traceback.format_exc())
+                        if isinstance(e, HTTPException):
+                            return JSONResponse(
+                                {"error": e.detail}, status_code=e.status_code
+                            )
+                        return JSONResponse({"error": str(e)}, status_code=500)
+                    else:
+                        if not isinstance(res, response_class):
+                            res = response_class(res)
+                        return res
+
+                typed_handler = types.FunctionType(
+                    wrapped_method.__code__,
+                    globals(),
+                    "typed_handler",
+                    wrapped_method.__defaults__,
+                    wrapped_method.__closure__,
+                )  # type: ignore
+                # Transfer the defaults and signature from the original method.
+                typed_handler.__annotations__ = method.__annotations__
+                typed_handler.__defaults__ = method.__defaults__  # type: ignore
+                typed_handler.__kwdefaults__ = method.__kwdefaults__  # type: ignore
+                typed_handler.__signature__ = inspect.signature(method)  # type: ignore
+            elif request_model is not None:
+                vd = pydantic.decorator.validate_arguments(method).vd
+
                 # for post handler, we change endpoint function's signature to make
                 # it taking json body as input, so do not copy the
                 # `__annotations__` attribute here
@@ -797,6 +835,7 @@ class Photon(BasePhoton):
                             res = response_class(res)
                         return res
 
+                delattr(typed_handler, "__wrapped__")
             else:
                 # for post handler, we change endpoint function's signature to make
                 # it taking json body as input, so do not copy the
@@ -812,7 +851,6 @@ class Photon(BasePhoton):
                 async def typed_handler():  # type: ignore
                     if rate_limiter is not None:
                         check_rate_limit()
-
                     try:
                         res = await method()
                     except Exception as e:
@@ -827,7 +865,7 @@ class Photon(BasePhoton):
                             res = response_class(res)
                         return res
 
-            delattr(typed_handler, "__wrapped__")
+                delattr(typed_handler, "__wrapped__")
 
         elif http_method.lower() == "get":
 

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -774,6 +774,14 @@ class Photon(BasePhoton):
             # - If no args are specified, we don't wrap anything.
             if kwargs.get("use_raw_args"):
 
+                @functools.wraps(
+                    method,
+                    assigned=(
+                        wa
+                        for wa in functools.WRAPPER_ASSIGNMENTS
+                        if wa != "__annotations__"
+                    ),  # type: ignore
+                )
                 async def wrapped_method(*args, **kwargs):
                     if rate_limiter is not None:
                         check_rate_limit()
@@ -801,6 +809,7 @@ class Photon(BasePhoton):
                 # Transfer the defaults and signature from the original method.
                 typed_handler.__annotations__ = method.__annotations__
                 typed_handler.__defaults__ = method.__defaults__  # type: ignore
+                typed_handler.__doc__ = method.__doc__
                 typed_handler.__kwdefaults__ = method.__kwdefaults__  # type: ignore
                 typed_handler.__signature__ = inspect.signature(method)  # type: ignore
             elif request_model is not None:

--- a/leptonai/photon/tests/test_photon_raw_args.py
+++ b/leptonai/photon/tests/test_photon_raw_args.py
@@ -1,0 +1,66 @@
+import os
+import requests
+import tempfile
+from typing import List
+import unittest
+
+# Set cache dir to a temp dir before importing anything from leptonai
+tmpdir = tempfile.mkdtemp()
+os.environ["LEPTON_CACHE_DIR"] = tmpdir
+
+from fastapi import UploadFile
+
+from leptonai import Photon
+from leptonai.client import Client, local
+
+from utils import random_name, photon_run_local_server
+
+
+class UploadFile(Photon):
+    @Photon.handler(use_raw_args=True)
+    def filename(self, file: UploadFile) -> str:
+        return file.filename
+
+    @Photon.handler(use_raw_args=True)
+    def multiplefiles(self, files: List[UploadFile]) -> List[str]:
+        return [f.filename for f in files]
+
+
+class TestPhotonRawArgs(unittest.TestCase):
+    def setUp(self):
+        # pytest imports test files as top-level module which becomes
+        # unavailable in server process
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            import cloudpickle
+            import sys
+
+            cloudpickle.register_pickle_by_value(sys.modules[__name__])
+
+    def test_upload_file(self):
+        name = random_name()
+        ph = UploadFile(name=name)
+        path = ph.save()
+
+        proc, port = photon_run_local_server(path=path)
+
+        # TODO: refactor client code to upload files.
+        url = f"http://127.0.0.1:{port}/"
+        with open(__file__, "rb") as f:
+            resp = requests.post(url + "filename", files={"file": f})
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json(), os.path.basename(__file__), resp.json)
+
+            resp = requests.post(url + "multiplefiles", files=[("files", f)] * 3)
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json(), [os.path.basename(__file__)] * 3, resp.json)
+
+        c = Client(local(port=port))
+        print(c.paths())
+        from pprint import pprint
+
+        pprint(c.openapi)
+        print(c.filename.__doc__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/photon/tests/test_photon_raw_args.py
+++ b/leptonai/photon/tests/test_photon_raw_args.py
@@ -11,7 +11,6 @@ os.environ["LEPTON_CACHE_DIR"] = tmpdir
 from fastapi import UploadFile
 
 from leptonai import Photon
-from leptonai.client import Client, local
 
 from utils import random_name, photon_run_local_server
 

--- a/leptonai/photon/tests/test_photon_raw_args.py
+++ b/leptonai/photon/tests/test_photon_raw_args.py
@@ -54,13 +54,6 @@ class TestPhotonRawArgs(unittest.TestCase):
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json(), [os.path.basename(__file__)] * 3, resp.json)
 
-        c = Client(local(port=port))
-        print(c.paths())
-        from pprint import pprint
-
-        pprint(c.openapi)
-        print(c.filename.__doc__)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ uvicorn
 loguru
 requests
 pydantic!=2.1.0 # 2.1.0 has a bug (pydantic #6862) that breaks fastapi.
+python-multipart
 
 accelerate # needed by low_cpu_mem_usage
 huggingface_hub


### PR DESCRIPTION
This is particularly useful if one wants to handle files etc.