### PR TITLE
feat(sdk): provide pydantic 2.x and 1.x compatibility

### DIFF
--- a/leptonai/api/v1/types/deployment_operator_v1alpha1/deployment.py
+++ b/leptonai/api/v1/types/deployment_operator_v1alpha1/deployment.py
@@ -1,7 +1,8 @@
 from enum import Enum
-from pydantic import BaseModel, Field, field_validator, ValidationInfo
+from pydantic import BaseModel, Field
 from typing import Optional, List
 
+from leptonai.config import compatible_field_validator, v2only_field_validator
 from .affinity import LeptonResourceAffinity
 
 DEFAULT_STORAGE_VOLUME_NAME = "default"
@@ -39,13 +40,13 @@ class ContainerPort(BaseModel):
     host_port: Optional[int] = None
     enable_load_balancer: Optional[bool] = None
 
-    @field_validator("container_port")
+    @compatible_field_validator("container_port")
     def validate_container_port(cls, v):
         if v < 0 or v > 65535:
             raise ValueError("Invalid port number. Port must be between 0 and 65535.")
         return v
 
-    @field_validator("protocol")
+    @compatible_field_validator("protocol")
     def validate_protocol(cls, v):
         if v and v.lower() not in ["tcp", "udp"]:
             raise ValueError(
@@ -93,7 +94,7 @@ class ResourceRequirement(BaseModel):
     max_replicas: Optional[int] = None
     host_network: Optional[bool] = None
 
-    @field_validator("resource_shape")
+    @compatible_field_validator("resource_shape")
     def validate_resource_shape(cls, v):
         if v is None:
             return v
@@ -115,7 +116,7 @@ class ResourceRequirement(BaseModel):
         #     )
         return v
 
-    @field_validator("min_replicas")
+    @compatible_field_validator("min_replicas")
     def validate_min_replicas(cls, min_replicas):
         if min_replicas is None:
             return min_replicas
@@ -125,8 +126,8 @@ class ResourceRequirement(BaseModel):
             )
         return min_replicas
 
-    @field_validator("max_replicas")
-    def validate_max_replicas(cls, max_replicas, values: ValidationInfo):
+    @v2only_field_validator("max_replicas")
+    def validate_max_replicas(cls, max_replicas, values: "ValidationInfo"):  # type: ignore
         if max_replicas is None:
             return max_replicas
         if max_replicas < 0:
@@ -150,13 +151,13 @@ class ScaleDown(BaseModel):
     no_traffic_timeout: Optional[int] = None
     not_ready_timeout: Optional[int] = None
 
-    @field_validator("no_traffic_timeout")
+    @compatible_field_validator("no_traffic_timeout")
     def validate_no_traffic_timeout(cls, v):
         if v is not None and v < 0:
             raise ValueError(f"no_traffic_timeout must be non-negative. Found {v}.")
         return v
 
-    @field_validator("not_ready_timeout")
+    @compatible_field_validator("not_ready_timeout")
     def validate_not_ready_timeout(cls, v):
         if v is not None and v < 0:
             raise ValueError(f"not_ready_timeout must be non-negative. Found {v}.")
@@ -174,7 +175,7 @@ class AutoScaler(BaseModel):
     target_gpu_utilization_percentage: Optional[int] = None
     target_throughput: Optional[AutoscalerTargetThroughput] = None
 
