### PR TITLE
feat: add support for ip whitelists for endpoints

### DIFF
--- a/example_usage.md
+++ b/example_usage.md
@@ -1,0 +1,195 @@
+# IP Whitelist Usage Examples
+
+## Clean Separation of Concerns
+
+The IP whitelist functionality now correctly follows this clean design:
+- **IP Access Control**: `--public` vs `--ip-whitelist` (network/ingress level)
+- **Authentication**: `--tokens` (application level, completely independent)
+
+## Key Design Principles
+
+1. **`--public`**: Endpoint accessible from any IP address (equivalent to `--ip-whitelist` with empty array)
+2. **`--ip-whitelist`**: Endpoint only accessible from specified IP addresses/CIDR ranges
+3. **`--tokens`**: Authentication tokens required (completely independent of IP access control)
+4. **Mutual Exclusivity**: `--public` and `--ip-whitelist` cannot be used together
+
+## Valid Usage Examples
+
+### 1. Public Endpoint (Accessible from any IP, no authentication tokens)
+```bash
+lep endpoint create \
+  --name public-endpoint \
+  --resource-shape cpu.tiny \
+  --container-image python:3.9-slim \
+  --container-port 8080 \
+  --container-command 'python3 -m http.server 8080' \
+  --public
+```
+
+### 2. Public Endpoint with Authentication Tokens
+```bash
+lep endpoint create \
+  --name public-endpoint-with-auth \
+  --resource-shape cpu.tiny \
+  --container-image python:3.9-slim \
+  --container-port 8080 \
+  --container-command 'python3 -m http.server 8080' \
+  --public \
+  --tokens my-token-1 \
+  --tokens my-token-2
+```
+
+### 3. IP-Whitelisted Endpoint (Default: workspace token required)
+```bash
+lep endpoint create \
+  --name ip-restricted-endpoint \
+  --resource-shape cpu.tiny \
+  --container-image python:3.9-slim \
+  --container-port 8080 \
+  --container-command 'python3 -m http.server 8080' \
+  --ip-whitelist 128.77.86.0/24 \
+  --ip-whitelist 192.168.1.0/24
+```
+
+### 4. IP-Whitelisted Endpoint with Comma-Separated Values
+```bash
+lep endpoint create \
+  --name ip-restricted-endpoint-comma \
+  --resource-shape cpu.tiny \
+  --container-image python:3.9-slim \
+  --container-port 8080 \
+  --container-command 'python3 -m http.server 8080' \
+  --ip-whitelist "128.77.86.0/24,192.168.1.0/24,10.0.0.0/8"
+```
+
+### 5. IP-Whitelisted Endpoint with Authentication Tokens
+```bash
+lep endpoint create \
+  --name ip-restricted-endpoint-with-auth \
+  --resource-shape cpu.tiny \
+  --container-image python:3.9-slim \
+  --container-port 8080 \
+  --container-command 'python3 -m http.server 8080' \
+  --ip-whitelist "128.77.86.0/24,10.0.0.0/8" \
+  --tokens my-token-1 \
+  --tokens my-token-2
+```
+
+### 6. Private Endpoint (Default: workspace token required, no IP restrictions)
+```bash
+lep endpoint create \
+  --name private-endpoint \
+  --resource-shape cpu.tiny \
+  --container-image python:3.9-slim \
+  --container-port 8080 \
+  --container-command 'python3 -m http.server 8080'
+  # No --public or --ip-whitelist specified
+```
+
+### 7. Private Endpoint with Additional Authentication Tokens
+```bash
+lep endpoint create \
+  --name private-endpoint-with-auth \
+  --resource-shape cpu.tiny \
+  --container-image python:3.9-slim \
+  --container-port 8080 \
+  --container-command 'python3 -m http.server 8080' \
+  --tokens my-token-1 \
+  --tokens my-token-2
+```
+
+## Invalid Usage (Will Show Error)
+
+### ❌ Cannot use both --public and --ip-whitelist
+```bash
+lep endpoint create \
+  --name invalid-endpoint \
+  --resource-shape cpu.tiny \
+  --container-image python:3.9-slim \
+  --container-port 8080 \
+  --container-command 'python3 -m http.server 8080' \
+  --public \
+  --ip-whitelist 192.168.1.0/24  # This will cause an error
+```
+
+## IP Whitelist Usage Patterns
+
+The `--ip-whitelist` option supports two usage patterns:
+
+### Pattern 1: Individual Values
+```bash
+--ip-whitelist 192.168.1.0/24 --ip-whitelist 10.0.0.0/8
+```
+
+### Pattern 2: Comma-Separated Values
+```bash
+--ip-whitelist "192.168.1.0/24,10.0.0.0/8,172.16.0.0/12"
+```
+
+### Pattern 3: Mixed Usage
+```bash
+--ip-whitelist "192.168.1.0/24,10.0.0.0/8" --ip-whitelist 172.16.0.0/12
+```
+
+## Generated JSON Structure
+
+### Public Endpoint (no IP restrictions)
+```json
+{
+  "spec": {
+    "auth_config": {
+      "ip_allowlist": []
+    },
+    "api_tokens": []
+  }
+}
+```
+
+### IP-Whitelisted Endpoint
+```json
+{
+  "spec": {
+    "auth_config": {
+      "ip_allowlist": ["128.77.86.0/24", "192.168.1.0/24", "10.0.0.0/8"]
+    },
+    "api_tokens": [
+      {
+        "value_from": {
+          "token_name_ref": "WORKSPACE_TOKEN"
+        }
+      },
+      {
+        "value": "my-token-1"
+      },
+      {
+        "value": "my-token-2"
+      }
+    ]
+  }
+}
+```
+
+### Private Endpoint (default)
+```json
+{
+  "spec": {
+    "api_tokens": [
+      {
+        "value_from": {
+          "token_name_ref": "WORKSPACE_TOKEN"
+        }
+      }
+    ]
+  }
+}
+```
+
+## Key Points
+
+1. **Clean Separation**: IP access control and authentication are completely independent
+2. **IP Access Control**: Choose either `--public` OR `--ip-whitelist`, not both
+3. **Authentication**: `--tokens` can be used with any IP access control method
+4. **Default Behavior**: If neither `--public` nor `--ip-whitelist` is specified, the endpoint is private (no IP restrictions)
+5. **IP Whitelist**: Stored in `auth_config.ip_allowlist` field
+6. **Workspace Token**: Always included for non-public endpoints to maintain internal access
+7. **Flexible Input**: IP whitelist accepts both individual values and comma-separated lists 

