### PR TITLE
feat(storage): no need to enable/disable rsync

### DIFF
--- a/leptonai/api/storage.py
+++ b/leptonai/api/storage.py
@@ -130,17 +130,3 @@ def du(conn: Connection):
     """
     response = conn.get("/storage/du")
     return json_or_error(response)
-
-
-def enable_rsync(conn: Connection):
-    """
-    Enable rsync for the current workspace.
-    """
-    return conn.post("/storage/rsync")
-
-
-def disable_rsync(conn: Connection):
-    """
-    Disable rsync for the current workspace.
-    """
-    return conn.delete("/storage/rsync")

--- a/leptonai/cli/storage.py
+++ b/leptonai/cli/storage.py
@@ -8,6 +8,7 @@ from .constants import STORAGE_DISPLAY_PREFIX_LAST, STORAGE_DISPLAY_PREFIX_MIDDL
 import click
 
 from leptonai.api import storage as api
+from leptonai.api import deployment as deploymentapi
 from leptonai.api.workspace import WorkspaceInfoLocalRecord
 
 from .util import (
@@ -17,6 +18,7 @@ from .util import (
     get_connection_or_die,
     explain_response,
     sizeof_fmt,
+    get_only_replica_public_ip_or_die,
 )
 
 custom_theme = Theme({
@@ -87,36 +89,6 @@ def du():
     print(usage)
     humanized_usage = sizeof_fmt(usage["totalDiskUsageBytes"])
     console.print(f"Total disk usage: {humanized_usage}")
-
-
-@storage.command()
-def enable_rsync():
-    """
-    Enables rsync for the workspace
-    """
-    conn = get_connection_or_die()
-    response = api.enable_rsync(conn)
-    explain_response(
-        response,
-        "Enabled rsync for the workspace.",
-        "enable rsync failed. See error message above.",
-        "enable rsync failed. Internal service error.",
-    )
-
-
-@storage.command()
-def disable_rsync():
-    """
-    Disables rsync for the workspace
-    """
-    conn = get_connection_or_die()
-    response = api.disable_rsync(conn)
-    explain_response(
-        response,
-        "Disabled rsync for the workspace.",
-        "disable rsync failed. See error message above.",
-        "disable rsync failed. Internal service error.",
-    )
 
 
 @storage.command()
@@ -258,29 +230,21 @@ def upload(local_path, remote_path, rsync, recursive, progress):
             f" [green]{remote_path}[/] with rsync..."
         )
 
+        conn = get_connection_or_die()
+
+        name = "storage-rsync-deployment"
+        dep_info = guard_api(
+            deploymentapi.get_deployment(conn, name),
+            detail=True,
+            msg="Cannot obtain info for [red]rsync service[/]. See error above.",
+        )
+        port = dep_info["container"]["ports"][0]["host_port"]
+        ip = get_only_replica_public_ip_or_die(conn, name)
+
         workspace = WorkspaceInfoLocalRecord.get_current_workspace_id()
         pwd = WorkspaceInfoLocalRecord.get_current_workspace_token()
         if len(pwd) > 8:
             pwd = pwd[:8]
-        url = WorkspaceInfoLocalRecord._get_current_workspace_deployment_url()
-        if url is None or workspace is None or pwd is None:
-            console.print("It seems that you are not logged in yet.")
-            return
-
-        split_url = url.split("//")
-        check(
-            len(split_url) == 2,
-            "[red]Invalid Workspace URL format[/]: Missing protocol",
-        )
-
-        rest = split_url[1]
-        parts = rest.split(".")
-        check(
-            len(parts) >= 3,
-            "[red]Invalid Workspace URL format[/]: Missing domain",
-        )
-
-        root_domain = ".".join(parts[1:])
         env_vars = {"RSYNC_PASSWORD": pwd}
         flags = "-v"
         if recursive:
@@ -289,7 +253,7 @@ def upload(local_path, remote_path, rsync, recursive, progress):
             flags += " --progress"
         command = (
             f"rsync {flags}"
-            f" {local_path} rsync://{workspace}@{workspace}-storage-rsync-deployment.{root_domain}:8873/volume{remote_path}"
+            f" {local_path} rsync://{workspace}@{ip}:{port}/volume{remote_path}"
         )
         console.print(f"Running command: [bold]{command}[/]")
 


### PR DESCRIPTION
Now we enable it by default for standard and enterprise plans.

test with 

```
lep storage upload test / --rsync
Uploading file(or directory) NOTICE to /test with rsync...
Running command: rsync -v NOTICE rsync://latest@129.80.137.39:41860/volume/test
test

sent 83 bytes  received 44 bytes  50.80 bytes/sec
total size is 29  speedup is 0.23
```