-    @field_validator("target_gpu_utilization_percentage")
+    @compatible_field_validator("target_gpu_utilization_percentage")
     def validate_target_gpu_utilization_percentage(cls, v):
         if v is not None and (v < 0 or v > 100):
             raise ValueError(

--- a/leptonai/api/v1/types/readiness.py
+++ b/leptonai/api/v1/types/readiness.py
@@ -1,6 +1,8 @@
 from enum import Enum
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel
 from typing import Dict, List
+
+from leptonai.config import CompatibleRootModel
 
 
 class ReplicaReadinessReason(str, Enum):
@@ -21,5 +23,5 @@ class ReplicaReadinessIssue(BaseModel):
     creationTimestamp: str
 
 
-class ReadinessIssue(RootModel[Dict[str, List[ReplicaReadinessIssue]]]):
+class ReadinessIssue(CompatibleRootModel[Dict[str, List[ReplicaReadinessIssue]]]):
     root: Dict[str, List[ReplicaReadinessIssue]] = {}

--- a/leptonai/api/v1/types/termination.py
+++ b/leptonai/api/v1/types/termination.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel, RootModel
+from pydantic import BaseModel
 from typing import Dict, List
+
+from leptonai.config import CompatibleRootModel
 
 
 class ReplicaTermination(BaseModel):
@@ -10,5 +12,5 @@ class ReplicaTermination(BaseModel):
     message: str
 
 
-class DeploymentTerminations(RootModel[Dict[str, List[ReplicaTermination]]]):
+class DeploymentTerminations(CompatibleRootModel[Dict[str, List[ReplicaTermination]]]):
     root: Dict[str, List[ReplicaTermination]] = {}

--- a/leptonai/tests/test_configs.py
+++ b/leptonai/tests/test_configs.py
@@ -1,10 +1,19 @@
 from importlib import reload
 import os
-import torch
+from pydantic import BaseModel
+from typing import Dict
 import unittest
+
+try:
+    import torch
+
+    torch_available = True
+except ImportError:
+    torch_available = False
 
 
 class TestConfig(unittest.TestCase):
+    @unittest.skipIf(not torch_available, "Pytorch is not available")
     def test_is_rocm_flag(self):
         from leptonai import config
 
@@ -23,6 +32,62 @@ class TestConfig(unittest.TestCase):
         self.assertFalse(config._is_rocm())
         self.assertNotIn("photon-rocm-py", config.BASE_IMAGE)
         self.assertIn("photon-py", config.BASE_IMAGE)
+
+
+class TestPydanticCompatib(unittest.TestCase):
+    def test_compatible_root_model(self):
+        from leptonai.config import CompatibleRootModel
+
+        class TestModel(CompatibleRootModel[Dict[str, str]]):
+            root: Dict[str, str] = {}
+
+        test_model = TestModel()
+        self.assertEqual(test_model.root, {})
+        self.assertEqual(test_model.dict(), {})
+        self.assertEqual(test_model.json(), "{}")
+        test_model.root = {"key": "value"}
+        self.assertEqual(test_model.root, {"key": "value"})
+        self.assertEqual(test_model.dict(), {"key": "value"})
+        self.assertEqual(test_model.json(), '{"key":"value"}')
+
+    def test_compatible_field_validator(self):
+        from leptonai.config import compatible_field_validator
+
+        class TestModel(BaseModel):
+            field: str
+
+            @compatible_field_validator("field")
+            def field_cannot_be_moo(cls, value):
+                if value == "moo":
+                    raise ValueError("Field cannot be moo")
+                return value
+
+        test_model = TestModel(field="bar")
+        self.assertEqual(test_model.field, "bar")
+        with self.assertRaises(ValueError):
+            test_model = TestModel(field="moo")
+
+    def test_v2only_field_validator(self):
+        from leptonai.config import v2only_field_validator, PYDANTIC_MAJOR_VERSION
+
+        class TestModel(BaseModel):
+            field: str
+
+            @v2only_field_validator("field")
+            def field_cannot_be_moo(cls, value):
+                if value == "moo":
+                    raise ValueError("Field cannot be moo")
+                return value
+
+        test_model = TestModel(field="bar")
+        self.assertEqual(test_model.field, "bar")
+        if PYDANTIC_MAJOR_VERSION > 1:
+            with self.assertRaises(ValueError):
+                test_model = TestModel(field="moo")
+        else:
+            # v2only validators will not be called in pydantic v1
+            test_model = TestModel(field="moo")
+            self.assertEqual(test_model.field, "moo")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR tries to support pydantic 1.x in a best-effort fashion by backporting a few functionalities - mainly field_validator and RootModel - to 1.x. Right now the recommended version is still pydantic 2.x.