### PR TITLE
fix：deployment list crush caused by new state

### DIFF
--- a/leptonai/api/v1/types/deployment.py
+++ b/leptonai/api/v1/types/deployment.py
@@ -1,3 +1,4 @@
+import warnings
 from enum import Enum
 from pydantic import BaseModel, Field
 from typing import Optional, List
@@ -250,8 +251,11 @@ class LeptonDeploymentState(str, Enum):
     Deleting = "Deleting"
     Stopping = "Stopping"
     Stopped = "Stopped"
-    Unknown = ""
-
+    Unknown = "unk"
+    @classmethod
+    def _missing_(cls, value):
+        warnings.warn("You might be using an out of date SDK. consider updating.")
+        return cls.Unknown
 
 class DeploymentEndpoint(BaseModel):
     internal_endpoint: str
@@ -273,7 +277,7 @@ class AutoScalerStatus(BaseModel):
 
 
 class LeptonDeploymentStatus(BaseModel):
-    state: str
+    state: LeptonDeploymentState
     endpoint: DeploymentEndpoint
     autoscaler_status: Optional[AutoScalerStatus] = None
     with_system_photon: Optional[bool] = None

--- a/leptonai/api/v1/types/deployment.py
+++ b/leptonai/api/v1/types/deployment.py
@@ -248,6 +248,8 @@ class LeptonDeploymentState(str, Enum):
     Starting = "Starting"
     Updating = "Updating"
     Deleting = "Deleting"
+    Stopping = "Stopping"
+    Stopped = "Stopped"
     Unknown = ""
 
 
@@ -271,7 +273,7 @@ class AutoScalerStatus(BaseModel):
 
 
 class LeptonDeploymentStatus(BaseModel):
-    state: LeptonDeploymentState
+    state: str
     endpoint: DeploymentEndpoint
     autoscaler_status: Optional[AutoScalerStatus] = None
     with_system_photon: Optional[bool] = None

--- a/leptonai/api/v1/types/deployment.py
+++ b/leptonai/api/v1/types/deployment.py
@@ -251,11 +251,13 @@ class LeptonDeploymentState(str, Enum):
     Deleting = "Deleting"
     Stopping = "Stopping"
     Stopped = "Stopped"
-    Unknown = "unk"
+    Unknown = "UNK"
+
     @classmethod
     def _missing_(cls, value):
         warnings.warn("You might be using an out of date SDK. consider updating.")
         return cls.Unknown
+
 
 class DeploymentEndpoint(BaseModel):
     internal_endpoint: str

--- a/leptonai/api/v1/types/job.py
+++ b/leptonai/api/v1/types/job.py
@@ -41,7 +41,7 @@ class LeptonJobState(str, Enum):
     Deleting = "Deleting"
     Restarting = "Restarting"
     Archived = "Archived"
-    Unknown = ""
+    Unknown = "UNK"
 
     @classmethod
     def _missing_(cls, value):

--- a/leptonai/api/v1/types/job.py
+++ b/leptonai/api/v1/types/job.py
@@ -1,3 +1,4 @@
+import warnings
 from enum import Enum
 from pydantic import BaseModel
 from typing import Optional, List
@@ -42,6 +43,11 @@ class LeptonJobState(str, Enum):
     Archived = "Archived"
     Unknown = ""
 
+    @classmethod
+    def _missing_(cls, value):
+        warnings.warn("You might be using an out of date SDK. consider updating.")
+        return cls.Unknown
+
 
 class LeptonJobStatusDetails(BaseModel):
     """
@@ -49,7 +55,7 @@ class LeptonJobStatusDetails(BaseModel):
     """
 
     job_name: Optional[str] = None
-    state: str
+    state: LeptonJobState
     ready: int
     active: int
     failed: int

--- a/leptonai/api/v1/types/job.py
+++ b/leptonai/api/v1/types/job.py
@@ -39,6 +39,7 @@ class LeptonJobState(str, Enum):
     Completed = "Completed"
     Deleting = "Deleting"
     Restarting = "Restarting"
+    Archived = "Archived"
     Unknown = ""
 
 
@@ -48,7 +49,7 @@ class LeptonJobStatusDetails(BaseModel):
     """
 
     job_name: Optional[str] = None
-    state: LeptonJobState
+    state: str
     ready: int
     active: int
     failed: int


### PR DESCRIPTION
Backend introduced new 'stopping' and 'stopped' states, causing a crash on deployment list. 

Quick fix by adding the new states and decoupling them from the enum class. 

Tao will add a new field for this change, and we will follow up accordingly
 
Will also add an end-to-end test for this case.