### PR TITLE
fix(sdk): when env and secret in dep template are not set, issue warning rather than exception

### DIFF
--- a/leptonai/api/photon.py
+++ b/leptonai/api/photon.py
@@ -1,9 +1,10 @@
 import os
 from typing import List, Optional, Dict, Any
-
-from leptonai.config import CACHE_DIR, ENV_VAR_REQUIRED
+import warnings
 
 from loguru import logger
+
+from leptonai.config import CACHE_DIR, ENV_VAR_REQUIRED
 
 # import leptonai.photon to register the schemas and types
 import leptonai.photon  # noqa: F401
@@ -155,9 +156,11 @@ def run_remote(
     for k, v in template_envs.items():
         if v == ENV_VAR_REQUIRED:
             if not any(s.startswith(k + "=") for s in (env_list or [])):
-                raise ValueError(
+                warnings.warn(
                     f"This deployment requires env var {k}, but it's missing. Please"
-                    f" specify it with --env {k}=YOUR_VALUE."
+                    f" specify it with --env {k}=YOUR_VALUE. Otherwise, the deployment"
+                    " may fail.",
+                    RuntimeWarning,
                 )
         else:
             env_list = list(env_list) if env_list is not None else []
@@ -169,9 +172,11 @@ def run_remote(
         if not any(s.startswith(k) for s in (secret_list or [])) and not any(
             s.startswith(k) for s in (env_list or [])
         ):
-            raise ValueError(
+            warnings.warn(
                 f"This deployment requires secret {k}, but it's missing. Please set the"
-                f" secret, and specify it with --secret {k}."
+                f" secret, and specify it with --secret {k}. Otherwise, the deployment"
+                " may fail.",
+                RuntimeWarning,
             )
 
     # TODO: check if the given id is a valid photon id

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -553,15 +553,23 @@ class Photon(BasePhoton):
         for key in envs:
             if os.environ.get(key) is None:
                 if envs[key] == ENV_VAR_REQUIRED:
-                    raise RuntimeError(
-                        f"This photon expects env variable {key} but it s not set."
+                    warnings.warn(
+                        f"This photon expects env variable {key}, but it's not set."
+                        " Please set it before running the photon, or you may get"
+                        " unexpected behavior.",
+                        RuntimeWarning,
                     )
                 else:
                     os.environ[key] = envs[key]
         secrets = self._deployment_template.get("secret", [])
         for s in secrets:
             if os.environ.get(s) is None:
-                raise RuntimeError(f"This photon expects secret {s} but it s not set.")
+                warnings.warn(
+                    f"This photon expects secret {s}, but it's not set."
+                    " Please set it before running the photon, or you may get"
+                    " unexpected behavior.",
+                    RuntimeWarning,
+                )
 
     def _call_init_once(self):
         """


### PR DESCRIPTION
This is because in some cases, like running LLMs, some secrets are optional - like one may or may not need the `HUGGING_FACE_HUB_TOKEN` secret, depending on whether the specific model is behind an authentication wall. We will use deployment template as a guidance but not a strict rule as a result, and let the user specify what to do.