### PR TITLE
fix: update deployment autoscaler behavior to handle None values

### DIFF
--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -1640,29 +1640,29 @@ def update(
         min_replicas = replicas
         max_replicas = replicas
         no_traffic_timeout = timeout
-        target_gpu_utilization = 0
-        threshold = 0
+        target_gpu_utilization = None
+        threshold = None
 
     if autoscale_gpu_util:
         parts = autoscale_gpu_util.split(",")
         min_replicas = int(parts[0])
         max_replicas = int(parts[1])
         target_gpu_utilization = int(parts[2].rstrip("%"))
-        no_traffic_timeout = 0
-        threshold = 0
+        no_traffic_timeout = None
+        threshold = None
 
     if autoscale_qpm:
         parts = autoscale_qpm.split(",")
         min_replicas = int(parts[0])
         max_replicas = int(parts[1])
         threshold = float(parts[2])
-        no_traffic_timeout = 0
-        target_gpu_utilization = 0
+        no_traffic_timeout = None
+        target_gpu_utilization = None
 
     autoscaler_flag = (
-        no_traffic_timeout is not None
-        or autoscale_gpu_util is not None
-        or threshold is not None
+        (no_traffic_timeout is not None)
+        or (autoscale_gpu_util is not None)
+        or (threshold is not None)
     )
 
     lepton_deployment_spec = LeptonDeploymentUserSpec(

--- a/leptonai/cli/tests/test_deployment_cli.py
+++ b/leptonai/cli/tests/test_deployment_cli.py
@@ -6,12 +6,18 @@ tmpdir = tempfile.mkdtemp()
 os.environ["LEPTON_CACHE_DIR"] = tmpdir
 
 import unittest
+from unittest.mock import patch
 
 from click.testing import CliRunner
 from loguru import logger
 
 from leptonai import config
 from leptonai.cli import lep as cli
+from leptonai.api.v1.types.common import Metadata
+from leptonai.api.v1.types.deployment import (
+    LeptonDeployment,
+    LeptonDeploymentUserSpec,
+)
 
 
 logger.info(f"Using cache dir: {config.CACHE_DIR}")
@@ -25,6 +31,86 @@ class TestDeploymentCliLocal(unittest.TestCase):
         result = runner.invoke(cli, ["deployment", "list"])
         self.assertNotEqual(result.exit_code, 0)
         # self.assertIn("It seems that you are not logged in", result.output)
+
+    def test_update_without_autoscale_flags_includes_autoscaler_payload(self):
+        runner = CliRunner()
+
+        class FakeDeploymentAPI:
+            def __init__(self):
+                self.last_spec = None
+
+            def get(self, name):
+                # Return minimal valid deployment object for update flow
+                return LeptonDeployment(
+                    metadata=Metadata(id=name, name=name),
+                    spec=LeptonDeploymentUserSpec(),
+                )
+
+            def update(self, name_or_deployment, spec, dryrun=False):
+                # Capture the full LeptonDeployment sent by CLI
+                self.last_spec = spec
+                # Echo back a LeptonDeployment-like object
+                return spec
+
+        class FakeAPIClient:
+            def __init__(self, *args, **kwargs):
+                self.deployment = FakeDeploymentAPI()
+
+        with patch("leptonai.cli.deployment.APIClient", new=lambda *a, **k: FakeAPIClient()):
+            # Act: run update without any autoscaling-related flags
+            result = runner.invoke(
+                cli,
+                [
+                    "endpoint",
+                    "update",
+                    "-n",
+                    "unit-test-ep",
+                    "--shared-memory-size",
+                    "128",
+                ],
+            )
+
+            # Assert CLI completed (Fake client prevents network/login)
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        # Re-run with grab-able instance
+        captured = {"last": None}
+
+        class GrabbableAPIClient:
+            def __init__(self, *args, **kwargs):
+                self.deployment = FakeDeploymentAPI()
+                captured["last"] = self.deployment
+
+        with patch("leptonai.cli.deployment.APIClient", new=lambda *a, **k: GrabbableAPIClient()):
+            result = runner.invoke(
+                cli,
+                [
+                    "endpoint",
+                    "update",
+                    "-n",
+                    "unit-test-ep",
+                    "--shared-memory-size",
+                    "128",
+                ],
+            )
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+
+            sent_spec = captured["last"].last_spec  # type: ignore
+            self.assertIsNotNone(sent_spec)
+            # sent_spec is a LeptonDeployment instance
+            self.assertIsNotNone(sent_spec.spec)
+
+            # Core assertion: autoscaler was included (due to current 0-default behavior)
+            self.assertIsNotNone(
+                sent_spec.spec.auto_scaler,
+                msg=f"Expected auto_scaler to be set, payload: {sent_spec.model_dump()}",
+            )
+
+            # Optionally assert scale_down.no_traffic_timeout was explicitly set to 0
+            if sent_spec.spec.auto_scaler and sent_spec.spec.auto_scaler.scale_down:
+                self.assertEqual(
+                    sent_spec.spec.auto_scaler.scale_down.no_traffic_timeout, 0
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Changed default values for target_gpu_utilization, threshold, and no_traffic_timeout to None when autoscale flags are not set.