### PR TITLE
feat: add Claude Code / Codex agent skill for the lep CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "leptonai",
+  "description": "Agent skills for operating NVIDIA DGX Cloud Lepton through the `lep` CLI.",
+  "owner": {
+    "name": "Lepton AI"
+  },
+  "plugins": [
+    {
+      "name": "lepton-cli",
+      "source": "./.claude",
+      "description": "Operate NVIDIA DGX Cloud Lepton through the globally installed `lep` CLI.",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/.claude/.claude-plugin/plugin.json
+++ b/.claude/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "lepton-cli",
+  "description": "Operate NVIDIA DGX Cloud Lepton through the globally installed `lep` CLI.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Lepton AI"
+  }
+}

--- a/.claude/skills/lepton-cli/SKILL.md
+++ b/.claude/skills/lepton-cli/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: lepton-cli
+description: "Operate NVIDIA DGX Cloud Lepton through the globally installed `lep` CLI. Use when the user asks to inspect or manage Lepton workspaces, endpoints/deployments, dev pods, batch jobs, fine-tuning jobs, Ray clusters, Slurm clusters, Dynamo endpoints, storage, secrets, queues, nodes, ingress, templates, logs, authentication, or workspace status — or any task that needs safe command-line access to Lepton resources. Skip when the user is operating a different cloud or a different `lep`/`lepton` tool that isn't NVIDIA DGX Cloud Lepton."
+---
+
+# Lepton CLI
+
+Use the globally installed `lep` command to operate NVIDIA DGX Cloud Lepton resources from the terminal.
+
+## Runner
+
+Run commands directly:
+
+```bash
+lep <command> [args...]
+```
+
+Before doing real work, verify the CLI is available:
+
+```bash
+lep --help
+```
+
+If `lep` is missing, tell the user the global Lepton CLI is not available in the current environment and ask them to install or expose it on `PATH`. Do not attempt to download or install it yourself.
+
+## Source Of Truth
+
+- Use `lep --help` and `lep <group> --help` before any unfamiliar command.
+- Use `lep <group> <subcommand> --help` for exact flags and required arguments.
+- Read [references/workloads.md](references/workloads.md) for the workload types Lepton exposes (endpoints, dev pods, batch jobs, Ray clusters, Slurm, fine-tuning) and when each one applies. Consult it before recommending a resource shape to the user.
+- Treat the installed `lep` help output as authoritative for command behavior — command availability and flags vary by version.
+
+## Auth And Context
+
+Lepton authentication is scoped to a single workspace. A logged-in `lep` CLI may have a default workspace, but that default must not be assumed when the user has not named a workspace.
+
+The CLI may read local configuration and these environment variables:
+
+- `LEP_API_URL` — workspace URL used by `lep`.
+- `LEP_TOKEN` — workspace auth token.
+- `LEP_WORKSPACE` — default workspace name/display name.
+- `LEP_ENV` — optional environment label.
+
+Rules:
+
+- Before running a series of operations, identify the target workspace. If the user did not specify one, ask whether they intend to use the CLI's default logged-in workspace.
+- Start read-only with `lep workspace auth-status`, `lep workspace status`, `lep workspace list`, `lep workspace url`, or `lep workspace id`.
+- If the CLI is not logged in for the target workspace, fall back to provided `LEP_*` environment variables when available.
+- Prefer the exact `LEP_*` variables above when using environment credentials. Do not substitute `LEPTON_WORKSPACE_*` names unless the installed `lep` help or local configuration proves this CLI version reads them.
+- Do not run `lep workspace token`, print config files, echo tokens, or include tokens in final answers unless the user explicitly asks.
+- Prefer existing config/env credentials. Only run `lep workspace login -i <id> -t <token>` when the user explicitly provides credentials and accepts that the token may be persisted by the CLI.
+- If a read-only `lep` command fails with `FailedToOpenSocket`, DNS, or other connection errors that look like a sandboxed network, surface the error to the user and ask whether to retry with broader network permission rather than silently retrying.
+
+## Operating Workflow
+
+1. Identify the target workspace and resource; confirm default-workspace intent when the user has not specified a workspace.
+2. Verify current context with a read-only workspace command.
+3. Discover exact syntax with `--help`.
+4. For reads, run the narrowest command that answers the request.
+5. For mutations, inspect current state first when possible.
+6. For destructive operations, require explicit user intent or ask before proceeding.
+7. Summarize the result with resource names, status, and any next action; redact secrets.
+
+Destructive or high-impact commands include `remove`, `delete`, `stop`, `stop-all`, `remove-all`, `rm`, `rmdir`, `update`, `restart`, `create`, uploads/downloads to user-sensitive paths, and interactive `pod ssh`.
+
+## Modifying Or Deleting Existing Workloads
+
+Workloads are endpoints/deployments, dev pods, batch jobs, fine-tuning jobs, Ray clusters, Slurm clusters, and Dynamo endpoints (see [references/workloads.md](references/workloads.md)). Any command that modifies or deletes an existing workload requires explicit confirmation before it runs — even when auto mode is active or the user has previously approved similar actions in the session. Authorization does not carry over between resources or invocations.
+
+Before running the mutation, read the workload's current state with a narrow read-only command, then show the user: the exact `lep` command to be run, the target workload name, the workspace, and the current state. State what will change in one sentence (e.g., "About to delete endpoint `foo` in workspace `bar` — this is irreversible") and ask the user to confirm. Only execute the mutating command after an explicit yes. A waiver applies only to the single named workload — do not generalize it to other workloads or to a later command.
+
+## Output Handling
+
+- Prefer table output for human inspection.
+- Use JSON/YAML only when a command advertises `--output` or when the command naturally emits structured JSON.
+- For logs or streaming commands, scope the request with available flags such as replica/name/time/tail when the command supports them.
+- If a command writes files through options like `--path`, `download`, or `upload`, verify the source and destination before running.
+
+## Known Gotchas
+
+- `deployment` may be available as an alias for `endpoint`.
+- Some command groups may be hidden from top-level help but still invokable. If the user asks for a known Lepton resource, try `lep <group> --help` before concluding it is unsupported.
+- Slurm clusters are not self-serve — they are provisioned on request by the Lepton team. See [references/workloads.md](references/workloads.md).
+- Help output is authoritative for the installed CLI version; command availability and flags can vary by version.

