### PR TITLE
Add UserSecurityContext to deployment types for devpods

### DIFF
--- a/leptonai/api/v1/types/deployment.py
+++ b/leptonai/api/v1/types/deployment.py
@@ -12,6 +12,14 @@ from .auth import AuthConfig
 DEFAULT_STORAGE_VOLUME_NAME = "default"
 
 
+class UserSecurityContext(BaseModel):
+    """
+    User security context controlling user privileges within the container.
+    """
+
+    privileged: Optional[bool] = None
+
+
 class ReservationConfig(BaseModel):
     reservation_id: Optional[str] = None
     allow_burst_to_other_reservations: Optional[bool] = None
@@ -295,6 +303,7 @@ class LeptonDeploymentUserSpec(BaseModel):
     queue_config: Optional[QueueConfig] = None
     scheduling_policy: Optional[DeploymentSchedulingPolicy] = None
     auth_config: Optional[AuthConfig] = None
+    user_security_context: Optional[UserSecurityContext] = None
 
 
 class LeptonDeploymentState(str, Enum):


### PR DESCRIPTION
- Add UserSecurityContext class with privileged field
- Add user_security_context field to LeptonDeploymentUserSpec
- Enables container privilege escalation configuration

Following in the spec: 
```
  "user_security_context": {
    "privileged": true
  }
```