### PR TITLE
fix: resolve daemon warnings for threading methods

### DIFF
--- a/leptonai/photon/tests/test_photon_should_not_override_init.py
+++ b/leptonai/photon/tests/test_photon_should_not_override_init.py
@@ -45,7 +45,7 @@ class TestPhotonShouldNotOverrideInit(unittest.TestCase):
             ph.launch()
 
         t = threading.Thread(target=self._test_init_should_work)
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
         time.sleep(0.1)
         self.assertIsNone(self.e)


### PR DESCRIPTION
# PR Summary
This small PR resolves the `threading` deprecation warnings:
```python
/runner/_work/leptonai/leptonai/leptonai/photon/tests/test_photon_should_not_override_init.py:48: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
```