### PR TITLE
fix: conditionally override deployment config tokens and secrets

### DIFF
--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -946,8 +946,12 @@ def create(
             spec.mounts = make_mounts_from_strings(mount_list)
         # else: preserve existing spec.mounts from loaded file
 
-        spec.api_tokens = make_token_vars_from_config(public, tokens)
-        spec.image_pull_secrets = list(image_pull_secrets)
+        if tokens or not file:
+            spec.api_tokens = make_token_vars_from_config(public, tokens)
+
+        if image_pull_secrets or not file:
+            # CLI args provided or no file loaded - use CLI args
+            spec.image_pull_secrets = list(image_pull_secrets)
         # Only overwrite auto_scaler if user provided any autoscale-related flag/arg
         if any([
             no_traffic_timeout is not None,


### PR DESCRIPTION
Only set `api_tokens` and `image_pull_secrets` when CLI arguments are provided or when no config file is loaded, preserving existing values from loaded files