### PR TITLE
feat(sdk): initial support for job api

### DIFF
--- a/leptonai/api/job.py
+++ b/leptonai/api/job.py
@@ -1,0 +1,45 @@
+from .connection import Connection
+from .util import json_or_error
+from .types import LeptonJob
+
+
+def list_jobs(conn: Connection):
+    """
+    List all jobs on a workspace.
+    """
+    response = conn.get("/jobs")
+    return json_or_error(response)
+
+
+def create_job(conn: Connection, job: LeptonJob):
+    """
+    Create a job on a workspace.
+    """
+    response = conn.post("/jobs/", json=job.dict(exclude_none=True))
+    return json_or_error(response)
+
+
+def get_job(conn: Connection, name: str):
+    """
+    Get a job from a workspace.
+    :param str id: id of the job to fetch
+    """
+    response = conn.get("/jobs/" + name)
+    return json_or_error(response)
+
+
+def update_job(conn: Connection, name: str, *args, **kwargs):
+    """
+    Update a job from a workspace.
+    :param str id: id of the job to update
+    """
+    raise NotImplementedError("Job update is not implemented yet.")
+
+
+def delete_job(conn: Connection, name: str):
+    """
+    Delete a job from a workspace.
+    :param str id: id of the job to delete
+    """
+    response = conn.delete("/jobs/" + name)
+    return response

--- a/leptonai/api/types.py
+++ b/leptonai/api/types.py
@@ -4,6 +4,7 @@ Types for the Lepton AI API.
 These types are used as wrappers of the json payloads used by the API.
 """
 
+from enum import Enum
 from typing import List, Optional
 import warnings
 from pydantic import BaseModel
@@ -302,3 +303,77 @@ class DeploymentSpec(BaseModel):
     envs: Optional[List[EnvVar]] = None
     mounts: Optional[List[Mount]] = None
     health: Optional[HealthCheck] = None
+
+
+class LeptonJobState(str, Enum):
+    NotReady = "Not Ready"
+    Running = "Running"
+    Failed = "Failed"
+    Completed = "Completed"
+    Deleting = "Deleting"
+    Unknown = ""
+
+
+class LeptonJobStatus(BaseModel):
+    """
+    The observed state of a Lepton Job.
+    """
+
+    state: LeptonJobState
+    ready: int
+    active: int
+    failed: int
+    succeeded: int
+    completion_time: Optional[int] = None
+
+
+class ContainerPort(BaseModel):
+    """
+    The port spec of a Lepton Job.
+    """
+
+    container_port: int
+    protocol: Optional[str] = None
+
+
+class LeptonContainer(BaseModel):
+    """
+    The container spec of a Lepton Job.
+    """
+
+    image: str
+    ports: Optional[List[ContainerPort]] = None
+    command: Optional[List[str]] = None
+
+
+class LeptonJobSpec(BaseModel):
+    """
+    The desired state of a Lepton Job.
+    """
+
+    resource_shape: Optional[str] = None
+    container: LeptonContainer
+    completions: int
+    parallelism: int
+    envs: List[EnvVar] = []
+    mounts: List[Mount] = []
+
+
+class LeptonMetadata(BaseModel):
+    """
+    The metadata of Lepton types.
+    """
+
+    id: str
+    created_at: Optional[int] = None
+    version: Optional[int] = None
+
+
+class LeptonJob(BaseModel):
+    """
+    The Lepton Job.
+    """
+
+    metadata: LeptonMetadata
+    spec: LeptonJobSpec
+    status: Optional[LeptonJobStatus] = None

--- a/leptonai/cli/cli.py
+++ b/leptonai/cli/cli.py
@@ -3,6 +3,7 @@ import click
 import leptonai
 from . import deployment
 from . import in_n_out
+from . import job
 from . import lfs
 from . import photon
 from . import queue
@@ -28,6 +29,7 @@ def lep():
 
 # Add subcommands
 deployment.add_command(lep)
+job.add_command(lep)
 lfs.add_command(lep)
 photon.add_command(lep)
 queue.add_command(lep)

--- a/leptonai/cli/job.py
+++ b/leptonai/cli/job.py
@@ -1,0 +1,107 @@
+import click
+import json
+
+from rich.table import Table
+
+from .util import (
+    console,
+    click_group,
+    guard_api,
+    get_connection_or_die,
+    explain_response,
+)
+from leptonai.api import job as api
+from leptonai.api.types import LeptonJobSpec, LeptonJob, LeptonMetadata
+
+
+@click_group()
+def job():
+    """
+    Manages Lepton Jobs.
+
+    Jobs is an experimental feature. More details will be added soon.
+    """
+    pass
+
+
+@job.command()
+@click.option("--name", "-n", help="Job name", type=str, required=True)
+@click.option("--file", "-f", help="Job spec file", type=str, required=True)
+def create(name, file):
+    """
+    Creates a job from a job spec file.
+    """
+    try:
+        with open(file, "r") as f:
+            content = f.read()
+            job_spec = LeptonJobSpec.parse_raw(content)
+            job = LeptonJob(spec=job_spec, metadata=LeptonMetadata(id=name))
+    except Exception as e:
+        console.print(f"[red]Error[/]: {e}")
+        return
+
+    conn = get_connection_or_die()
+    guard_api(api.create_job(conn, job), detail=True)
+    console.print(f"Job [green]{name}[/] created successfully.")
+
+
+@job.command(name="list")
+def list_command():
+    """
+    Lists all jobs in the current workspace.
+    """
+    conn = get_connection_or_die()
+    jobs = guard_api(api.list_jobs(conn), detail=True)
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Name")
+    table.add_column("Created At")
+    table.add_column("State")
+    table.add_column("Ready")
+    table.add_column("Active")
+    table.add_column("Succeeded")
+    table.add_column("Failed")
+    for job in jobs:
+        table.add_row(
+            job["metadata"]["name"],
+            job["metadata"]["creationTimestamp"],
+            job["status"]["state"],
+            str(job["status"]["ready"]),
+            str(job["status"]["active"]),
+            str(job["status"]["succeeded"]),
+            str(job["status"]["failed"]),
+        )
+    table.title = "Jobs"
+    console.print(table)
+
+
+@job.command()
+@click.option("--name", "-n", help="Job name", type=str, required=True)
+def get(name):
+    """
+    Gets the job with the given name.
+    """
+    conn = get_connection_or_die()
+    job = guard_api(api.get_job(conn, name), detail=True)
+    console.print(f"Job details for [green]{name}[/]:")
+    console.print(json.dumps(job, indent=2))
+
+
+@job.command()
+@click.option("--name", "-n", help="Job name")
+def remove(name):
+    """
+    Removes the job with the given name.
+    """
+    conn = get_connection_or_die()
+    response = api.delete_job(conn, name)
+    explain_response(
+        response,
+        f"Job [green]{name}[/] deleted successfully.",
+        f"Job [yellow]{name}[/] does not exist.",
+        f"{response.text}\nInternal error. See error message above.",
+    )
+
+
+def add_command(cli_group):
+    cli_group.add_command(job)


### PR DESCRIPTION
Tried with the following test.json job file:
```
{
    "resource_shape": "cpu.small",
    "container": {
        "image": "python:3.11-slim",
        "command": ["python", "--version"]
    },
    "completions": 1,
    "parallelism": 1
}
```

Since the job config is a bit too much for the cli to write, I am letting the CLI take a file rather than using a bunch of args.