### PR TITLE
feat: Add Worker skeleton for task queue type of workload

### DIFF
--- a/leptonai/photon/__init__.py
+++ b/leptonai/photon/__init__.py
@@ -14,6 +14,7 @@ from .photon import (  # noqa: F401
     FileParam,
     StaticFiles,
 )
+from .worker import Worker  # noqa: F401
 from .types import get_file_content, make_png_response  # noqa: F401
 import leptonai.photon.hf  # noqa: F401
 import leptonai.photon.vllm  # noqa: F401

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -85,7 +85,7 @@ def create_model_for_func(func: Callable, func_name: Optional[str] = None):
     if len(args) > 0 and (args[0] == "self" or args[0] == "cls"):
         args = args[1:]  # remove self or cls
 
-    if len(args) > 0:
+    if args or varkw:
         if defaults is None:
             defaults = ()
         non_default_args_count = len(args) - len(defaults)
@@ -1166,9 +1166,12 @@ class Photon(BasePhoton):
 
     @classmethod
     def _find_photon_subcls_names(cls, module):
+        # cyclic import
+        from .worker import Worker
+
         valid_cls_names = []
         for name, obj in inspect.getmembers(module):
-            if obj is cls:
+            if obj in (cls, Worker):
                 continue
             if inspect.isclass(obj) and issubclass(obj, cls):
                 valid_cls_names.append(name)

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -783,41 +783,42 @@ class Photon(BasePhoton):
         # waits for a given amount time before stopping to receive incoming
         # traffic.
         if self.incoming_traffic_grace_period:
-
-            def sleep_and_handle_exit(sig: int, frame: Optional[FrameType]) -> None:
-                if sig == signal.SIGINT:
-                    # SIGINT will always set should_exit to True immediately, and double
-                    # SIGINT will force exit.
-                    if lepton_uvicorn_server.should_exit:
-                        lepton_uvicorn_server.force_exit = True
-                    else:
-                        lepton_uvicorn_server.should_exit = True
-                else:
-                    # SIGTERM and others will trigger a slow shutdown
-                    logger.info(
-                        "Gracefully stopping incoming traffic after "
-                        f"{self.incoming_traffic_grace_period} seconds."
-                    )
-                    time.sleep(self.incoming_traffic_grace_period)
-                    logger.info("Setting should_exit to True.")
-                    lepton_uvicorn_server.should_exit = True
-
-            def handle_exit(sig: int, frame: Optional[FrameType]) -> None:
-                # calls sleep_and_handle_exit in a separate thread to avoid
-                # blocking the main thread
-                th = threading.Thread(
-                    target=sleep_and_handle_exit, args=(sig, frame), daemon=True
-                )
-                th.start()
-
             logger.info(
                 "Setting up signal handlers for graceful incoming traffic"
                 f" shutdown after {self.incoming_traffic_grace_period} seconds."
             )
-            lepton_uvicorn_server.handle_exit = handle_exit
+            lepton_uvicorn_server.handle_exit = functools.partial(
+                self._handle_exit, lepton_uvicorn_server
+            )
 
         self._print_launch_info(host, port, log_level)
         lepton_uvicorn_server.run()
+
+    def _handle_exit(
+        self, uvicorn_server: uvicorn.Server, sig: int, frame: FrameType
+    ) -> None:
+        def sleep_and_handle_exit() -> None:
+            if sig == signal.SIGINT:
+                # SIGINT will always set should_exit to True immediately, and double
+                # SIGINT will force exit.
+                if uvicorn_server.should_exit:
+                    uvicorn_server.force_exit = True
+                else:
+                    uvicorn_server.should_exit = True
+            else:
+                # SIGTERM and others will trigger a slow shutdown
+                logger.info(
+                    "Gracefully stopping incoming traffic after "
+                    f"{self.incoming_traffic_grace_period} seconds."
+                )
+                time.sleep(self.incoming_traffic_grace_period)
+                logger.info("Setting should_exit to True.")
+                uvicorn_server.should_exit = True
+
+        # calls sleep_and_handle_exit in a separate thread to avoid
+        # blocking the main thread
+        th = threading.Thread(target=sleep_and_handle_exit, daemon=True)
+        th.start()
 
     def _run_liveness_server(self):
         def run_server():