--- a/.claude/skills/lepton-cli/references/workloads.md
+++ b/.claude/skills/lepton-cli/references/workloads.md
@@ -1,0 +1,91 @@
+# Lepton Workloads
+
+Lepton (NVIDIA DGX Cloud Lepton) is a multi-tenant AI cloud platform. Users in
+a workspace create **workloads** to consume GPU/CPU capacity. This document
+lists the workload types and what each one is for.
+
+## Endpoints
+
+Long-running model inference services exposed at a stable URL. An endpoint
+serves traffic, autoscales replicas based on demand (QPM or GPU utilization),
+and can scale to zero when idle. The served model can come from an NVIDIA NIM
+container, a vLLM or SGLang engine, or an arbitrary container image.
+
+Use an endpoint whenever something needs to serve requests — a chat model,
+an embedding service, a custom inference backend.
+
+## Dynamo Endpoints
+
+A specialized endpoint shape where serving is split across multiple services
+in a graph — typically separate frontend, prefill, and decode services. Each
+service has its own resource shape, image, and replica count, and is scaled
+independently. Supported backend frameworks are sglang, vllm, and trtllm.
+
+Use Dynamo when disaggregated serving is needed for better throughput or
+latency on large LLMs.
+
+## Dev Pods
+
+Single-replica, long-lived interactive environments. A Dev Pod is a personal
+machine — users ssh in, open Jupyter, or attach an IDE. It runs until
+explicitly stopped or deleted, does not fan out across replicas, and is not
+intended to receive external production traffic.
+
+Use a Dev Pod for day-to-day development, data exploration, debugging, and
+notebook work.
+
+## Batch Jobs
+
+Finite workloads that run to completion. A job can fan out into many parallel
+pods that communicate with each other (configurable parallelism and
+completions count). Jobs support retries, scheduling priority and preemption,
+reservation binding, delayed start, TTL-after-finish, and per-attempt history.
+
+Use a Batch Job for training runs, evaluations, hyperparameter sweeps, data
+processing, or any work with a defined end state. Built-in templates exist
+for `torchrun` (multi-GPU PyTorch) and MPI (multi-node) patterns.
+
+## Ray Clusters
+
+A managed Ray cluster — one head plus one or more worker groups, each with
+its own resource shape and min/max replica count. The cluster can autoscale
+its worker groups based on demand and can be suspended (paused without
+deletion) to release capacity. Users submit Ray jobs and inspect Ray actors
+against the running cluster.
+
+Use a Ray Cluster for distributed Python workloads — RLHF, large-scale data
+processing, ML pipelines built on Ray's actor model.
+
+## Slurm Clusters
+
+A managed Slurm cluster — controller plus login nodes. Lepton provisions and
+operates the cluster; users use Slurm normally (ssh to a login node, submit
+jobs via `sbatch` / `srun`). Slurm jobs are not independently managed Lepton
+resources — they live inside the cluster and are surfaced as a queryable list.
+
+Slurm clusters are **not self-serve** — they are provisioned on request by the
+Lepton team. Use them for teams already on Slurm workflows or doing classic
+HPC work.
+
+## Fine-Tuning Jobs
+
+A specialized job flavor for model fine-tuning, configured by picking a base
+model, a dataset, and a recipe (LoRA, full SFT, etc.) rather than by writing
+a job spec from scratch. Internally it shares the Batch Job machinery but
+with a guided configuration path and a recipe-aware view of the run.
+
+Use a Fine-Tuning Job to tune a model without authoring a custom training
+spec. For workflows that need full control over the training entrypoint, use
+a Batch Job instead.
+
+## Quick comparison
+
+| Workload    | Lifetime                   | Replica model              | Self-serve       | Primary purpose                |
+|-------------|----------------------------|----------------------------|------------------|--------------------------------|
+| Endpoint    | long-running               | autoscaled                 | yes              | Serve inference traffic        |
+| Dynamo      | long-running               | per-service autoscaled     | yes              | Disaggregated LLM serving      |
+| Dev Pod     | long-running (manual stop) | single                     | yes              | Interactive development        |
+| Batch Job   | runs to completion         | parallelism × completions  | yes              | Finite training / processing   |
+| Ray Cluster | long-running (suspendable) | head + worker groups       | yes              | Distributed Python / Ray       |
+| Slurm       | long-running               | controller + login nodes   | **request only** | Slurm / classic HPC            |
+| Fine-Tune   | runs to completion         | parallel pods              | yes              | Guided model fine-tuning       |

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ c.echo(inputs="hello world")
 
 For more details, checkout the [documentation](https://docs.nvidia.com/dgx-cloud/lepton) and the [examples](https://github.com/leptonai/examples).
 
-## Operating Lepton from Claude Code or Codex
+## Skills: Operating Lepton from Claude Code or Codex
 
 This repo ships an [agent skill](.claude/skills/lepton-cli/SKILL.md) that lets [Claude Code](https://claude.com/claude-code) (or Codex) drive the `lep` CLI for you — listing endpoints, inspecting jobs and dev pods, checking workspace status, and managing workloads, all from natural language. It uses the same `lep` CLI installed above, so make sure it is authenticated to your workspace.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,34 @@ c.echo(inputs="hello world")
 
 For more details, checkout the [documentation](https://docs.nvidia.com/dgx-cloud/lepton) and the [examples](https://github.com/leptonai/examples).
 
+## Operating Lepton from Claude Code or Codex
+
+This repo ships an [agent skill](.claude/skills/lepton-cli/SKILL.md) that lets [Claude Code](https://claude.com/claude-code) (or Codex) drive the `lep` CLI for you — listing endpoints, inspecting jobs and dev pods, checking workspace status, and managing workloads, all from natural language. It uses the same `lep` CLI installed above, so make sure it is authenticated to your workspace.
+
+**Claude Code** — install in one line, nothing to clone:
+
+```text
+/plugin marketplace add leptonai/leptonai
+/plugin install lepton-cli@leptonai
+```
+
+Start a new session, then ask something like *"List the endpoints in my Lepton workspace."* The skill asks for explicit confirmation before any command that modifies or deletes a workload.
+
+<details>
+<summary><b>Codex, or Claude Code without plugins</b></summary>
+
+Clone this repo, then copy the skill into your agent's skills directory:
+
+```bash
+# Codex
+cp -R .claude/skills/lepton-cli "${CODEX_HOME:-$HOME/.codex}/skills/lepton-cli"
+# Claude Code (personal skill)
+cp -R .claude/skills/lepton-cli "$HOME/.claude/skills/lepton-cli"
+```
+
+Restart the agent afterward.
+</details>
+
 ## Contributing
 
 Contributions and collaborations are welcome and highly appreciated. Please check out the [contributor guide](https://github.com/leptonai/leptonai/blob/main/CONTRIBUTING.md) for how to get involved.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The LeptonAI Python library allows you to build an AI service from Python code w
 - AI tailored batteries included such as autobatching, background jobs, etc.
 - A client to automatically call your service like native Python functions.
 - Pythonic configuration specs to be readily shipped in a cloud environment.
+- Skills enable agents to interact with Lepton platform itself.
 
 ## Getting started with one-liner
 Install the library with:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <a href="https://docs.nvidia.com/dgx-cloud/lepton">Homepage</a> •
 <a href="https://github.com/leptonai/examples">Examples</a> •
 <a href="https://docs.nvidia.com/dgx-cloud/lepton">Documentation</a> •
-<a href="https://docs.nvidia.com/dgx-cloud/lepton/reference/cli">CLI References</a>
+<a href="https://docs.nvidia.com/dgx-cloud/lepton/reference/cli/get-started/">CLI References</a>
 
 The LeptonAI Python library allows you to build an AI service from Python code with ease. Key features include:
 


### PR DESCRIPTION
## What

Adds an agent skill that lets **Claude Code** or **Codex** operate NVIDIA DGX Cloud Lepton through the globally installed `lep` CLI — listing endpoints, inspecting jobs and dev pods, checking workspace status, and managing workloads from natural language.

- `.claude/skills/lepton-cli/` — the skill (`SKILL.md` + `references/workloads.md`). It is read-first and requires explicit confirmation before any command that modifies or deletes a workload.
- `.claude-plugin/marketplace.json` + `.claude/.claude-plugin/plugin.json` — a plugin marketplace manifest so Claude Code can install the skill straight from this public repo, no checkout needed.
- `README.md` — a short "Operating Lepton from Claude Code or Codex" section.

## Install (for users, once merged)

Claude Code — one line, nothing to clone:

```text
/plugin marketplace add leptonai/leptonai
/plugin install lepton-cli@leptonai
```

Codex (or Claude Code without plugins): copy `.claude/skills/lepton-cli` into the agent's skills directory (documented in the README).

## Notes

- No Python code changes — only docs and agent-skill assets.
- The plugin reuses the `.claude/` tree, so a marketplace install and a personal/project-skill install resolve to the same content.
- Validated with `claude plugin validate --strict` and an end-to-end add → install → uninstall cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
