### PR TITLE
fix: tighten autoscaler flag detection

### DIFF
--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -1660,9 +1660,9 @@ def update(
         target_gpu_utilization = 0
 
     autoscaler_flag = (
-        no_traffic_timeout is not None
-        or autoscale_gpu_util is not None
-        or threshold is not None
+        (no_traffic_timeout > 0)
+        or (target_gpu_utilization > 0)
+        or (threshold > 0)
     )
 
     lepton_deployment_spec = LeptonDeploymentUserSpec(

--- a/leptonai/cli/tests/test_deployment_cli.py
+++ b/leptonai/cli/tests/test_deployment_cli.py
@@ -6,12 +6,18 @@ tmpdir = tempfile.mkdtemp()
 os.environ["LEPTON_CACHE_DIR"] = tmpdir
 
 import unittest
+from unittest.mock import patch
 
 from click.testing import CliRunner
 from loguru import logger
 
 from leptonai import config
 from leptonai.cli import lep as cli
+from leptonai.api.v1.types.common import Metadata
+from leptonai.api.v1.types.deployment import (
+    LeptonDeployment,
+    LeptonDeploymentUserSpec,
+)
 
 
 logger.info(f"Using cache dir: {config.CACHE_DIR}")
@@ -25,6 +31,80 @@ class TestDeploymentCliLocal(unittest.TestCase):
         result = runner.invoke(cli, ["deployment", "list"])
         self.assertNotEqual(result.exit_code, 0)
         # self.assertIn("It seems that you are not logged in", result.output)
+
+    def test_update_without_autoscale_flags_excludes_autoscaler_payload(self):
+        runner = CliRunner()
+
+        class FakeDeploymentAPI:
+            def __init__(self):
+                self.last_spec = None
+
+            def get(self, name):
+                # Return minimal valid deployment object for update flow
+                return LeptonDeployment(
+                    metadata=Metadata(id=name, name=name),
+                    spec=LeptonDeploymentUserSpec(),
+                )
+
+            def update(self, name_or_deployment, spec, dryrun=False):
+                # Capture the full LeptonDeployment sent by CLI
+                self.last_spec = spec
+                # Echo back a LeptonDeployment-like object
+                return spec
+
+        class FakeAPIClient:
+            def __init__(self, *args, **kwargs):
+                self.deployment = FakeDeploymentAPI()
+
+        with patch("leptonai.cli.deployment.APIClient", new=lambda *a, **k: FakeAPIClient()):
+            # Act: run update without any autoscaling-related flags
+            result = runner.invoke(
+                cli,
+                [
+                    "endpoint",
+                    "update",
+                    "-n",
+                    "unit-test-ep",
+                    "--shared-memory-size",
+                    "128",
+                ],
+            )
+
+            # Assert CLI completed (Fake client prevents network/login)
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        # Re-run with grab-able instance
+        captured = {"last": None}
+
+        class GrabbableAPIClient:
+            def __init__(self, *args, **kwargs):
+                self.deployment = FakeDeploymentAPI()
+                captured["last"] = self.deployment
+
+        with patch("leptonai.cli.deployment.APIClient", new=lambda *a, **k: GrabbableAPIClient()):
+            result = runner.invoke(
+                cli,
+                [
+                    "endpoint",
+                    "update",
+                    "-n",
+                    "unit-test-ep",
+                    "--shared-memory-size",
+                    "128",
+                ],
+            )
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+
+            sent_spec = captured["last"].last_spec  # type: ignore
+            self.assertIsNotNone(sent_spec)
+            # sent_spec is a LeptonDeployment instance
+            self.assertIsNotNone(sent_spec.spec)
+
+            # Core assertion: without autoscale-related flags, autoscaler should not be sent
+            self.assertIsNone(
+                sent_spec.spec.auto_scaler,
+                msg=f"Did not expect auto_scaler to be set, payload: {sent_spec.model_dump()}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Only enable autoscaler when flags are > 0
- Replace is not None with > 0 so default 0 isn’t treated as “set,” preventing unintended autoscaler activation and payloads