### PR TITLE
fix: preserve health configuration from spec files instead of overwriting

### DIFF
--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -1067,13 +1067,15 @@ def create(
                 ),
             )
 
-        spec.health = HealthCheck(
-            liveness=(
-                HealthCheckLiveness(initial_delay_seconds=initial_delay_seconds)
-                if initial_delay_seconds
-                else None
+        # Only override health if CLI argument was provided
+        if initial_delay_seconds is not None:
+            spec.health = HealthCheck(
+                liveness=(
+                    HealthCheckLiveness(initial_delay_seconds=initial_delay_seconds)
+                    if initial_delay_seconds
+                    else None
+                )
             )
-        )
 
         if log_collection is not None:
             spec.log = LeptonLog(enable_collection=log_collection)


### PR DESCRIPTION
## Problem
health configuration from JSON spec files was being unconditionally overwritten by CLI defaults, causing custom health check settings (like 
initial_delay_seconds) to be ignored.

## Root Cause
The CLI code was hardcoded to always set `spec.health` regardless of whether a 
JSON file was loaded or not. This meant that even when users provided a complete 
deployment specification via `--file` parameter, their health configuration was 
being discarded and replaced with CLI defaults.
