### PR TITLE
docs: clarify --mount MOUNT_FROM format

### DIFF
--- a/leptonai/api/v1/photon.py
+++ b/leptonai/api/v1/photon.py
@@ -40,7 +40,9 @@ def make_mounts_from_strings(
         else:
             raise ValueError(
                 f"Invalid mount definition: {mount_str} (expected format:"
-                " STORAGE_PATH:MOUNT_PATH:MOUNT_FROM)"
+                " STORAGE_PATH:MOUNT_PATH:MOUNT_FROM, where MOUNT_FROM is"
+                " <type>:<storage_name> e.g. node-nfs:my-nfs, or node-local"
+                " for node-local storage)"
             )
     return mount_list
 

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -573,7 +573,10 @@ def _create_workspace_token_secret_var_if_not_existing(client: APIClient):
     "--mount",
     help=(
         "Persistent storage to be mounted to the endpoint, in the format"
-        " `STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`."
+        " `STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`, where `STORAGE_PATH` is the path"
+        " inside the volume, `MOUNT_PATH` is the container mount point, and"
+        " `MOUNT_FROM` is `<type>:<storage_name>` (e.g. `node-nfs:my-nfs`) or"
+        " `node-local` for node-local storage."
     ),
     multiple=True,
 )

--- a/leptonai/cli/finetune.py
+++ b/leptonai/cli/finetune.py
@@ -509,7 +509,10 @@ def list_trainers_command():
     multiple=True,
     help=(
         "[job] Persistent storage to be mounted to the job, in the format"
-        "`STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`."
+        " `STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`, where `STORAGE_PATH` is the path"
+        " inside the volume, `MOUNT_PATH` is the container mount point, and"
+        " `MOUNT_FROM` is `<type>:<storage_name>` (e.g. `node-nfs:my-nfs`) or"
+        " `node-local` for node-local storage."
     ),
 )
 @click.option(

--- a/leptonai/cli/job.py
+++ b/leptonai/cli/job.py
@@ -403,7 +403,10 @@ def job():
     "--mount",
     help=(
         "Persistent storage to be mounted to the job, in the format"
-        " `STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`."
+        " `STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`, where `STORAGE_PATH` is the path"
+        " inside the volume, `MOUNT_PATH` is the container mount point, and"
+        " `MOUNT_FROM` is `<type>:<storage_name>` (e.g. `node-nfs:my-nfs`) or"
+        " `node-local` for node-local storage."
     ),
     multiple=True,
 )

--- a/leptonai/cli/node.py
+++ b/leptonai/cli/node.py
@@ -453,7 +453,8 @@ def storage_command(node_group=None):
     console.print(
         "[dim]Note:[/dim] Mount syntax: "
         "`--mount STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`\n"
-        "[dim]Where `MOUNT_FROM` = `<type>:<storage_name>`.[/dim]"
+        "[dim]Where `MOUNT_FROM` = `<type>:<storage_name>` "
+        "(e.g. `node-nfs:my-nfs`), or `node-local` for node-local storage.[/dim]"
     )
 
 

--- a/leptonai/cli/pod.py
+++ b/leptonai/cli/pod.py
@@ -111,7 +111,10 @@ def pod():
     "--mount",
     help=(
         "Persistent storage to be mounted to the deployment, in the format"
-        " `STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`."
+        " `STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`, where `STORAGE_PATH` is the path"
+        " inside the volume, `MOUNT_PATH` is the container mount point, and"
+        " `MOUNT_FROM` is `<type>:<storage_name>` (e.g. `node-nfs:my-nfs`) or"
+        " `node-local` for node-local storage."
     ),
     multiple=True,
 )

--- a/leptonai/cli/raycluster.py
+++ b/leptonai/cli/raycluster.py
@@ -346,6 +346,8 @@ class WorkerGroupCommand(click.Command):
                     Repeatable or comma-separated. Inject secret as env var NAME from secret SECRET_NAME.
                 --mount STORAGE_PATH:MOUNT_PATH:MOUNT_FROM
                     Repeatable or comma-separated. Persistent storage mount specification.
+                    `MOUNT_FROM` is `<type>:<storage_name>` (e.g. `node-nfs:my-nfs`)
+                    or `node-local` for node-local storage.
             """).rstrip()
         return f"{base_help}\n\n{group_help}"
 
@@ -1144,7 +1146,10 @@ def list_command(name):
     "--head-mount",
     help=(
         "Persistent storage to be mounted to the head group, in the format "
-        "`STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`."
+        "`STORAGE_PATH:MOUNT_PATH:MOUNT_FROM`, where `STORAGE_PATH` is the path"
+        " inside the volume, `MOUNT_PATH` is the container mount point, and"
+        " `MOUNT_FROM` is `<type>:<storage_name>` (e.g. `node-nfs:my-nfs`) or"
+        " `node-local` for node-local storage."
     ),
     multiple=True,
 )


### PR DESCRIPTION
## Summary
- Clarify the `--mount` help text across all `lep` CLI commands so users know `MOUNT_FROM` is `<type>:<storage_name>` (e.g. `node-nfs:my-nfs`) or `node-local`, not a single token.
- Align the `ValueError` raised by `make_mounts_from_strings` with the same explanation, so a malformed `--mount` produces a self-explanatory error.

## Why
A customer reported (Jira LS-1087, Cosmos team) that `lep endpoint create --mount /hf-cache:/root/.cache/huggingface:node-nfs` failed with `drive does not exist`, while passing the same flag via the dashboard UI worked. They concluded the CLI must require 4 fields and filed a documentation gap.

The actual cause: `make_mounts_from_strings` uses `split(":", 2)`, so the third segment greedily absorbs trailing colons. `MOUNT_FROM` is itself a composite — for NFS it must be `node-nfs:<NFS_NAME>` (see `leptonai/cli/job_spec_example.json:18` -> `"from": "node-nfs:nfs-name"`). The customer's working `--mount /hf-cache:/root/.cache/huggingface:node-nfs:nfs` is still 3 fields; they just supplied the missing NFS drive name. Existing docs only said `STORAGE_PATH:MOUNT_PATH:MOUNT_FROM` and never explained that `MOUNT_FROM` could/must contain a colon.

## Files touched
- `leptonai/cli/deployment.py` — `lep endpoint create/update --mount` help
- `leptonai/cli/job.py` — `lep job create --mount` help
- `leptonai/cli/pod.py` — `lep pod create --mount` help
- `leptonai/cli/finetune.py` — `lep finetune ... --mount` help (also fixes a missing leading space)
- `leptonai/cli/raycluster.py` — worker-group `--mount` and `--head-mount` help
- `leptonai/cli/node.py` — `lep node storage` footer note
- `leptonai/api/v1/photon.py` — `make_mounts_from_strings` `ValueError` message

No behavior change; help text and one error message only.

## Test plan
- [ ] `lep endpoint create -h` shows the expanded `MOUNT_FROM` explanation
- [ ] `lep job create -h`, `lep pod create -h`, `lep finetune ... -h`, `lep raycluster create -h` show the same wording
- [ ] `lep node storage` footer mentions `node-local`
- [ ] `lep endpoint create --mount foo:bar` (only 2 fields) prints the clarified `ValueError`
- [ ] `black --check` and `ruff check` pass on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)