### PR TITLE
fix: handling for streaming responses in leptonai.client.py._generator

### DIFF
--- a/leptonai/client.py
+++ b/leptonai/client.py
@@ -469,6 +469,9 @@ class Client(object):
         if not res.is_error:
             return
 
+        if res.stream:
+            res.read()
+
         try:
             detail = res.json()["error"]
         except Exception:


### PR DESCRIPTION
From ticket
```
File "/opt/lepton/venv/lib/python3.10/site-packages/leptonai/client.py", line
423, in _generator
self._raise_for_detailed_status(res)
File "/opt/lepton/venv/lib/python3.10/site-packages/leptonai/client.py", line
411, in _raise_for_detailed_status
detail = res.text
File "/opt/lepton/venv/lib/python3.10/site-packages/httpx/_models.py", line
574, in text
content = self.content
File "/opt/lepton/venv/lib/python3.10/site-packages/httpx/_models.py", line
568, in content
raise ResponseNotRead()
httpx.ResponseNotRead: Attempted to access streaming response content, without
having called `read()`.
```