### PR TITLE
feat(sdk): add local authentication

### DIFF
--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -5,6 +5,7 @@ Overall configurations and constants for the Lepton AI python library.
 import os
 from pathlib import Path
 import sys
+import warnings
 
 import pydantic.version
 
@@ -111,6 +112,42 @@ BASE_IMAGE_CMD = None
 
 # Default port used by the Lepton deployments.
 DEFAULT_PORT = 8080
+
+
+def set_local_deployment_token(token: str):
+    """
+    Sets the local token used by Lepton deployments. If the token is empty, we will not
+    set the token in the deployment. If the token is set, all local endpoints defined
+    by Photon.handler are protected by the token.
+
+    Note that on the Lepton platform, the token is managed by the platform, so we
+    will ignore the local deployment token.
+    """
+    if token is None:
+        raise RuntimeError(
+            'Token cannot be None. To set an empty token, use empty string ("").'
+        )
+    global _LOCAL_DEPLOYMENT_TOKEN
+    if "LEPTON_WORKSPACE_ID" in os.environ and "LEPTON_DEPLOYMENT_NAME" in os.environ:
+        warnings.warn(
+            "We are running on the Lepton platform, so we will ignore the local"
+            " deployment token."
+        )
+    else:
+        _LOCAL_DEPLOYMENT_TOKEN = token
+
+
+def get_local_deployment_token() -> str:
+    """
+    Gets the local deployment token. If the token is explicitly set by set_local_deployment_token,
+    return the token. Otherwise, return the token from the environment variable LEPTON_LOCAL_DEPLOYMENT_TOKEN.
+    If the environment variable is not set, return an empty string.
+    """
+    if _LOCAL_DEPLOYMENT_TOKEN is None:
+        return os.environ.get("LEPTON_LOCAL_DEPLOYMENT_TOKEN", "")
+    else:
+        return _LOCAL_DEPLOYMENT_TOKEN
+
 
 # In the photon's deployment template, this means you will need to specify env variables.
 ENV_VAR_REQUIRED = "PLEASE_ENTER_YOUR_ENV_VARIABLE_HERE_(LEPTON_ENV_VAR_REQUIRED)"

--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -113,6 +113,8 @@ BASE_IMAGE_CMD = None
 # Default port used by the Lepton deployments.
 DEFAULT_PORT = 8080
 
+_LOCAL_DEPLOYMENT_TOKEN = None
+
 
 def set_local_deployment_token(token: str):
     """
@@ -127,13 +129,13 @@ def set_local_deployment_token(token: str):
         raise RuntimeError(
             'Token cannot be None. To set an empty token, use empty string ("").'
         )
-    global _LOCAL_DEPLOYMENT_TOKEN
     if "LEPTON_WORKSPACE_ID" in os.environ and "LEPTON_DEPLOYMENT_NAME" in os.environ:
         warnings.warn(
             "We are running on the Lepton platform, so we will ignore the local"
             " deployment token."
         )
     else:
+        global _LOCAL_DEPLOYMENT_TOKEN
         _LOCAL_DEPLOYMENT_TOKEN = token
 
 

--- a/leptonai/photon/tests/test_photon_auth.py
+++ b/leptonai/photon/tests/test_photon_auth.py
@@ -77,6 +77,7 @@ class TestPhotonAuth(unittest.TestCase):
         self.assertEqual(c.hello(name="world"), "Hello world")
 
         proc.kill()
+        set_local_deployment_token("")
 
 
 if __name__ == "__main__":

--- a/leptonai/photon/tests/test_photon_auth.py
+++ b/leptonai/photon/tests/test_photon_auth.py
@@ -1,0 +1,83 @@
+import multiprocessing
+import os
+import tempfile
+import time
+import unittest
+
+# Set cache dir to a temp dir before importing anything from leptonai
+tmpdir = tempfile.mkdtemp()
+os.environ["LEPTON_CACHE_DIR"] = tmpdir
+
+from leptonai import Photon
+from leptonai.client import Client, local
+
+from leptonai.config import set_local_deployment_token
+from leptonai.util import find_available_port
+
+from utils import random_name, photon_run_local_server
+
+
+class MyPhoton(Photon):
+    @Photon.handler
+    def foo(self) -> str:
+        return "bar"
+
+    @Photon.handler(method="GET")
+    def foo_get(self) -> str:
+        return "bar"
+
+    @Photon.handler
+    def hello(self, name: str) -> str:
+        return f"Hello {name}"
+
+
+class TestPhotonAuth(unittest.TestCase):
+    def setUp(self):
+        # pytest imports test files as top-level module which becomes
+        # unavailable in server process
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            import cloudpickle
+            import sys
+
+            cloudpickle.register_pickle_by_value(sys.modules[__name__])
+
+    def test_auth(self):
+        os.environ["LEPTON_LOCAL_DEPLOYMENT_TOKEN"] = "test_token"
+        ph = MyPhoton(name=random_name())
+        path = ph.save()
+        proc, port = photon_run_local_server(path=path)
+
+        with self.assertRaises(ConnectionError):
+            c = Client(local(port=port))
+        c = Client(local(port=port), token="test_token")
+        self.assertEqual(c.foo(), "bar")
+        self.assertEqual(c.foo_get(), "bar")
+        self.assertEqual(c.hello(name="world"), "Hello world")
+
+    def test_auth_with_set(self):
+        os.environ["LEPTON_LOCAL_DEPLOYMENT_TOKEN"] = ""
+        set_local_deployment_token("test_token2")
+
+        def subprocess_launch_wrapper(port):
+            set_local_deployment_token("test_token2")
+            photon = MyPhoton()
+            photon.launch(port=port)
+
+        port = find_available_port()
+        proc = multiprocessing.Process(target=subprocess_launch_wrapper, args=(port,))
+        proc.start()
+        time.sleep(1)
+
+        with self.assertRaises(ConnectionError):
+            c = Client(local(port=port))
+
+        c = Client(local(port=port), token="test_token2")
+        self.assertEqual(c.foo(), "bar")
+        self.assertEqual(c.foo_get(), "bar")
+        self.assertEqual(c.hello(name="world"), "Hello world")
+
+        proc.kill()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
To use, do
```python
config.set_local_deployment_token("sdfakdsjfj")
```
or set the env variable in shell
```shell
export LEPTON_LOCAL_DEPLOYMENT_TOKEN="sdfakdsjfj"
```

Note that local deployment token is ignored when deployed on the lepton platform.