### PR TITLE
fix: respx mock error and mps oom

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "contextlib2", # backports async support in nullcontext
     "exceptiongroup",
     "fastapi",
-    "httpx[http2]",
+    "httpx[http2]==0.28.0",
     "prometheus-fastapi-instrumentator",
     "rich",
     "typing-extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "contextlib2", # backports async support in nullcontext
     "exceptiongroup",
     "fastapi",
-    "httpx[http2]==0.28.0",
+    "httpx[http2]==0.27.2",
     "prometheus-fastapi-instrumentator",
     "rich",
     "typing-extensions",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ runtime = [
     "diffusers>=0.27.0",
     "sentence-transformers>=2.3.0",
     "torch",
-    "transformers",
+    "transformers==4.46.3",
 ]
 
 [build-system]


### PR DESCRIPTION
Fixed httpx version to 0.28.0 and transformers version to address CI errors. Refer to the error messages in the CI tests for ‘fix httpx to 0.28.0’ and ‘fix httpx to 0.27.2’ for more details.