--- a/leptonai/api/v1/deployment.py
+++ b/leptonai/api/v1/deployment.py
@@ -10,28 +10,23 @@ from .types.replica import Replica
 
 
 def make_token_vars_from_config(
-    is_public: Optional[bool], tokens: Optional[List[str]]
+    is_public: Optional[bool], 
+    tokens: Optional[List[str]]
 ) -> Optional[List[TokenVar]]:
     # Note that None is different from [] here. None means that the tokens are not
-    # changed, while [] means that the tokens are cleared (aka, public deployment)
-    if is_public is None and tokens is None:
+    # changed, while [] means that the tokens are cleared (aka, no tokens)
+    
+    # If no changes to tokens are requested, return None (no change)
+    if tokens is None:
         return None
-    elif is_public and tokens:
-        raise ValueError(
-            "For access control, you cannot specify both is_public and token at the"
-            " same time. Please specify either is_public=True with no tokens passed"
-            " in, or is_public=False and tokens as a list."
-        )
-    else:
-        if is_public:
-            return []
-        else:
-            final_tokens = [
-                TokenVar(value_from=TokenValue(token_name_ref="WORKSPACE_TOKEN"))
-            ]
-            if tokens:
-                final_tokens.extend([TokenVar(value=token) for token in tokens])
-            return final_tokens
+    
+    # Build token list: always include workspace token, plus any additional tokens
+    final_tokens = [
+        TokenVar(value_from=TokenValue(token_name_ref="WORKSPACE_TOKEN"))
+    ]
+    if tokens:
+        final_tokens.extend([TokenVar(value=token) for token in tokens])
+    return final_tokens
 
 
 class DeploymentAPI(APIResourse):

--- a/leptonai/api/v1/deployment.py
+++ b/leptonai/api/v1/deployment.py
@@ -10,20 +10,17 @@ from .types.replica import Replica
 
 
 def make_token_vars_from_config(
-    is_public: Optional[bool], 
-    tokens: Optional[List[str]]
+    is_public: Optional[bool], tokens: Optional[List[str]]
 ) -> Optional[List[TokenVar]]:
     # Note that None is different from [] here. None means that the tokens are not
     # changed, while [] means that the tokens are cleared (aka, no tokens)
-    
+
     # If no changes to tokens are requested, return None (no change)
     if tokens is None:
         return None
-    
+
     # Build token list: always include workspace token, plus any additional tokens
