### PR TITLE
fix: lock ruff version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ lep = "leptonai.cli:lep"
 [project.optional-dependencies]
 lint = [
     "black==23.12.0",
-    "ruff"
+    "ruff==0.5.7"
 ]
 test = [
     "pytest",


### PR DESCRIPTION
The recent upgrade of Ruff (10 hours ago) caused our linting process to fail, as it started checking .ipynb files in the leptonai/example project.