### PR TITLE
fix: photon multiple values for argument request error

### DIFF
--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -379,4 +379,4 @@ LEPTON_WORKSPACE_URL = LEPTON_DASHBOARD_URL + "/workspace/{workspace_id}"
 # Append "/demo", "/api", "/metrics", "/events", "/replicas/list" for the deployment dashboard functions.
 LEPTON_DEPLOYMENT_URL = LEPTON_WORKSPACE_URL + "/deployments/detail/{deployment_name}"
 
-PHOTON_FORBIDDEN_PARAMETER_NAMES = {'request', 'cancel_on_connect_interval', 'callback'}
+PHOTON_FORBIDDEN_PARAMETER_NAMES = {"request", "cancel_on_connect_interval", "callback"}

--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -378,3 +378,5 @@ LEPTON_WORKSPACE_URL = LEPTON_DASHBOARD_URL + "/workspace/{workspace_id}"
 # LEPTON_DEPLOYMENT_URL is used to get the web url for the deployment.
 # Append "/demo", "/api", "/metrics", "/events", "/replicas/list" for the deployment dashboard functions.
 LEPTON_DEPLOYMENT_URL = LEPTON_WORKSPACE_URL + "/deployments/detail/{deployment_name}"
+
+PHOTON_FORBIDDEN_PARAMETER_NAMES = {'request', 'cancel_on_connect_interval', 'callback'}

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -51,7 +51,7 @@ from leptonai.config import (  # noqa: F401
     ENV_VAR_REQUIRED,
     PYDANTIC_MAJOR_VERSION,
     VALID_SHAPES,
-    get_local_deployment_token,
+    get_local_deployment_token, PHOTON_FORBIDDEN_PARAMETER_NAMES,
 )
 from leptonai.photon.constants import METADATA_VCS_URL_KEY
 from leptonai.photon.download import fetch_code_from_vcs
@@ -1235,6 +1235,10 @@ class Photon(BasePhoton):
 
     @staticmethod
     def handler(path=None, method="POST", **kwargs):
+        for key in PHOTON_FORBIDDEN_PARAMETER_NAMES:
+            if key in kwargs:
+                raise ValueError(f"The parameter name '{key}' is not allowed. "
+                                 f"Please rename the parameter and rebuild Photon.")
         Photon._santity_check_handler_kwargs(kwargs)
 
         def decorator(func):

--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -51,7 +51,8 @@ from leptonai.config import (  # noqa: F401
     ENV_VAR_REQUIRED,
     PYDANTIC_MAJOR_VERSION,
     VALID_SHAPES,
-    get_local_deployment_token, PHOTON_FORBIDDEN_PARAMETER_NAMES,
+    get_local_deployment_token,
+    PHOTON_FORBIDDEN_PARAMETER_NAMES,
 )
 from leptonai.photon.constants import METADATA_VCS_URL_KEY
 from leptonai.photon.download import fetch_code_from_vcs
@@ -1237,8 +1238,10 @@ class Photon(BasePhoton):
     def handler(path=None, method="POST", **kwargs):
         for key in PHOTON_FORBIDDEN_PARAMETER_NAMES:
             if key in kwargs:
-                raise ValueError(f"The parameter name '{key}' is not allowed. "
-                                 f"Please rename the parameter and rebuild Photon.")
+                raise ValueError(
+                    f"The parameter name '{key}' is not allowed. "
+                    "Please rename the parameter and rebuild Photon."
+                )
         Photon._santity_check_handler_kwargs(kwargs)
 
         def decorator(func):


### PR DESCRIPTION
When a user creates a Photon class and passes parameters such as **request, cancel_on_connect_interval, or callback,** a multiple values error occurs 
Because these parameters are already defined in the **photon/photon.py: handle_request** function, which accepts them as parameters along with *args and **kwargs