### PR TITLE
refactor(api): bootstrap v2 (shallow re-exports)

### DIFF
--- a/leptonai/api/__init__.py
+++ b/leptonai/api/__init__.py
@@ -24,3 +24,4 @@ Lepton AI web APIs usually return two types of responses:
 
 from . import v0
 from . import v1
+from . import v2

--- a/leptonai/api/v0/__init__.py
+++ b/leptonai/api/v0/__init__.py
@@ -21,7 +21,7 @@ from . import workspace
 
 warnings.warn(
     "The v0 API is deprecated and will be removed in the next major version. Consider"
-    " using the v1 API for new code.",
+    " using the v2 API for new code.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/leptonai/api/v1/__init__.py
+++ b/leptonai/api/v1/__init__.py
@@ -5,3 +5,12 @@ Lepton API v1 is a cleaned up version of the API that interacts with the platfor
 
 from . import types
 from . import client
+
+import warnings as _warnings
+
+_warnings.warn(
+    "The v1 API is deprecated and will be removed in the next major version. Consider"
+    " using the v2 API for new code.",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/leptonai/api/v2/__init__.py
+++ b/leptonai/api/v2/__init__.py
@@ -1,0 +1,32 @@
+# flake8: noqa
+"""
+Bootstrap for API v2.
+
+This module provides a shallow re-export of v1 resources, so users can migrate to
+leptonai.api.v2 import paths without behavior changes. Modules that already have
+native v2 implementations should be imported from v2 directly and are not
+re-exported here.
+"""
+
+# Native v2 modules (keep as-is, do not re-export from v1)
+from .client import APIClient  # noqa: F401
+from .resource_shape import ResourceShapeAPI  # noqa: F401
+from .template import TemplateAPI  # noqa: F401
+from .dedicated_node_groups import DedicatedNodeGroupAPI  # noqa: F401
+from .utils import *  # noqa: F401,F403
+from .workspace_record import WorkspaceRecord  # noqa: F401
+
+# Shallow re-exports from v1 (until their native v2 versions are implemented)
+from ..v1.deployment import DeploymentAPI  # noqa: F401
+from ..v1.job import JobAPI  # noqa: F401
+from ..v1.secret import SecretAPI  # noqa: F401
+from ..v1.kv import KVAPI  # noqa: F401
+from ..v1.queue import QueueAPI  # noqa: F401
+from ..v1.pod import PodAPI  # noqa: F401
+from ..v1.ingress import IngressAPI  # noqa: F401
+from ..v1.storage import StorageAPI  # noqa: F401
+from ..v1.object_storage import ObjectStorageAPI  # noqa: F401
+from ..v1.log import LogAPI  # noqa: F401
+from ..v1.raycluster import RayClusterAPI  # noqa: F401
+
+# types remain in v1 for now; import selectively when needed in modules


### PR DESCRIPTION
refactor(api): bootstrap v2 (shallow re-exports), deprecate v1, point v0 to v2, expose v2 in api/__init__