### PR TITLE
fix: deployment create error

### DIFF
--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -316,7 +316,6 @@ def create(
 
     # First, check whether the input is photon or container. We will prioritize using
     # photon if both are specified.
-    deployment_template = PhotonDeploymentTemplate()
     if photon_name is not None or photon_id is not None:
         # We will use photon.
         if container_image is not None or container_command is not None:

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime
 import re
 import shlex

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -360,7 +360,17 @@ def create(
         # container based deployment won't have the deployment template as photons do.
         # So we will simply create an empty one.
         deployment_template = PhotonDeploymentTemplate()
-
+    else:
+        # No photon_id, photon_name, container_image, or container_command
+        console.print("""
+            You have not provided a photon_name, photon_id, or container image.
+            Please use one of the following options:
+            -p <photon_name>
+            -i <photon_id>
+            --container-image <container_image> and --container-command <container_command>
+            to specify a photon or container image.
+            """)
+        sys.exit(1)
     # default timeout
     if (
         no_traffic_timeout is None

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -314,6 +314,7 @@ def create(
 
     # First, check whether the input is photon or container. We will prioritize using
     # photon if both are specified.
+    deployment_template = PhotonDeploymentTemplate()
     if photon is not None or photon_id is not None:
         # We will use photon.
         if container_image is not None or container_command is not None:


### PR DESCRIPTION
It seems our deployment create function will have

- deployment_template has not been declared error
- Deployment creation failed due to the mixed-use of 'name', 'photon', and 'photon(obj)'.

**Which seems led to our deployment create function not being usable at this time.**

