### PR TITLE
fix(sdk): bug from pydantic 1.x

### DIFF
--- a/leptonai/photon/tests/test_types_file.py
+++ b/leptonai/photon/tests/test_types_file.py
@@ -20,6 +20,13 @@ class TestFile(unittest.TestCase):
         file_object = File(content)
         self.assertEqual(file_object.get_content(), content)
 
+    def test_file_from_file(self):
+        content = b"hello world"
+        file_object = File(BytesIO(content))
+        self.assertEqual(file_object.get_content(), content)
+        ff = File(file_object)
+        self.assertEqual(ff.get_content(), content)
+
     def test_file_str(self):
         # illegal string
         content = "hello world"

--- a/leptonai/photon/types/file.py
+++ b/leptonai/photon/types/file.py
@@ -50,7 +50,9 @@ _BASE64FILE_ENCODED_PREFIX = "data:application/octet-stream;base64,"
 class File(BaseModel):
     content: Union[bytes, str]
 
-    def __init__(self, content: Union[IO, bytes, str]):
+    def __init__(self, content: Union[IO, bytes, str, "File"]):
+        if isinstance(content, File):
+            content = content.content
         if hasattr(content, "read"):
             content = content.read()  # type: ignore
         super().__init__(content=content)
@@ -159,6 +161,9 @@ class File(BaseModel):
 
         class Config:
             json_encoders = {Union[bytes, str, IO]: lambda v: File.encode(v)}
+            # Backward compatibility to run smart_union if pydantic version is old.
+            # See https://docs.pydantic.dev/1.10/usage/model_config/#smart-union for more details.
+            smart_union = True
 
     else:
         from pydantic import field_serializer  # type: ignore


### PR DESCRIPTION
pydantic 1.x doesn't have smart union set to true, and will coerce str into bytes. This fixes the problem.

Also added a copy contructor capability.