### PR TITLE
JSON spec mounts and envs being ignored in `lep endpoint create --file`

### DIFF
--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -874,19 +874,19 @@ def create(
                     f" set the secret, and specify it with --secret {k}. Otherwise,"
                     " the deployment may fail."
                 )
-        
+
         # Fix: Only override mounts and envs if CLI arguments were provided
         # If no CLI arguments for env/mount are given and we loaded from file, preserve existing values
         if env_list or secret_list or not file:
             # CLI args provided or no file loaded - use CLI args
             spec.envs = make_env_vars_from_strings(env_list, secret_list)
         # else: preserve existing spec.envs from loaded file
-        
+
         if mount_list or not file:
             # CLI args provided or no file loaded - use CLI args
             spec.mounts = make_mounts_from_strings(mount_list)
         # else: preserve existing spec.mounts from loaded file
-        
+
         spec.api_tokens = make_token_vars_from_config(public, tokens)
         spec.image_pull_secrets = list(image_pull_secrets)
         spec.auto_scaler = AutoScaler(

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -874,8 +874,19 @@ def create(
                     f" set the secret, and specify it with --secret {k}. Otherwise,"
                     " the deployment may fail."
                 )
-        spec.envs = make_env_vars_from_strings(env_list, secret_list)
-        spec.mounts = make_mounts_from_strings(mount_list)
+        
+        # Fix: Only override mounts and envs if CLI arguments were provided
+        # If no CLI arguments for env/mount are given and we loaded from file, preserve existing values
+        if env_list or secret_list or not file:
+            # CLI args provided or no file loaded - use CLI args
+            spec.envs = make_env_vars_from_strings(env_list, secret_list)
+        # else: preserve existing spec.envs from loaded file
+        
+        if mount_list or not file:
+            # CLI args provided or no file loaded - use CLI args
+            spec.mounts = make_mounts_from_strings(mount_list)
+        # else: preserve existing spec.mounts from loaded file
+        
         spec.api_tokens = make_token_vars_from_config(public, tokens)
         spec.image_pull_secrets = list(image_pull_secrets)
         spec.auto_scaler = AutoScaler(

--- a/leptonai/cli/job.py
+++ b/leptonai/cli/job.py
@@ -88,8 +88,8 @@ def _display_jobs_table(jobs: List[LeptonJob], workspace_id: str):
     # Print worker count per resource shape
     num_jobs = len(jobs)
     console.print(
-        f"[bold]Resource Utilization Summary for above [cyan]{num_jobs}[/] job{'s' if num_jobs!=1 else ''} "
-        "(Running / Restarting / Deleting only):[/]"
+        f"[bold]Resource Utilization Summary for above [cyan]{num_jobs}[/]"
+        f" job{'s' if num_jobs!=1 else ''} (Running / Restarting / Deleting only):[/]"
     )
     for shape, count in sorted(shape_totals.items()):
         console.print(f"  [bright_black]{shape}[/] : [bold cyan]{count}[/]")


### PR DESCRIPTION
When creating endpoints using `lep endpoint create --file spec.json`, the `mounts` and `envs` arrays defined in the JSON spec file were being completely ignored, resulting in endpoints with `"mounts": null` and `"envs": null` even when properly configured in the input file.

In `leptonai/cli/deployment.py`, the code was **unconditionally overwriting** `spec.envs` and `spec.mounts` with values derived from CLI arguments, regardless of whether CLI arguments were provided:

```python
#  Always overwrites spec values, ignoring JSON file content
spec.envs = make_env_vars_from_strings(env_list, secret_list)
spec.mounts = make_mounts_from_strings(mount_list)
```

Modified the logic to only override spec values when CLI arguments are actually provided:

## Testing

### Before fix:
```bash
lep endpoint create --file spec.json --name test
# Result: "mounts": null, "envs": null
```

### After fix:
```bash
lep endpoint create --file spec.json --name test
# Result: "mounts": [...], "envs": [...] (preserved from JSON)
```