### PR TITLE
feat(sdk): rocm docker

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,6 +18,14 @@ on:
         description: "Whether to install nightly version of torch"
         type: boolean
         default: false
+      build_rocm_base:
+        description: "Whether to (re)build rocm base images"
+        type: boolean
+        default: false
+      is_rocm_release:
+        description: "Is this a rocm release build"
+        type: boolean
+        default: false
 
 jobs:
   build_matrix:
@@ -44,6 +52,12 @@ jobs:
           ECR_REPOSITORY: lepton
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: echo "base_image=${ECR_REGISTRY}/${ECR_REPOSITORY}:photon-py${{ matrix.python_version }}" >> $GITHUB_OUTPUT
+      - name: Compute ROCm Vars
+        id: rocm-vars
+        env:
+          ECR_REPOSITORY: lepton
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: echo "rocm_base_image=${ECR_REGISTRY}/${ECR_REPOSITORY}:photon-rocm-py${{ matrix.python_version }}" >> $GITHUB_OUTPUT
       - name: Build Base Images
         if: inputs.build_base
         run: |
@@ -75,6 +89,30 @@ jobs:
 
           tag="${{ steps.vars.outputs.base_image }}-runner-${VERSION_TAG}"
           docker build . --build-arg BASE_IMAGE="${base_tag}" --file leptonai/photon/dockerfiles/photon-runner.Dockerfile --tag "${tag}"
+          if [ "${{ inputs.is_release }}" == 'true' ]; then
+              docker push ${tag}
+          fi
+          docker rmi ${tag}
+      - name: Build ROCm Base Images
+        if: inputs.build_rocm_base
+        run: |
+          tag="${{ steps.vars.outputs.base_rocm_image }}"
+          docker build . \
+              --build-arg PYTHON_VERSION=${{ matrix.python_version }} \
+              --build-arg ROCM_VERSION=5.6 \
+              --file leptonai/photon/dockerfiles/photon-rocm-py.Dockerfile --tag "${tag}"
+
+          if [ "${{ inputs.is_rocm_release }}" == 'true' ]; then
+              docker push ${tag}
+          fi
+      - name: Build ROCm Runner Images
+        env:
+          VERSION_TAG: ${{ github.event.inputs.version || github.sha }}
+        run: |
+          echo "HEAD SHA=$(git rev-parse --short HEAD)"
+          base_tag="${{ steps.vars.outputs.base_rocm_image }}"
+          tag="${{ steps.vars.outputs.base_rocm_image }}-runner-${VERSION_TAG}"
+          docker build . --build-arg BASE_IMAGE="${base_tag}" --file leptonai/photon/dockerfiles/photon-rocm-runner.Dockerfile --tag "${tag}"
           if [ "${{ inputs.is_release }}" == 'true' ]; then
               docker push ${tag}
           fi

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -53,7 +53,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: echo "base_image=${ECR_REGISTRY}/${ECR_REPOSITORY}:photon-py${{ matrix.python_version }}" >> $GITHUB_OUTPUT
       - name: Compute ROCm Vars
-        id: rocm-vars
+        id: rocm_vars
         env:
           ECR_REPOSITORY: lepton
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -96,7 +96,7 @@ jobs:
       - name: Build ROCm Base Images
         if: inputs.build_rocm_base
         run: |
-          tag="${{ steps.vars.outputs.base_rocm_image }}"
+          tag="${{ steps.rocm_vars.outputs.rocm_base_image }}"
           docker build . \
               --build-arg PYTHON_VERSION=${{ matrix.python_version }} \
               --build-arg ROCM_VERSION=5.6 \
@@ -110,8 +110,8 @@ jobs:
           VERSION_TAG: ${{ github.event.inputs.version || github.sha }}
         run: |
           echo "HEAD SHA=$(git rev-parse --short HEAD)"
-          base_tag="${{ steps.vars.outputs.base_rocm_image }}"
-          tag="${{ steps.vars.outputs.base_rocm_image }}-runner-${VERSION_TAG}"
+          base_tag="${{ steps.rocm_vars.outputs.rocm_base_image }}"
+          tag="${{ steps.rocm_vars.outputs.rocm_base_image }}-runner-${VERSION_TAG}"
           docker build . --build-arg BASE_IMAGE="${base_tag}" --file leptonai/photon/dockerfiles/photon-rocm-runner.Dockerfile --tag "${tag}"
           if [ "${{ inputs.is_release }}" == 'true' ]; then
               docker push ${tag}

