### PR TITLE
chore(cli): migrate the kv cli and kv wrapper class to the new API.

### DIFF
--- a/leptonai/api/kv.py
+++ b/leptonai/api/kv.py
@@ -1,3 +1,12 @@
+import warnings
+
+warnings.warn(
+    "This module is deprecated and will be removed in the future. Please use"
+    " leptonai.api.v1 instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 # Because most of the apis in kv do not return json, we will not use json_or_error here.
 from typing import Union, Optional
 

--- a/leptonai/api/v1/kv.py
+++ b/leptonai/api/v1/kv.py
@@ -19,7 +19,7 @@ class KVAPI(APIResourse):
 
     def get_namespace(self, name_or_ns: Union[str, KV]) -> KV:
         """
-        Get the value of a key in the KV.
+        Get a KV in the current workspace.
         """
         response = self._get(f"/kv/namespaces/{self._to_name(name_or_ns)}")
         return self.ensure_type(response, KV)

--- a/leptonai/photon/worker.py
+++ b/leptonai/photon/worker.py
@@ -14,8 +14,6 @@ from loguru import logger
 
 from .photon import Photon, HTTPException
 from leptonai.api.v1.workspace_record import WorkspaceRecord
-from leptonai.queue import Queue, Empty
-from leptonai.kv import KV
 from leptonai.util import asyncfy_with_semaphore
 
 
@@ -69,6 +67,10 @@ class Worker(Photon):
         If your class does not implement the init function, the Worker's init function
         will be called automatically.
         """
+        # to avoid circular import
+        from leptonai.kv import KV
+        from leptonai.queue import Queue
+
         super().init()
         # Logs in to the workspace if not logged in yet.
         if not WorkspaceRecord.current():
@@ -113,6 +115,8 @@ class Worker(Photon):
 
     def _worker_loop(self):
         """Keep polling the queue for new tasks, and dispatch them to `on_task` (through `_on_task`)"""
+        from leptonai.queue import Empty
+
         loop = asyncio.new_event_loop()
         # TODO: Is this the right way to start the loop?
         threading.Thread(target=loop.run_forever, daemon=True).start()


### PR DESCRIPTION
This is probably a good illustrative migration from the old api to the new api. A few things @xlu451 to notice:

- we should add the deprecated warning lines in the old leptonai/api/*.py, in this case kv.py.
- For all the cli, if you encounter `explain_response` or old school `if res.ok` or other try-catch phrases of earlier APIs, let's delete them for the sake of clean code. Exceptions from the new style API should already be good enough to convey a meaningful message.
- for the rest of CLI commands, most of them do not come with a top level wrapper class (in this case lepton.kv.KV), other than queue and object store. Just FYI.

Tested: leptonai/tests/test_kv.py although this isn't a specific API test. We should add API tests down the road.