### PR TITLE
Revert "chore(sdk): Remove dangling testing file"

### DIFF
--- a/leptonai/tests/shell/README.md
+++ b/leptonai/tests/shell/README.md
@@ -1,0 +1,14 @@
+This is a simple class that uses the `/run` api to run a shell command on the
+local deployment. Note: since the deployments are considered stateless, any
+command you run that may have a non-ephemeral effect, such as creating a file
+or so, will not be persistent, unless it is written to a persistent storage
+such as the Lepton storage or a mounted S3.
+
+To build the photon, do:
+
+    lep photon create -n shell -m shell.py:Shell
+
+To run the photon, simply do
+
+    lep photon run -n shell [optional arguments]
+

--- a/leptonai/tests/shell/shell.py
+++ b/leptonai/tests/shell/shell.py
@@ -1,0 +1,21 @@
+import subprocess
+from typing import Tuple
+
+# This is what you should do to load the Photon class and write your code.
+from leptonai.photon import Photon, handler
+
+
+class Shell(Photon):
+    def init(self):
+        pass
+
+    @handler("run", example={"query": "pwd"})
+    def run(self, query: str) -> Tuple[str, str]:
+        """Run the shell. Don't do rm -rf though."""
+        output = subprocess.run(
+            query, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        stdout_output = output.stdout.strip()
+        stderr_output = output.stderr.strip()
+
+        return stdout_output, stderr_output


### PR DESCRIPTION
Reverts leptonai/leptonai#195

The file is actually used in internal e2e test. Leaving it as-is and not deleting.