### PR TITLE
fix(sdk): pin uvicorn version to be >=0.22.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ limits
 prometheus-fastapi-instrumentator
 rich
 typing-extensions
-uvicorn
+uvicorn>=0.22.0 # needed by timeout_graceful_shutdown
 loguru
 requests
 pydantic!=2.1.0 # 2.1.0 has a bug (pydantic #6862) that breaks fastapi.


### PR DESCRIPTION
We use `timeout_graceful_shutdown` in our codebase. It is introduced in https://github.com/encode/uvicorn/pull/1950

Earlier versions will show this exception:
```
Failed to launch photon: <class 'TypeError'>: Config.__init__() got an unexpected keyword 
argument 'timeout_graceful_shutdown'
Traceback:
Traceback (most recent call last):
  File "/home/jiayq/Documents/code/lepton/sdk/leptonai/cli/photon.py", line 669, in run
    photon.launch(port=port)
  File "/home/jiayq/Documents/code/lepton/sdk/leptonai/photon/photon.py", line 841, in launch
    self._uvicorn_run(
  File "/home/jiayq/Documents/code/lepton/sdk/leptonai/photon/photon.py", line 755, in 
_uvicorn_run
    config = uvicorn.Config(
TypeError: Config.__init__() got an unexpected keyword argument 'timeout_graceful_shutdown'
```