-    final_tokens = [
-        TokenVar(value_from=TokenValue(token_name_ref="WORKSPACE_TOKEN"))
-    ]
+    final_tokens = [TokenVar(value_from=TokenValue(token_name_ref="WORKSPACE_TOKEN"))]
     if tokens:
         final_tokens.extend([TokenVar(value=token) for token in tokens])
     return final_tokens

--- a/leptonai/api/v1/types/auth.py
+++ b/leptonai/api/v1/types/auth.py
@@ -1,0 +1,11 @@
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class LeptonWorkspaceTokenAuth(BaseModel):
+    remove_authorization_header: Optional[bool] = None
+
+
+class AuthConfig(BaseModel):
+    lepton_workspace_token_auth: Optional[LeptonWorkspaceTokenAuth] = None
+    ip_allowlist: Optional[List[str]] = None

--- a/leptonai/api/v1/types/deployment.py
+++ b/leptonai/api/v1/types/deployment.py
@@ -7,7 +7,7 @@ from leptonai.config import compatible_field_validator, v2only_field_validator
 
 from .affinity import LeptonResourceAffinity
 from .common import Metadata
-from ..api.v1.types.ingress import AuthConfig
+from ..ingress import AuthConfig
 
 DEFAULT_STORAGE_VOLUME_NAME = "default"
 

--- a/leptonai/api/v1/types/deployment.py
+++ b/leptonai/api/v1/types/deployment.py
@@ -7,7 +7,7 @@ from leptonai.config import compatible_field_validator, v2only_field_validator
 
 from .affinity import LeptonResourceAffinity
 from .common import Metadata
-from ..ingress import AuthConfig
+from .auth import AuthConfig
 
 DEFAULT_STORAGE_VOLUME_NAME = "default"
 

--- a/leptonai/api/v1/types/deployment.py
+++ b/leptonai/api/v1/types/deployment.py
@@ -7,6 +7,7 @@ from leptonai.config import compatible_field_validator, v2only_field_validator
 
 from .affinity import LeptonResourceAffinity
 from .common import Metadata
+from ..api.v1.types.ingress import AuthConfig
 
 DEFAULT_STORAGE_VOLUME_NAME = "default"
 
@@ -287,6 +288,7 @@ class LeptonDeploymentUserSpec(BaseModel):
     log: Optional[LeptonLog] = None
     queue_config: Optional[QueueConfig] = None
     scheduling_policy: Optional[DeploymentSchedulingPolicy] = None
+    auth_config: Optional[AuthConfig] = None
 
 
 class LeptonDeploymentState(str, Enum):

--- a/leptonai/api/v1/types/ingress.py
+++ b/leptonai/api/v1/types/ingress.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from typing import Optional, List
 
 from .common import Metadata
+from .auth import AuthConfig
 
 
 class LeastRequestLoadBalancer(BaseModel):
@@ -25,15 +26,6 @@ class WorkspaceTierRateLimiter(BaseModel):
 
 class RateLimitConfig(BaseModel):
     workspace_tier_ratelimiter: Optional[WorkspaceTierRateLimiter] = None
-
-
-class LeptonWorkspaceTokenAuth(BaseModel):
-    remove_authorization_header: Optional[bool] = None
-
-
-class AuthConfig(BaseModel):
-    lepton_workspace_token_auth: Optional[LeptonWorkspaceTokenAuth] = None
-    ip_allowlist: Optional[List[str]] = None
 
 
 class LeptonIngressLocality(BaseModel):

--- a/leptonai/api/v1/types/ingress.py
+++ b/leptonai/api/v1/types/ingress.py
@@ -33,6 +33,7 @@ class LeptonWorkspaceTokenAuth(BaseModel):
 
 class AuthConfig(BaseModel):
     lepton_workspace_token_auth: Optional[LeptonWorkspaceTokenAuth] = None
+    ip_allowlist: Optional[List[str]] = None
 
 
 class LeptonIngressLocality(BaseModel):

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -45,6 +45,7 @@ from ..api.v1.types.deployment import (
     SchedulingToggle,
 )
 from ..api.v1.types.photon import PhotonDeploymentTemplate
+from ..api.v1.types.ingress import AuthConfig
 
 
 def _same_major_version(version_str_list: List[str]) -> bool:
@@ -226,15 +227,39 @@ def is_positive_number(value):
 def _normalize_replica_spread(ctx, param, value):
     if value is None:
         return None
-    v = value.strip().lower()
-    if v in ("required", "r"):
+    if value.lower() in ["required", "r"]:
         return "required"
