### PR TITLE
Revert "pre-install hf-transfer for faster download"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ python-multipart
 
 accelerate # needed by low_cpu_mem_usage
 huggingface_hub
-hf-transfer
 diffusers[torch]
 sentence-transformers
 torch


### PR DESCRIPTION
Reverts leptonai/leptonai#211 . This fixes #321 , and if we want faster download, one can manually install hf-transfer.

closes #321 