### PR TITLE
fix: clarify reserved-name error 

### DIFF
--- a/leptonai/cli/secret.py
+++ b/leptonai/cli/secret.py
@@ -48,7 +48,7 @@ def create(name, value):
         check(
             n not in LEPTON_RESERVED_ENV_NAMES,
             "You have used a reserved secret name that is "
-            "used by Lepton internally: {k}. Please use a different name. "
+            f"used by Lepton internally: {n}. Please use a different name. "
             "Here is a list of all reserved environment variable names:\n"
             f"{LEPTON_RESERVED_ENV_NAMES}",
         )


### PR DESCRIPTION
fix(cli/secret): clarify reserved-name error when creating a secret with a reserved name

- Use f-string with the actual offending name to avoid showing a stale placeholder