### PR TITLE
feat(sdk): add http method to openapi schema, and added client support multiple methods for a path.

### DIFF
--- a/leptonai/photon/tests/test_client.py
+++ b/leptonai/photon/tests/test_client.py
@@ -55,11 +55,11 @@ class PostAndGetSameName(Photon):
 
     @handler(path="run", method="POST")
     def run_post(self) -> str:
-        return f"post"
+        return "post"
 
     @handler(path="run", method="GET")
     def run_get(self) -> str:
-        return f"get"
+        return "get"
 
 
 class Throws429(Photon):

--- a/leptonai/photon/tests/test_client.py
+++ b/leptonai/photon/tests/test_client.py
@@ -86,7 +86,7 @@ class TestPathTree(unittest.TestCase):
         def temp_func(x):
             return x
 
-        tree._add("foo", temp_func)
+        tree._add("foo", temp_func, "get")
         self.assertTrue(tree)
 
 

--- a/leptonai/photon/tests/test_client.py
+++ b/leptonai/photon/tests/test_client.py
@@ -165,14 +165,14 @@ class TestClient(unittest.TestCase):
         self.assertTrue(client.healthz())
         # Tests if run is registered
         res = client.run()
-        self.assertIn(res, ["post", "get"])
+        self.assertEqual(res, "post")
         # Tests if run_post and run_get are both registered
         from leptonai.client import _MultipleEndpointWithDefault
 
         self.assertIsInstance(
             client.run, _MultipleEndpointWithDefault, client._debug_record
         )
-        self.assertIn(client.run.post(), "post")
+        self.assertEqual(client.run.post(), "post")
         self.assertTrue(client.run.get(), "get")
 
     def test_client_with_throw_429(self):

--- a/leptonai/photon/tests/test_client.py
+++ b/leptonai/photon/tests/test_client.py
@@ -166,9 +166,14 @@ class TestClient(unittest.TestCase):
         # Tests if run is registered
         res = client.run()
         self.assertIn(res, ["post", "get"])
-        self.assertTrue(client.run() == "post")
-        # This does not work yet, as client right now still only supports one handler per path.
-        # self.assertTrue(client.run() == "get")
+        # Tests if run_post and run_get are both registered
+        from leptonai.client import _MultipleEndpointWithDefault
+
+        self.assertIsInstance(
+            client.run, _MultipleEndpointWithDefault, client._debug_record
+        )
+        self.assertIn(client.run.post(), "post")
+        self.assertTrue(client.run.get(), "get")
 
     def test_client_with_throw_429(self):
         proc, port = photon_run_local_server_simple(Throws429)


### PR DESCRIPTION
Closes: #5004

If there is a path name, say "/run", with multiple methods specified, we will:
- use "post" as the default method, so client.run() always calls post
- allow user to specify the method, like client.run.post() and client.run.get().
See the test file for details.