### PR TITLE
fix(requirements): add missing "exceptiongroup"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ anyio
 click
 cloudpickle==2.2.1
 contextlib2 # backports async support in nullcontext
+exceptiongroup
 fastapi
 httpx
 limits


### PR DESCRIPTION
```bash
cd ${HOME}/leptonai
pip install -e .
lep photon run -h
```

will fail:

```
Traceback (most recent call last):
  File "/Users/leegyuho/anaconda3/bin/lep", line 5, in <module>
    from leptonai.cli import lep
  File "/Users/leegyuho/leptonai/leptonai/__init__.py", line 6, in <module>
    from .cloudrun import Remote
  File "/Users/leegyuho/leptonai/leptonai/cloudrun/__init__.py", line 14, in <module>
    from .remote import Remote, clean
  File "/Users/leegyuho/leptonai/leptonai/cloudrun/remote.py", line 17, in <module>
    from leptonai.photon import Photon
  File "/Users/leegyuho/leptonai/leptonai/photon/__init__.py", line 6, in <module>
    from .photon import (  # noqa: F401
  File "/Users/leegyuho/leptonai/leptonai/photon/photon.py", line 66, in <module>
    from leptonai.util.cancel_on_disconnect import run_with_cancel_on_disconnect
  File "/Users/leegyuho/leptonai/leptonai/util/cancel_on_disconnect.py", line 8, in <module>
    from exceptiongroup import catch, ExceptionGroup
ModuleNotFoundError: No module named 'exceptiongroup
```