--- a/leptonai/photon/tests/test_worker.py
+++ b/leptonai/photon/tests/test_worker.py
@@ -1,0 +1,87 @@
+import os
+import tempfile
+
+# Set cache dir to a temp dir before importing anything from leptonai
+tmpdir = tempfile.mkdtemp()
+os.environ["LEPTON_CACHE_DIR"] = tmpdir
+
+import unittest
+import sys
+import time
+
+from loguru import logger
+import requests
+
+from leptonai.api import workspace as workspace_api
+from leptonai.photon import Worker
+from leptonai.kv import KV
+from leptonai.queue import Queue
+from utils import random_name, photon_run_local_server
+
+
+@unittest.skipIf(
+    workspace_api.WorkspaceInfoLocalRecord.get_current_workspace_id() is None,
+    "No login info. Skipping test.",
+)
+class TestWorker(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # pytest imports test files as top-level module which becomes
+        # unavailable in server process
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            import cloudpickle
+
+            cloudpickle.register_pickle_by_value(sys.modules[__name__])
+
+        cls.kv_name = random_name()
+        logger.info(f"Creating KV {cls.kv_name}")
+        KV(cls.kv_name, create_if_not_exists=True)
+        logger.info(f"KV {cls.kv_name} created")
+
+        cls.queue_name = random_name()
+        logger.info(f"Creating Queue {cls.queue_name}")
+        Queue(cls.queue_name, create_if_not_exists=True)
+        logger.info(f"Queue {cls.queue_name} created")
+
+    @classmethod
+    def tearDownClass(cls):
+        KV.delete_kv(cls.kv_name)
+        Queue.delete_queue(cls.queue_name)
+
+    def test_worker(self):
+        class MyWorker(Worker):
+            queue_name = TestWorker.queue_name
+            kv_name = TestWorker.kv_name
+
+            # speed up test
+            queue_empty_sleep_time = 1
+
+            def on_task(self, task_id: str, x: int):
+                time.sleep(2)
+                logger.info(f"Got task {x}")
+                return x * 2
+
+        worker = MyWorker(name=random_name())
+        path = worker.save()
+
+        proc, port = photon_run_local_server(path=path)
+        res = requests.post(f"http://localhost:{port}/task", json={"x": 1})
+        self.assertEqual(res.status_code, 200, res.text)
+        task_id = res.json()
+        self.assertTrue(isinstance(task_id, str))
+        logger.info(f"Got task id {task_id}")
+
+        time.sleep(3)
+        res = requests.get(f"http://localhost:{port}/task", params={"task_id": task_id})
+        self.assertEqual(res.status_code, 200, res.text)
+        self.assertIn("status", res.json())
+        self.assertIn(res.json()["status"], ["RUNNING", "SUCCESS"])
+        self.assertIn("created_at", res.json())
+        self.assertIn("started_at", res.json())
+        if res.json()["status"] == "RUNNING":
+            time.sleep(2)
+            self.assertIn("finished_at", res.json())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/photon/worker.py
+++ b/leptonai/photon/worker.py
@@ -44,9 +44,9 @@ class Worker(Photon):
             raise RuntimeError("kv_name is not set")
         self._kv = KV(self.kv_name, create_if_not_exists=False, wait_for_creation=True)
 
-        # so that `on_task` shares the handler_max_concurrency
+        # so that `on_task` shares the background_tasks_max_concurrency
         self._on_task_handler = asyncfy_with_semaphore(
-            self.on_task, self._handler_semaphore
+            self.on_task, self._background_task_semaphore
         )
 
         self._lepton_worker_thread_should_exit = False

--- a/leptonai/photon/worker.py
+++ b/leptonai/photon/worker.py
@@ -1,0 +1,130 @@
+import asyncio
+from abc import abstractmethod
+import datetime
+from enum import Enum
+import json
+import threading
+import time
+from typing import Any, Dict
+import uuid
+
+from loguru import logger
+
+from .photon import Photon, HTTPException
+from leptonai.queue import Queue, Empty
+from leptonai.kv import KV
+from leptonai.util import asyncfy_with_semaphore
+
+
+class Status(str, Enum):
+    CREATED = "CREATED"
+    RUNNING = "RUNNING"
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+
+
+class Worker(Photon):
+    queue_name: str = None
+    kv_name: str = None
+
+    queue_empty_sleep_time: int = 5
+    save_result: bool = False
+
+    LEPTON_TASK_ID_TAG = "_lepton_task_id"
+
+    def init(self):
+        super().init()
+
+        if self.queue_name is None:
+            raise RuntimeError("queue_name is not set")
+        self._queue = Queue(
+            self.queue_name, create_if_not_exists=False, wait_for_creation=True
+        )
+        if self.kv_name is None:
+            raise RuntimeError("kv_name is not set")
+        self._kv = KV(self.kv_name, create_if_not_exists=False, wait_for_creation=True)
+
+        # so that `on_task` shares the handler_max_concurrency
+        self._on_task_handler = asyncfy_with_semaphore(
+            self.on_task, self._handler_semaphore
+        )
+
+        threading.Thread(target=self._worker_loop, daemon=True).start()
+
+    def _worker_loop(self):
+        """Keep polling the queue for new tasks, and dispatch them to `on_task` (through `_on_task`)"""
+
+        loop = asyncio.new_event_loop()
+
+        while True:
+            try:
+                message = self._queue.receive()
+                payload = json.loads(message)
+                task_id = payload.pop(self.LEPTON_TASK_ID_TAG)
+                loop.run_until_complete(self._on_task(task_id, **payload))
+            except Empty:
+                logger.info(
+                    "Queue is empty, sleeping for"
+                    f" {self.queue_empty_sleep_time} seconds"
+                )
+                time.sleep(self.queue_empty_sleep_time)
+            except Exception as e:
+                logger.error(f"Error in worker loop: {e}")
+
+    async def _on_task(self, task_id: str, **payload):
+        """Do some accounting and error handling work, then dispatch the task to `on_task`"""
+
+        logger.info(f"Received task {task_id}")
+
+        task_json = json.loads(self._kv.get(task_id))
+        task_json["status"] = Status.RUNNING
+        task_json["started_at"] = datetime.datetime.utcnow().isoformat()
+        self._kv.put(task_id, json.dumps(task_json))
+
+        try:
+            res = await self._on_task_handler(task_id=task_id, **payload)
+        except Exception as e:
+            logger.exception(f"Task {task_id} failed: {e}")
+            task_json["status"] = Status.FAILED
+        else:
+            logger.info(f"Task {task_id} succeeded")
+            task_json["status"] = Status.SUCCESS
+            if self.save_result:
+                task_json["result"] = res
+        finally:
+            task_json["finished_at"] = datetime.datetime.utcnow().isoformat()
+            self._kv.put(task_id, json.dumps(task_json))
+
+        logger.info(f"Task {task_id} finished")
+
+    @abstractmethod
+    def on_task(self, task_id: str, **payload):
+        """The actual task handler, should be implemented by concrete Worker subclass"""
+        raise NotImplementedError("Concrete Worker subclass should implement on_task")
+
+    @Photon.handler(path="task", method="POST", use_raw_args=True)
+    def task_post(self, payload: Dict[str, Any]):
+        task_id = uuid.uuid4().hex
+
+        logger.info(f"request: {payload}")
+
+        payload[self.LEPTON_TASK_ID_TAG] = task_id
+        self._queue.send(json.dumps(payload))
+
+        task_json = {
+            "status": Status.CREATED,
+            "created_at": datetime.datetime.utcnow().isoformat(),
+        }
+        self._kv.put(task_id, json.dumps(task_json))
+
+        return task_id
+
+    @Photon.handler(path="task", method="GET")
+    def task_get(self, task_id: str):
+        try:
+            task_str = self._kv.get(task_id)
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"Task ({task_id}) not found")
+        else:
+            task_json = json.loads(task_str)
+            return task_json


### PR DESCRIPTION
```python
from leptonai.photon import Worker

class MyWorker(Worker):
    def on_task(self, x: int):
        # do some work
        time.sleep(5):
        return x * 2
```

POST /task {"x": 1} -> returns a task id
GET /task?task_id -> returns status (&& result if configured save_result=True) of the corresponding task