-    if v in ("preferred", "p"):
+    elif value.lower() in ["preferred", "p"]:
         return "preferred"
-    raise click.BadParameter(
-        "Invalid value for --replica-spread. Accepts: required|preferred or shorthand"
-        " r|p."
-    )
+    else:
+        raise click.BadParameter(
+            f"Invalid replica spread value: {value}. "
+            "Use 'required'/'r' or 'preferred'/'p'."
+        )
+
+
+def _parse_ip_whitelist(ip_whitelist_values):
+    """
+    Parse IP whitelist values, handling both comma-separated and individual values.
+    
+    Args:
+        ip_whitelist_values: List of strings, each potentially containing comma-separated IPs
+        
+    Returns:
+        List of individual IP addresses/CIDR ranges
+    """
+    if not ip_whitelist_values:
+        return []
+    
+    parsed_ips = []
+    for value in ip_whitelist_values:
+        # Split by comma and strip whitespace
+        ips = [ip.strip() for ip in value.split(',')]
+        # Filter out empty strings
+        ips = [ip for ip in ips if ip]
+        parsed_ips.extend(ips)
+    
+    return parsed_ips
 
 
 @click_group(hidden=True)
@@ -523,15 +548,30 @@ def _create_workspace_token_secret_var_if_not_existing(client: APIClient):
     "--public",
     is_flag=True,
     help=(
-        "If specified, the photon will be publicly accessible. See docs for details "
-        "on access control."
+        "If specified, the endpoint will be accessible from any IP address. "
+        "This is equivalent to --ip-whitelist with an empty list. "
+        "Mutually exclusive with --ip-whitelist."
     ),
+)
+@click.option(
+    "--ip-whitelist",
+    help=(
+        "IP addresses or CIDR ranges that are allowed to access the endpoint. "
+        "Can be specified multiple times or as comma-separated values. "
+        "Examples: --ip-whitelist 192.168.1.1,10.0.0.0/8 or "
+        "--ip-whitelist 192.168.1.1 --ip-whitelist 10.0.0.0/8. "
+        "Mutually exclusive with --public. This sets the IP allowlist in the "
+        "deployment's authentication configuration. "
+        "Note: --tokens are completely independent of IP access control."
+    ),
+    multiple=True,
 )
 @click.option(
     "--tokens",
     help=(
-        "Additional tokens that can be used to access the photon. See docs for details "
-        "on access control."
+        "Additional tokens that can be used to access the endpoint. See docs for details "
+        "on access control. These are completely independent of IP access control "
+        "(--public and --ip-whitelist)."
     ),
     multiple=True,
 )
