### PR TITLE
docs: use HTTPS URL for the plugin marketplace install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ This repo ships an [agent skill](.claude/skills/lepton-cli/SKILL.md) that lets [
 **Claude Code** — install in one line, nothing to clone:
 
 ```text
-/plugin marketplace add leptonai/leptonai
+/plugin marketplace add https://github.com/leptonai/leptonai.git
 /plugin install lepton-cli@leptonai
 ```
 


### PR DESCRIPTION
## What

Switch the README install command from the GitHub shorthand to the full HTTPS URL:

```diff
-/plugin marketplace add leptonai/leptonai
+/plugin marketplace add https://github.com/leptonai/leptonai.git
```

## Why

`/plugin marketplace add leptonai/leptonai` makes Claude Code clone the repo over **SSH** (`git@github.com:leptonai/leptonai.git`). For users who access GitHub over HTTPS and have no GitHub SSH key, that fails with:

```
git@github.com: Permission denied (publickey).
... ERR_STREAM_PREMATURE_CLOSE: Premature close
```

Claude Code runs the marketplace clone with an **isolated git config**, so a user's `insteadOf` rewrite (the usual `git@github.com:` → `https://github.com/` trick) is not applied — it really attempts SSH.

The full HTTPS URL clones the **public** repo **anonymously**, so it works for everyone regardless of SSH setup, with no credentials needed. Verified end-to-end (`marketplace add` → `plugin install` → skill resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
