### PR TITLE
feat(sdk): add anyio version dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-anyio
+anyio>=3.7.0 # we use exceptiongroup
 click
 cloudpickle==2.2.1
 contextlib2 # backports async support in nullcontext


### PR DESCRIPTION
@gyuho found the issue of the missing `exceptiongroup` dependency. I traced it down and turns out that to be absolutely safe, we would need to pin the anyio version.