### PR TITLE
drop support of creating photon from hf model and pipeline runtime instance

### DIFF
--- a/leptonai/photon/base.py
+++ b/leptonai/photon/base.py
@@ -9,7 +9,6 @@ from leptonai.util import create_cached_dir_if_needed
 from leptonai.registry import Registry
 
 schema_registry = Registry()
-type_registry = Registry()
 type_str_registry = Registry()
 
 

--- a/leptonai/photon/tests/test_sdk.py
+++ b/leptonai/photon/tests/test_sdk.py
@@ -8,7 +8,6 @@ os.environ["LEPTON_CACHE_DIR"] = tmpdir.name
 import unittest
 
 from loguru import logger
-from transformers import AutoModel, pipeline
 
 from leptonai import config
 from leptonai import photon
@@ -56,24 +55,6 @@ class TestPhotonSdk(unittest.TestCase):
         self.assertTrue(ph._photon_name == "abcdef")
         self.assertTrue(ph._photon_model == f"{self.test_hf_model_id}@{ph.hf_revision}")
         self.assertEqual(ph.hf_revision, revision)
-        ph.run("a cat")
-
-    def test_create_from_transformers_model(self):
-        model_id = "sshleifer/tiny-gpt2"
-        model = AutoModel.from_pretrained(model_id)
-
-        ph = photon.create(name=random_name(), model=model)
-
-        self.assertTrue(ph._photon_model == f"hf:{model_id}@{ph.hf_revision}")
-        ph.run("a cat")
-
-    def test_create_from_transformers_pipeline(self):
-        model_id = "sshleifer/tiny-gpt2"
-        pipe = pipeline(model=model_id)
-
-        ph = photon.create(name=random_name(), model=pipe)
-
-        self.assertTrue(ph._photon_model == f"hf:{model_id}@{ph.hf_revision}")
         ph.run("a cat")
 
     def test_load_metadata(self):

--- a/leptonai/photon/util.py
+++ b/leptonai/photon/util.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, Optional
-from leptonai.photon.base import schema_registry, type_registry, BasePhoton
+from leptonai.photon.base import schema_registry, BasePhoton
 
 from leptonai.util import check_photon_name
 
@@ -31,11 +31,6 @@ def create(name: str, model: Any) -> BasePhoton:
             creator = _find_creator(model)
         if creator is not None:
             return creator(name, model)
-    else:
-        for type_checker in type_registry.keys():
-            if type_checker(model):
-                creator = type_registry.get(type_checker)
-                return creator(name, model)
 
     raise ValueError(f"Failed to find Photon creator for name={name} and model={model}")
 


### PR DESCRIPTION
using hf model id is still supported

this is for trimming down dependencies in environment that don't need to run photons 