### PR TITLE
feat(sdk): Add deployment_template to photon

### DIFF
--- a/leptonai/api/types.py
+++ b/leptonai/api/types.py
@@ -8,14 +8,13 @@ from typing import List, Optional
 import warnings
 from pydantic import BaseModel
 
-from leptonai.config import LEPTON_RESERVED_ENV_PREFIX
+from leptonai.config import LEPTON_RESERVED_ENV_PREFIX, VALID_SHAPES
 
 
 # Valid shapes is defined as a list instead of a dict intentionally, because
 # we want to preserve the order of the shapes when printing. Granted, this
 # adds a bit of search time, but the list is small enough that it should not
 # matter.
-VALID_SHAPES = ["cpu.small", "cpu.medium", "cpu.large", "gpu.t4", "gpu.a10"]
 DEFAULT_RESOURCE_SHAPE = "cpu.small"
 
 
@@ -230,7 +229,7 @@ class DeploymentSpec(BaseModel):
     The main class that defines the deployment spec.
     """
 
-    name: str
+    name: Optional[str] = None
     photon_id: Optional[str] = None
     resource_requirement: Optional[ResourceRequirement] = None
     auto_scaler: Optional[AutoScaler] = None

--- a/leptonai/cli/photon.py
+++ b/leptonai/cli/photon.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import json
 import os
 import re
 import shutil
@@ -771,6 +772,20 @@ def push(name):
         f"Photon [yellow]{name}[/] already exists. Skipping pushing.",
         f"Photon [red]{name}[/] failed to push. Internal server error.",
     )
+
+
+@photon.command()
+@click.option("--name", "-n", help="Name of the photon", required=True)
+@click.option("--indent", "-i", type=int, help="Indentation of the json.", default=None)
+def metadata(name, indent):
+    """
+    Returns the metadata json of the photon.
+    """
+    path = find_local_photon(name)
+    check(path and os.path.exists(path), f"Photon [red]{name}[/] does not exist.")
+    # loads the metadata
+    metadata = photon_util.load_metadata(path)  # type: ignore
+    console.print(json.dumps(metadata, indent=indent))
 
 
 @photon.command()

--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -112,6 +112,12 @@ BASE_IMAGE_CMD = None
 # Default port used by the Lepton deployments.
 DEFAULT_PORT = 8080
 
+# In the photon's deployment template, this means you will need to specify env variables.
+ENV_VAR_REQUIRED = "PLEASE_ENTER_YOUR_ENV_VARIABLE_HERE_(LEPTON_ENV_VAR_REQUIRED)"
+
+# Valid resource shapes
+VALID_SHAPES = ["cpu.small", "cpu.medium", "cpu.large", "gpu.t4", "gpu.a10"]
+
 # Current API path to resolve a workspace url. When we calls the URL with a json
 # body {"id": <workspace_id>}, it returns the workspace url.
 WORKSPACE_URL_RESOLVER_API = "https://portal.lepton.ai/api/workspace"

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -13,7 +13,7 @@ import os
 import sys
 import traceback
 import types
-from typing import Callable, Any, List, Optional, Set, Iterator, Type
+from typing import Callable, Any, List, Dict, Optional, Set, Iterator, Type
 from typing_extensions import Annotated
 import uuid
 import warnings
@@ -37,13 +37,15 @@ import pydantic.decorator
 import uvicorn
 import uvicorn.config
 
-from leptonai.config import (
-    BASE_IMAGE,
-    BASE_IMAGE_CMD,
-    BASE_IMAGE_ARGS,
-    DEFAULT_PORT,
+from leptonai.config import (  # noqa: F401
     ALLOW_ORIGINS_URLS,
+    BASE_IMAGE,
+    BASE_IMAGE_ARGS,
+    BASE_IMAGE_CMD,
+    DEFAULT_PORT,
+    ENV_VAR_REQUIRED,
     PYDANTIC_MAJOR_VERSION,
+    VALID_SHAPES,
 )
 from leptonai.photon.constants import METADATA_VCS_URL_KEY
 from leptonai.photon.download import fetch_code_from_vcs
@@ -148,6 +150,46 @@ class Photon(BasePhoton):
     obj_pkl_filename: str = "obj.pkl"
     py_src_filename: str = "py.py"
 
+    # Required python dependencies that you usually install with `pip install`. For example, if
+    # your photon depends on `numpy`, you can set `requirement_dependency=["numpy"]`. If your
+    # photon depends on a package installable over github, you can set the dependency to
+    # `requirement_dependency=["git+xxxx"] where `xxxx` is the url to the github repo.
+    #
+    # Experimental feature: if you specify "uninstall xxxxx", instead of installing the library,
+    # we will uninstall the library. This is useful if you want to uninstall a library that is
+    # in conflict with some other libraries, and need to sequentialize a bunch of pip installs
+    # and uninstalls. The exact correctness of this will really depend on pip and the specific
+    # libraries you are installing and uninstalling, so please use this feature with caution.
+    requirement_dependency: Optional[List[str]] = None
+
+    # System dependencies that can be installed via `apt install`. FOr example, if your photon
+    # depends on `ffmpeg`, you can set `system_dependency=["ffmpeg"]`.
+    system_dependency: Optional[List[str]] = None
+
+    # The deployment template that gives a (soft) reminder to the users about how to use the
+    # photon. For example, if your photon has the following:
+    #   - requires gpu.a10 to run
+    #   - a required env variable called ENV_A, and the user needs to set the value.
+    #   - an optional env variable called ENV_B with default value "DEFAULT_B"
+    #   - a required secret called SECRET_A, and the user needs to choose the secret.
+    # Then, the deployment template should look like:
+    #     deployment_template: Dict = {
+    #       "resource_shape": "gpu.a10",
+    #       "env": {
+    #         "ENV_A": ENV_VAR_REQUIRED,
+    #         "ENV_B": "DEFAULT_B",
+    #       },
+    #       "secret": [
+    #         "SECRET_A",
+    #       ],
+    #     }
+    # Note that this is just a hint: we do not enforce the user to follow the template.
+    deployment_template: Dict[str, Any] = {
+        "resource_shape": None,
+        "env": {},
+        "secret": [],
+    }
+
     # The maximum number of concurrent requests that the photon can handle. In default when the photon
     # concurrency is 1, all the endpoints defined by @Photon.handler is mutually exclusive, and at any
     # time only one endpoint is running. This does not include system generated endpoints such as
@@ -178,22 +220,6 @@ class Photon(BasePhoton):
     args: List[str] = BASE_IMAGE_ARGS
     cmd: Optional[List[str]] = BASE_IMAGE_CMD
     exposed_port: int = DEFAULT_PORT
-
-    # Required python dependencies that you usually install with `pip install`. For example, if
-    # your photon depends on `numpy`, you can set `requirement_dependency=["numpy"]`. If your
-    # photon depends on a package installable over github, you can set the dependency to
-    # `requirement_dependency=["git+xxxx"] where `xxxx` is the url to the github repo.
-    #
-    # Experimental feature: if you specify "uninstall xxxxx", instead of installing the library,
-    # we will uninstall the library. This is useful if you want to uninstall a library that is
-    # in conflict with some other libraries, and need to sequentialize a bunch of pip installs
-    # and uninstalls. The exact correctness of this will really depend on pip and the specific
-    # libraries you are installing and uninstalling, so please use this feature with caution.
-    requirement_dependency: Optional[List[str]] = None
-
-    # System dependencies that can be installed via `apt install`. FOr example, if your photon
-    # depends on `ffmpeg`, you can set `system_dependency=["ffmpeg"]`.
-    system_dependency: Optional[List[str]] = None
 
     # The git repository to check out as part of the photon deployment phase.
     vcs_url: Optional[str] = None
@@ -321,6 +347,61 @@ class Photon(BasePhoton):
         return list(deps.keys())
 
     @property
+    def _deployment_template(self) -> Dict[str, Any]:
+        # Verify and return the deployment template.
+        if self.deployment_template is None:
+            return {}
+        # doing sanity check for the fields
+        sanity_checked_fields = ["resource_shape", "env", "secret"]
+        if any(
+            field not in sanity_checked_fields
+            for field in self.deployment_template.keys()
+        ):
+            raise ValueError(
+                "Deployment template encountered a field that is not supported."
+                f" Supported fields are: {sanity_checked_fields}."
+            )
+        # doing sanity check for the values
+        if self.deployment_template["resource_shape"] is not None:
+            if not isinstance(self.deployment_template["resource_shape"], str):
+                raise ValueError(
+                    "Deployment template resource_shape must be a string. Found"
+                    f" {self.deployment_template['resource_shape']} instead."
+                )
+            if self.deployment_template["resource_shape"] not in VALID_SHAPES:
+                # For now, only issue a warning if the user specified a non-standard
+                # shape, and not an error. This is because we want to allow future versions
+                # of the CLI to support more shapes, and we do not want to break the
+                # compatibility.
+                warnings.warn(
+                    "Deployment template resource_shape"
+                    f" {self.deployment_template['resource_shape']} is not one of the"
+                    " standard shapes. Just a kind reminder."
+                )
+        if not isinstance(self.deployment_template["env"], dict):
+            raise ValueError(
+                "Deployment template envs must be a dict. Found"
+                f" {self.deployment_template['env']} instead."
+            )
+        for key, value in self.deployment_template["env"].items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError(
+                    "Deployment template envs keys/values must be strings. Found"
+                    f" {key}:{value} instead."
+                )
+        if not isinstance(self.deployment_template["secret"], list):
+            raise ValueError(
+                "Deployment template secrets must be a list. Found"
+                f" {self.deployment_template['secret']} instead."
+            )
+        if any(not isinstance(s, str) for s in self.deployment_template["secret"]):
+            raise ValueError(
+                "Deployment template secrets must be a list of strings. Found"
+                f" {self.deployment_template['secret']} instead."
+            )
+        return self.deployment_template
+
+    @property
     def metadata(self):
         res = super().metadata
 
@@ -343,6 +424,8 @@ class Photon(BasePhoton):
         res.update({"requirement_dependency": self._requirement_dependency})
         res.update({"system_dependency": self._system_dependency})
         res.update({METADATA_VCS_URL_KEY: self.vcs_url})
+
+        res.update({"deployment_template": self._deployment_template})
 
         res.update({
             "image": self.image,

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -378,42 +378,43 @@ class Photon(BasePhoton):
                 f" Supported fields are: {sanity_checked_fields}."
             )
         # doing sanity check for the values
-        if self.deployment_template["resource_shape"] is not None:
-            if not isinstance(self.deployment_template["resource_shape"], str):
+        resource_shape = self.deployment_template.get("resource_shape")
+        if resource_shape is not None:
+            if not isinstance(resource_shape, str):
                 raise ValueError(
                     "Deployment template resource_shape must be a string. Found"
-                    f" {self.deployment_template['resource_shape']} instead."
+                    f" {resource_shape} instead."
                 )
-            if self.deployment_template["resource_shape"] not in VALID_SHAPES:
+            if resource_shape not in VALID_SHAPES:
                 # For now, only issue a warning if the user specified a non-standard
                 # shape, and not an error. This is because we want to allow future versions
                 # of the CLI to support more shapes, and we do not want to break the
                 # compatibility.
                 warnings.warn(
                     "Deployment template resource_shape"
-                    f" {self.deployment_template['resource_shape']} is not one of the"
+                    f" {resource_shape} is not one of the"
                     " standard shapes. Just a kind reminder."
                 )
-        if not isinstance(self.deployment_template["env"], dict):
+        env = self.deployment_template.get("env", {})
+        if not isinstance(env, dict):
             raise ValueError(
-                "Deployment template envs must be a dict. Found"
-                f" {self.deployment_template['env']} instead."
+                f"Deployment template envs must be a dict. Found {env} instead."
             )
-        for key, value in self.deployment_template["env"].items():
+        for key, value in env.items():
             if not isinstance(key, str) or not isinstance(value, str):
                 raise ValueError(
                     "Deployment template envs keys/values must be strings. Found"
                     f" {key}:{value} instead."
                 )
-        if not isinstance(self.deployment_template["secret"], list):
+        secret = self.deployment_template.get("secret", [])
+        if not isinstance(secret, list):
             raise ValueError(
-                "Deployment template secrets must be a list. Found"
-                f" {self.deployment_template['secret']} instead."
+                f"Deployment template secrets must be a list. Found {secret} instead."
             )
-        if any(not isinstance(s, str) for s in self.deployment_template["secret"]):
+        if any(not isinstance(s, str) for s in secret):
             raise ValueError(
                 "Deployment template secrets must be a list of strings. Found"
-                f" {self.deployment_template['secret']} instead."
+                f" {secret} instead."
             )
         return self.deployment_template
 

--- a/leptonai/photon/prebuilt/template.py
+++ b/leptonai/photon/prebuilt/template.py
@@ -20,6 +20,27 @@ class MyPhoton(Photon):
         # "ffmpeg",
     ]
 
+    # Add a deployment template to remind users how to use the photon.
+    # For example, if your photon has the following:
+    #   - requires gpu.a10 to run
+    #   - a required env variable called ENV_A, and the user needs to set the value.
+    #   - an optional env variable called ENV_B with default value "DEFAULT_B"
+    #   - a required secret called SECRET_A, and the user needs to choose the secret.
+    # Then, the deployment template should look like:
+    #     deployment_template: Dict = {
+    #       "resource_shape": "gpu.a10",
+    #       "env": {
+    #         "ENV_A": ENV_VAR_REQUIRED,
+    #         "ENV_B": "DEFAULT_B",
+    #       },
+    #       "secret": ["SECRET_A"],
+    #     }
+    deployment_template = {
+        "resource_shape": None,
+        "env": {},
+        "secret": [],
+    }
+
     # For more information about other configs of the photon, please refer to the
     # documentation at https://www.lepton.ai/docs/walkthrough/anatomy_of_a_photon
 

--- a/leptonai/photon/vllm/vllm.py
+++ b/leptonai/photon/vllm/vllm.py
@@ -10,6 +10,11 @@ VLLM_SCHEMAS = ["vllm"]
 class vLLMPhoton(Photon):
     photon_type: str = "vllm"
 
+    deployment_template = {
+        # At least using gpu.a10.
+        "resource_shape": "gpu.a10",
+    }
+
     requirement_dependency = [
         "vllm>=0.2.0",
         "fschat",


### PR DESCRIPTION
Also in the comments field of the source file:

    # The deployment template that gives a (soft) reminder to the users about how to use the
    # photon. For example, if your photon has the following:
    #   - requires gpu.a10 to run
    #   - a required env variable called ENV_A, and the user needs to set the value.
    #   - an optional env variable called ENV_B with default value "DEFAULT_B"
    #   - a required secret called SECRET_A, and the user needs to choose the secret.
    # Then, the deployment template should look like:
    #     deployment_template: Dict = {
    #       "resource_shape": "gpu.a10",
    #       "env": {
    #         "ENV_A": ENV_VAR_REQUIRED,
    #         "ENV_B": "DEFAULT_B",
    #       },
    #       "secret": [
    #         "SECRET_A",
    #       ],
    #     }
    # During photon init time, we will check the existence of the env variables and secrets,
    # issue RuntimeError of the required ones are not set, and set default values for non-existing
    # env variables that have default values.