@@ -790,6 +830,7 @@ def create(
     env,
     secret,
     public,
+    ip_whitelist,
     tokens,
     no_traffic_timeout,
     target_gpu_utilization,
@@ -818,6 +859,15 @@ def create(
     Creates an endpoint from either a photon or container image.
     """
     client = APIClient()
+
+    # Validate that public and ip-whitelist are mutually exclusive
+    if public and ip_whitelist:
+        console.print(
+            "[red]Error[/]: Cannot specify both --public and --ip-whitelist. "
+            "Use --public for public access or --ip-whitelist for restricted access. "
+            "Note that --tokens can be used with either option."
+        )
+        sys.exit(1)
 
     # Load spec from file if provided
     if file:
@@ -1084,6 +1134,19 @@ def create(
         if tokens or not file:
             spec.api_tokens = make_token_vars_from_config(public, tokens)
 
+        # Set IP access control in auth_config (independent of tokens)
+        if public or ip_whitelist:
+            if spec.auth_config is None:
+                spec.auth_config = AuthConfig()
+            
+            if public:
+                # Public means accessible from any IP (no IP restrictions)
+                spec.auth_config.ip_allowlist = []
+            elif ip_whitelist:
+                # IP whitelist means only accessible from specified IPs
+                parsed_ips = _parse_ip_whitelist(ip_whitelist)
+                spec.auth_config.ip_allowlist = parsed_ips
+
         if image_pull_secrets or not file:
             spec.image_pull_secrets = list(image_pull_secrets)
         # Only overwrite auto_scaler if user provided any autoscale-related flag/arg
@@ -1122,6 +1185,8 @@ def create(
 
         if log_collection is not None:
             spec.log = LeptonLog(enable_collection=log_collection)
+
+
 
     except ValueError as e:
         console.print(
@@ -1435,6 +1500,18 @@ def log(name, replica):
     ),
 )
 @click.option(
+    "--ip-whitelist",
+    help=(
+        "IP addresses or CIDR ranges that are allowed to access the endpoint. "
+        "Can be specified multiple times or as comma-separated values. "
+        "Examples: --ip-whitelist 192.168.1.1,10.0.0.0/8 or "
+        "--ip-whitelist 192.168.1.1 --ip-whitelist 10.0.0.0/8. "
+        "Mutually exclusive with --public. This sets the IP allowlist in the "
+        "deployment's authentication configuration."
+    ),
+    multiple=True,
+)
+@click.option(
     "--tokens",
     help=(
         "Access tokens that can be used to access the endpoint. See docs for"
@@ -1571,6 +1648,7 @@ def update(
     min_replicas,
     resource_shape,
     public,
+    ip_whitelist,
     tokens,
     remove_tokens,
     no_traffic_timeout,
@@ -1591,6 +1669,15 @@ def update(
 
     client = APIClient()
     lepton_deployment = client.deployment.get(name)
+
+    # Validate that public and ip-whitelist are mutually exclusive
+    if public and ip_whitelist:
+        console.print(
+            "[red]Error[/]: Cannot specify both --public and --ip-whitelist. "
+            "Use --public for public access or --ip-whitelist for restricted access. "
+            "Note that --tokens can be used with either option."
+        )
+        sys.exit(1)
 
     if id == "latest":
         current_photon_id = lepton_deployment.spec.photon_id
@@ -1712,6 +1799,20 @@ def update(
 
     if log_collection is not None:
         lepton_deployment_spec.log = LeptonLog(enable_collection=log_collection)
+
+    # Set IP access control in auth_config (independent of tokens)
+    if public is not None or ip_whitelist is not None:
+        if lepton_deployment_spec.auth_config is None:
+            lepton_deployment_spec.auth_config = AuthConfig()
+        
+        if public:
+            # Public means accessible from any IP (no IP restrictions)
+            lepton_deployment_spec.auth_config.ip_allowlist = []
+        elif ip_whitelist is not None:
+            # IP whitelist means only accessible from specified IPs
+            parsed_ips = _parse_ip_whitelist(ip_whitelist)
+            lepton_deployment_spec.auth_config.ip_allowlist = parsed_ips
+
     new_lepton_deployment = LeptonDeployment(
         metadata=Metadata(
             id=name,

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -241,24 +241,24 @@ def _normalize_replica_spread(ctx, param, value):
 def _parse_ip_whitelist(ip_whitelist_values):
     """
     Parse IP whitelist values, handling both comma-separated and individual values.
-    
+
     Args:
         ip_whitelist_values: List of strings, each potentially containing comma-separated IPs
-        
+
     Returns:
         List of individual IP addresses/CIDR ranges
     """
     if not ip_whitelist_values:
         return []
-    
+
     parsed_ips = []
     for value in ip_whitelist_values:
         # Split by comma and strip whitespace
-        ips = [ip.strip() for ip in value.split(',')]
+        ips = [ip.strip() for ip in value.split(",")]
         # Filter out empty strings
         ips = [ip for ip in ips if ip]
         parsed_ips.extend(ips)
-    
+
     return parsed_ips
 
 
@@ -569,9 +569,9 @@ def _create_workspace_token_secret_var_if_not_existing(client: APIClient):
 @click.option(
     "--tokens",
     help=(
-        "Additional tokens that can be used to access the endpoint. See docs for details "
-        "on access control. These are completely independent of IP access control "
-        "(--public and --ip-whitelist)."
+        "Additional tokens that can be used to access the endpoint. See docs for"
+        " details on access control. These are completely independent of IP access"
+        " control (--public and --ip-whitelist)."
     ),
     multiple=True,
 )
@@ -1138,7 +1138,7 @@ def create(
         if public or ip_whitelist:
             if spec.auth_config is None:
                 spec.auth_config = AuthConfig()
-            
+
             if public:
                 # Public means accessible from any IP (no IP restrictions)
                 spec.auth_config.ip_allowlist = []
@@ -1185,8 +1185,6 @@ def create(
 
         if log_collection is not None:
             spec.log = LeptonLog(enable_collection=log_collection)
-
-
 
     except ValueError as e:
         console.print(
@@ -1804,7 +1802,7 @@ def update(
     if public is not None or ip_whitelist is not None:
         if lepton_deployment_spec.auth_config is None:
             lepton_deployment_spec.auth_config = AuthConfig()
-        
+
         if public:
             # Public means accessible from any IP (no IP restrictions)
             lepton_deployment_spec.auth_config.ip_allowlist = []


### PR DESCRIPTION
backend MR: https://gitlab-master.nvidia.com/dgxc-lepton/lepton/-/merge_requests/189

UI MR: https://gitlab-master.nvidia.com/dgxc-lepton/lepton/-/merge_requests/321

public documentation: https://jirasw.nvidia.com/browse/LEP-2061

**Testing:**

Public
```
(.venv) dtzeng@dtzeng-mlt ~/workplace/leptonai % lep endpoint create \
--resource-shape gpu.h100-sxm \
--node-group heimdall-dev \
--autoscale-down 1,9999999 \
--container-image nvcr.io/nvidia/nemo:25.07 \
--container-port 8080 \
--container-command 'sleep infinity' \
--queue-priority 4 \
--public \
--log-collection true \
--name dtzeng-public1
/Volumes/workplace/leptonai/leptonai/api/v1/types/deployment.py:308: UserWarning: You might be using an out of date SDK. consider updating.
  warnings.warn("You might be using an out of date SDK. consider updating.")
/Volumes/workplace/leptonai/leptonai/api/v1/types/dedicated_node_group.py:16: UserWarning: You might be using an out of date SDK. consider updating.
  warnings.warn("You might be using an out of date SDK. consider updating.")
🎉 Endpoint Created Successfully!
Name: dtzeng-public1
Use `lep endpoint status -n dtzeng-public1` to check the status.
```

IP Whitelist
```
(.venv) dtzeng@dtzeng-mlt ~/workplace/leptonai % lep endpoint create \
--resource-shape gpu.h100-sxm \
--node-group heimdall-dev \
--autoscale-down 1,9999999 \
--container-image nvcr.io/nvidia/nemo:25.07 \
--container-port 8080 \
--container-command 'sleep infinity' \
--queue-priority 4 \
--ip-whitelist 216.228.125.0/24 \
--log-collection true \
--name dtzeng-whitelist1
/Volumes/workplace/leptonai/leptonai/api/v1/types/deployment.py:308: UserWarning: You might be using an out of date SDK. consider updating.
  warnings.warn("You might be using an out of date SDK. consider updating.")
/Volumes/workplace/leptonai/leptonai/api/v1/types/dedicated_node_group.py:16: UserWarning: You might be using an out of date SDK. consider updating.
  warnings.warn("You might be using an out of date SDK. consider updating.")
🎉 Endpoint Created Successfully!
Name: dtzeng-whitelist1
```

2 IP Whitelist
```
Use `lep endpoint status -n dtzeng-whitelist1` to check the status.
(.venv) dtzeng@dtzeng-mlt ~/workplace/leptonai % lep endpoint create \
--resource-shape gpu.h100-sxm \
--node-group heimdall-dev \
--autoscale-down 1,9999999 \
--container-image nvcr.io/nvidia/nemo:25.07 \
--container-port 8080 \
--container-command 'sleep infinity' \
--queue-priority 4 \
--ip-whitelist 216.228.125.0/24 \
--ip-whitelist 72.25.66.11 \
--log-collection true \
--name dtzeng-whitelist2
/Volumes/workplace/leptonai/leptonai/api/v1/types/deployment.py:308: UserWarning: You might be using an out of date SDK. consider updating.
  warnings.warn("You might be using an out of date SDK. consider updating.")
/Volumes/workplace/leptonai/leptonai/api/v1/types/dedicated_node_group.py:16: UserWarning: You might be using an out of date SDK. consider updating.
  warnings.warn("You might be using an out of date SDK. consider updating.")
🎉 Endpoint Created Successfully!
Name: dtzeng-whitelist2
Use `lep endpoint status -n dtzeng-whitelist2` to check the status.
```

Cannot give both public and ip whitelist
```
(.venv) dtzeng@dtzeng-mlt ~/workplace/leptonai % lep endpoint create \
--resource-shape gpu.h100-sxm \
--node-group heimdall-dev \
--autoscale-down 1,9999999 \
--container-image nvcr.io/nvidia/nemo:25.07 \
--container-port 8080 \
--container-command 'sleep infinity' \
--queue-priority 4 \
--public \
--ip-whitelist 216.228.125.0/24,72.25.66.11 \
--log-collection true \
--name dtzeng-should-fail
Error: Cannot specify both --public and --ip-whitelist. Use --public for public access or --ip-whitelist for restricted access. Note that --tokens can be used with either option.
```