--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -101,7 +101,7 @@ DB_PATH = CACHE_DIR / "lepton.db"
 LOGS_DIR = CACHE_DIR / "logs"
 
 
-def _is_rocm():
+def _is_rocm() -> bool:
     """
     Detects if we are using rocm.
 
@@ -121,7 +121,7 @@ def _is_rocm():
         # involve torch, and we will just use it.
         import torch
 
-        return torch.cuda.is_available() and torch.version.hip
+        return torch.cuda.is_available() and (torch.version.hip is not None)
 
 
 # Lepton's base image and image repository location.

--- a/leptonai/photon/dockerfiles/photon-rocm-py.Dockerfile
+++ b/leptonai/photon/dockerfiles/photon-rocm-py.Dockerfile
@@ -1,0 +1,23 @@
+ARG ROCM_VERSION=5.7
+ARG UBUNTU_VERSION=22.04
+
+FROM rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+COPY . /tmp/leptonai-sdk
+
+ARG PYTHON_VERSION
+ENV LEPTON_VIRTUAL_ENV=/opt/lepton/venv
+
+RUN /tmp/leptonai-sdk/leptonai/photon/dockerfiles/install_base.sh
+
+RUN /tmp/leptonai-sdk/leptonai/photon/dockerfiles/install_python.sh ${PYTHON_VERSION}
+ENV PATH="$LEPTON_VIRTUAL_ENV/bin:$PATH"
+
+RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.6 
+
+RUN pip install uvicorn[standard] gradio!=3.31.0
+
+RUN rm -rf /tmp/leptonai-sdk

--- a/leptonai/photon/dockerfiles/photon-rocm-runner.Dockerfile
+++ b/leptonai/photon/dockerfiles/photon-rocm-runner.Dockerfile
@@ -14,3 +14,4 @@ RUN pip install /tmp/leptonai-sdk
 RUN rm -rf /tmp/leptonai-sdk
 
 WORKDIR /workspace
+

--- a/leptonai/photon/dockerfiles/photon-rocm-runner.Dockerfile
+++ b/leptonai/photon/dockerfiles/photon-rocm-runner.Dockerfile
@@ -1,0 +1,16 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# TODO: Should move to base image
+RUN sudo apt-get update && sudo apt-get install -y libgl1 ffmpeg libgoogle-perftools-dev
+ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4"
+
+RUN pip install -U pip setuptools wheel
+
+RUN CT_HIPBLAS=1 pip install ctransformers -U --no-binary ctransformers --no-cache-dir
+
+COPY . /tmp/leptonai-sdk
+RUN pip install /tmp/leptonai-sdk
+RUN rm -rf /tmp/leptonai-sdk
+
+WORKDIR /workspace

--- a/leptonai/tests/test_configs.py
+++ b/leptonai/tests/test_configs.py
@@ -1,0 +1,29 @@
+from importlib import reload
+import os
+import torch
+import unittest
+
+
+class TestConfig(unittest.TestCase):
+    def test_is_rocm_flag(self):
+        from leptonai import config
+
+        # Since we cannot really control the underlying hardware, we try our best
+        # to test the flag.
+        if torch.cuda.is_available():
+            self.assertEqual(config._is_rocm(), (torch.version.hip is not None))
+        os.environ["LEPTON_BASE_IMAGE_FORCE_ROCM"] = "true"
+        reload(config)
+        self.assertTrue(config._is_rocm())
+        self.assertIn("photon-rocm-py", config.BASE_IMAGE)
+        self.assertNotIn("photon-py", config.BASE_IMAGE)
+
+        os.environ["LEPTON_BASE_IMAGE_FORCE_ROCM"] = "false"
+        reload(config)
+        self.assertFalse(config._is_rocm())
+        self.assertNotIn("photon-rocm-py", config.BASE_IMAGE)
+        self.assertIn("photon-py", config.BASE_IMAGE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Formally platiform-fy the image for non-first-party usage as well.

To avoid rebuilding and pushing base images that are too big, I added two options: `build_rocm_base` and `is_rocm_release`.
- The first time we push, we will need to build rocm base as it is a new base image.
- For all future builds, rocm and the default will be two parallel build and releases, but we likely will sync them as well.