### PR TITLE
feat(cli): revamp 'node list' and add 'node list-nodes'

### DIFF
--- a/leptonai/api/v1/dedicated_node_groups.py
+++ b/leptonai/api/v1/dedicated_node_groups.py
@@ -4,6 +4,7 @@ from typing import List, Union
 from .api_resource import APIResourse
 
 from .types.dedicated_node_group import DedicatedNodeGroup, Node
+from .types.node_reservation import NodeReservation
 
 
 class DedicatedNodeGroupAPI(APIResourse):
@@ -25,5 +26,13 @@ class DedicatedNodeGroupAPI(APIResourse):
             f"/dedicated-node-groups/{self._to_name(name_or_ng)}/nodes"
         )
         return self.ensure_list(response, Node)
+
+    def list_reservations(
+        self, name_or_ng: Union[str, DedicatedNodeGroup]
+    ) -> List[NodeReservation]:
+        response = self._get(
+            f"/dedicated-node-groups/{self._to_name(name_or_ng)}/reservations"
+        )
+        return self.ensure_list(response, NodeReservation)
 
     # todo: implement more node management and monitoring APIs

--- a/leptonai/api/v1/types/dedicated_node_group.py
+++ b/leptonai/api/v1/types/dedicated_node_group.py
@@ -84,6 +84,7 @@ class DedicatedNodeGroupSpec(BaseModel):
     infini_band_enabled: Optional[bool] = None
     scheduling_policy: Optional[SchedulingPolicy] = None
     owner: Optional[str] = None
+    node_mode: Optional[str] = None
     networking: Optional[NetworkConfigurations] = None
     alert_notification_config: Optional[AlertNotificationConfig] = None
 
@@ -124,8 +125,8 @@ class NodeResourceGPU(BaseModel):
 
 
 class NodeResourceDisk(BaseModel):
-    # TODO: get the current disk usage and total
-    pass
+    total_bytes: Optional[int] = None
+    used_bytes: Optional[int] = None
 
 
 class NodeResourceSystem(BaseModel):
@@ -157,6 +158,8 @@ class NodeResource(BaseModel):
 class NodeSpec(BaseModel):
     dedicated_node_group: Optional[str] = None
     public_op: Optional[str] = None
+    provider: Optional[str] = None
+    provider_region: Optional[str] = None
     resource: Optional[NodeResource] = None
     unschedulable: bool
 

--- a/leptonai/api/v1/types/node_reservation.py
+++ b/leptonai/api/v1/types/node_reservation.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel
+from loguru import logger
+
+from .common import Metadata
+
+
+class ReservationStatusEnum(str, Enum):
+    """Phase of a node reservation, mirroring the console's ReservationStatusEnum."""
+
+    PendingApproval = "PendingApproval"
+    Rejected = "Rejected"
+    WaitingEffective = "WaitingEffective"
+    Reserving = "Reserving"
+    Reserved = "Reserved"
+    Expired = "Expired"
+    Unknown = "UNK"
+
+    @classmethod
+    def _missing_(cls, value):
+        logger.trace(f"Unknown value: {value} for ReservationStatusEnum")
+        return cls.Unknown
+
+
+class NodeReservationTimeRule(BaseModel):
+    # Unix timestamps in SECONDS, per the api-server
+    # NodeReservationRequestSpecTimeRule (these are serialized with time.Unix()).
+    start_timestamp: Optional[int] = None
+    end_timestamp: Optional[int] = None
+
+
+class NodeReservationSpec(BaseModel):
+    users: Optional[List[str]] = None
+    desired_nodes: Optional[int] = None
+    approved_nodes: Optional[int] = None
+    time_rule: Optional[NodeReservationTimeRule] = None
+    created_by: Optional[str] = None
+    # The console type carries display_name in spec, but the api-server actually
+    # serializes the display name into metadata.name. Keep it optional so we can
+    # fall back to it when present.
+    display_name: Optional[str] = None
+
+
+class NodeReservationStatus(BaseModel):
+    phase: Optional[ReservationStatusEnum] = None
+    # reserved_count is omitempty on the wire, so 0 may be absent.
+    reserved_count: int = 0
+    reserved_nodes: Optional[List[str]] = None
+
+
+class NodeReservation(BaseModel):
+    # metadata.created_at is in MILLISECONDS (api-server uses CreationTimestamp
+    # .UnixMilli()), unlike spec.time_rule timestamps which are in seconds.
+    metadata: Metadata
+    spec: NodeReservationSpec
+    status: Optional[NodeReservationStatus] = None

--- a/leptonai/api/v2/dedicated_node_groups.py
+++ b/leptonai/api/v2/dedicated_node_groups.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from ..v1.api_resource import APIResourse
 
 from ..v1.types.dedicated_node_group import DedicatedNodeGroup, Node
+from ..v1.types.node_reservation import NodeReservation
 
 
 class DedicatedNodeGroupAPI(APIResourse):
@@ -33,6 +34,14 @@ class DedicatedNodeGroupAPI(APIResourse):
             params={"idle": "true"},
         )
         return self.ensure_list(response, Node)
+
+    def list_reservations(
+        self, name_or_ng: Union[str, DedicatedNodeGroup]
+    ) -> List[NodeReservation]:
+        response = self._get(
+            f"/dedicated-node-groups/{self._to_name(name_or_ng)}/reservations"
+        )
+        return self.ensure_list(response, NodeReservation)
 
     # todo: implement more node management and monitoring APIs
 

--- a/leptonai/cli/node.py
+++ b/leptonai/cli/node.py
@@ -26,7 +26,9 @@ def _is_node_usable(node):
     status = (node.status.status if node.status else None) or []
     spec = getattr(node, "spec", None)
     return bool(spec) and (
-        not getattr(spec, "unschedulable", True) and "Ready" in status and "Unhealthy" not in status
+        not getattr(spec, "unschedulable", True)
+        and "Ready" in status
+        and "Unhealthy" not in status
     )
 
 
@@ -568,7 +570,7 @@ def list_reservations_command(name):
                     node_gpu_by_id[node.metadata.id_] = gpu
         except Exception as e:
             console.print(
-                f"[dim]Warning:[/dim] Failed to fetch nodes for GPU usage in"
+                "[dim]Warning:[/dim] Failed to fetch nodes for GPU usage in"
                 f" {ng_name} ({ng_id}): {e}"
             )
 

--- a/leptonai/cli/node.py
+++ b/leptonai/cli/node.py
@@ -5,6 +5,7 @@ from rich.table import Table
 from .util import (
     console,
     click_group,
+    format_timestamp_ms,
     get_client,
     make_name_id_cell,
     resolve_node_groups,
@@ -418,6 +419,168 @@ def list_nodes_command(name):
                 _format_memory_cell(resource.memory if resource else None),
                 _format_disk_cell(resource.disk if resource else None),
             )
+
+        console.print(table)
+
+
+def _colorize_reservation_phase(phase):
+    """Colorize a reservation phase for visualization.
+
+    Mirrors the backend phase semantics: 'Reserved' is the usable end state,
+    'Reserving'/'WaitingEffective' are in-progress, 'PendingApproval' is waiting
+    on an admin, and 'Rejected'/'Expired' are dead.
+    """
+    text = (getattr(phase, "value", phase) if phase is not None else None) or "-"
+    if text == "Reserved":
+        return f"[green]{text}[/green]"
+    if text in ("Reserving", "WaitingEffective"):
+        return f"[cyan]{text}[/cyan]"
+    if text == "PendingApproval":
+        return f"[yellow]{text}[/yellow]"
+    if text in ("Rejected", "Expired"):
+        return f"[red]{text}[/red]"
+    return f"[dim]{text}[/dim]"
+
+
+def _format_reservation_gpu_cell(reserved_nodes, node_gpu_by_id):
+    """Aggregate GPU used/total across a reservation's reserved nodes.
+
+    The reservation payload carries no GPU data, so we cross-reference the
+    reserved node IDs against the node group's node list (node_gpu_by_id maps a
+    node id to its NodeResourceGPU). 'avail' is the idle GPU on those nodes.
+    """
+    used = 0.0
+    total = 0.0
+    products = set()
+    matched = 0
+    for node_id in reserved_nodes or []:
+        gpu = node_gpu_by_id.get(node_id)
+        if not gpu or gpu.total is None:
+            continue
+        matched += 1
+        total += gpu.total or 0
+        used += gpu.allocated or 0
+        if gpu.product:
+            products.add(gpu.product)
+    if matched == 0:
+        return "[dim]-[/dim]"
+    product = products.pop() if len(products) == 1 else "GPU"
+    avail = total - used
+    avail_color = "green" if avail > 0 else "dim"
+    return (
+        f"{product}\n[{avail_color}]{_trim_num(avail)} avail[/{avail_color}]"
+        f" · {_format_used_total(used, total)} used"
+    )
+
+
+def _format_reservation_row(reservation, node_gpu_by_id):
+    """Build a single 'lep node list-reservations' table row from a NodeReservation."""
+    meta = reservation.metadata
+    spec = reservation.spec
+    status = reservation.status
+
+    # Reservation: display name on metadata.name (spec.display_name as fallback) / id.
+    display_name = meta.name or (getattr(spec, "display_name", None) if spec else None)
+    name_id = make_name_id_cell(display_name, meta.id_)
+
+    status_cell = _colorize_reservation_phase(status.phase if status else None)
+
+    # Nodes: desired / approved / reserved, with reserved node ids listed below.
+    desired = spec.desired_nodes if spec else None
+    approved = spec.approved_nodes if spec else None
+    reserved = status.reserved_count if status else 0
+    reserved_nodes = (status.reserved_nodes if status else None) or []
+    desired_str = _trim_num(desired) if desired is not None else "[dim]-[/dim]"
+    approved_str = _trim_num(approved) if approved is not None else "[dim]-[/dim]"
+    reserved_color = "green" if reserved else "dim"
+    nodes_lines = [
+        f"{desired_str} / {approved_str} /"
+        f" [{reserved_color}]{_trim_num(reserved)}[/{reserved_color}]"
+    ]
+    for node_id in reserved_nodes:
+        nodes_lines.append(f"[dim]{node_id}[/dim]")
+    nodes_cell = "\n".join(nodes_lines)
+
+    gpu_cell = _format_reservation_gpu_cell(reserved_nodes, node_gpu_by_id)
+
+    users = (spec.users if spec else None) or []
+    users_cell = "\n".join(users) if users else "[dim]-[/dim]"
+
+    # Created: created_by plus created_at, which is in MILLISECONDS.
+    created_by = (spec.created_by if spec else None) or "-"
+    created_cell = f"[dim]{created_by}[/dim]\n{format_timestamp_ms(meta.created_at)}"
+
+    return (
+        name_id,
+        status_cell,
+        nodes_cell,
+        gpu_cell,
+        users_cell,
+        created_cell,
+    )
+
+
+@node.command(name="list-reservations")
+@click.argument("name", type=str)
+def list_reservations_command(name):
+    """
+    List node reservations under a node group.
+
+    NAME is the node group name or ID (partial match supported, e.g. 'h100').
+    For each reservation it shows the status, the desired/approved/reserved node
+    counts (with the reserved node IDs), the GPU usage on the reserved nodes, the
+    authorized users, and who created it and when.
+    """
+    node_groups = resolve_node_groups([name], is_exact_match=False)
+    if not node_groups:
+        return
+
+    client = get_client()
+
+    for node_group in node_groups:
+        ng_name = node_group.metadata.name
+        ng_id = node_group.metadata.id_
+
+        try:
+            reservations = client.nodegroup.list_reservations(node_group)
+        except Exception as e:
+            console.print(
+                f"[red]Failed to fetch reservations for {ng_name} ({ng_id}):[/red] {e}"
+            )
+            continue
+
+        if not reservations:
+            console.print(
+                f"[yellow]No reservations found in node group {ng_name}"
+                f" ({ng_id}).[/yellow]"
+            )
+            continue
+
+        # Reservations carry only node IDs; fetch the nodes once to resolve the
+        # GPU usage of each reservation's reserved nodes.
+        node_gpu_by_id = {}
+        try:
+            for node in client.nodegroup.list_nodes(node_group):
+                resource = node.spec.resource if node.spec else None
+                gpu = resource.gpu if resource else None
+                if gpu is not None:
+                    node_gpu_by_id[node.metadata.id_] = gpu
+        except Exception as e:
+            console.print(
+                f"[dim]Warning:[/dim] Failed to fetch nodes for GPU usage in"
+                f" {ng_name} ({ng_id}): {e}"
+            )
+
+        table = Table(title=f"Reservations in {ng_name} ({ng_id})", show_lines=True)
+        table.add_column("Reservation")
+        table.add_column("Status")
+        table.add_column("Nodes\n[dim](desired / approved / reserved)[/dim]")
+        table.add_column("GPU Usage\n[dim](avail · used/total)[/dim]")
+        table.add_column("Users")
+        table.add_column("Created")
+
+        for reservation in reservations:
+            table.add_row(*_format_reservation_row(reservation, node_gpu_by_id))
 
         console.print(table)
 

--- a/leptonai/cli/node.py
+++ b/leptonai/cli/node.py
@@ -24,8 +24,9 @@ def node():
 def _is_node_usable(node):
     """A node is usable when it is ready, healthy, and schedulable."""
     status = (node.status.status if node.status else None) or []
-    return (
-        not node.spec.unschedulable and "Ready" in status and "Unhealthy" not in status
+    spec = getattr(node, "spec", None)
+    return bool(spec) and (
+        not getattr(spec, "unschedulable", True) and "Ready" in status and "Unhealthy" not in status
     )
 
 
@@ -73,7 +74,7 @@ def _get_node_group_stats(nodes):
             stats["gpu_total"] += total
             stats["gpu_used"] += used
             if usable:
-                stats["gpu_avail"] += total - used
+                stats["gpu_avail"] += max(0, total - used)
         if resource.cpu:
             stats["cpu_used"] += resource.cpu.allocated or 0
             stats["cpu_total"] += resource.cpu.total or 0
@@ -324,7 +325,7 @@ def _format_gpu_cell(gpu, usable=True):
         return "[dim]-[/dim]"
     product = gpu.product or "GPU"
     allocated = gpu.allocated or 0
-    avail = (gpu.total - allocated) if usable else 0
+    avail = max(0, gpu.total - allocated) if usable else 0
     avail_color = "green" if avail > 0 else "dim"
     return (
         f"{product}\n[{avail_color}]{_trim_num(avail)} avail[/{avail_color}]"

--- a/leptonai/cli/node.py
+++ b/leptonai/cli/node.py
@@ -6,6 +6,7 @@ from .util import (
     console,
     click_group,
     get_client,
+    make_name_id_cell,
     resolve_node_groups,
 )
 from ..api.v2.client import APIClient
@@ -19,77 +20,69 @@ def node():
     pass
 
 
-def _is_node_used(node):
-    """Check if a node is in use"""
-    workloads = getattr(getattr(node, "status", None), "workloads", None)
-    if not workloads:
-        return False
-    return any((getattr(w, "type_", "") or "").lower() != "system" for w in workloads)
-
-
-def _is_node_unhealthy(node):
-    """Check if a node is unhealthy"""
-    return "Unhealthy" in node.status.status
-
-
-def _is_node_available(node):
-    """
-    Check if a node is available for use.
-
-    A node is considered available when it meets ALL of the following conditions:
-    1. Has no workloads on GPU(No workload used gpu)
-    2. Is in Ready state (has 'Ready' in node.status.status)
-    3. Is not marked as unschedulable (node.spec.unschedulable is False)
-    4. Is not unhealthy (does not have 'Unhealthy' in node.status.status)
-    """
-    gpu_used = False
-    if node.status.workloads:
-        for workload in node.status.workloads:
-            if workload.gpu_count and workload.gpu_count > 0:
-                gpu_used = True
+def _is_node_usable(node):
+    """A node is usable when it is ready, healthy, and schedulable."""
+    status = (node.status.status if node.status else None) or []
     return (
-        not node.spec.unschedulable
-        and "Ready" in node.status.status
-        and "Unhealthy" not in node.status.status
-        and not gpu_used
+        not node.spec.unschedulable and "Ready" in status and "Unhealthy" not in status
     )
 
 
-def _get_node_stats(nodes):
-    """Calculate node statistics"""
-    used_nodes = 0
-    unhealthy_nodes = 0
-    available_nodes = 0
-    unhealthy_node_details = []
-    used_node_details = []
-    available_node_details = []
-    ready_node_details = []
-    for node in nodes:
-        node_details = _format_node_details(node)
+def _node_group_type(node_group):
+    """Render whether a node group is Lepton-managed or customer BYOC."""
+    mode = getattr(node_group.spec, "node_mode", None)
+    if mode == "lepton-node":
+        return "[cyan]Lepton[/cyan]"
+    if mode == "customer-node":
+        return "[magenta]BYOC[/magenta]"
+    return "[dim]-[/dim]"
 
-        ready_node_details.append(node_details)
 
-        if _is_node_used(node):
-            used_nodes += 1
-            used_node_details.append(node_details)
+def _get_node_group_stats(nodes):
+    """Aggregate node counts and resource capacity across a node group.
 
-        if _is_node_unhealthy(node):
-            unhealthy_nodes += 1
-            unhealthy_node_details.append(node_details)
-
-        if _is_node_available(node):
-            available_nodes += 1
-            available_node_details.append(node_details)
-
-    return {
-        "used": used_nodes,
-        "unhealthy": unhealthy_nodes,
-        "available": available_nodes,
-        "unhealthy_nodes_details": unhealthy_node_details,
-        "used_nodes_details": used_node_details,
-        "available_nodes_details": available_node_details,
-        "ready_nodes_details": ready_node_details,
+    'avail' for GPU counts only idle GPUs on usable (ready/healthy/schedulable)
+    nodes, so GPUs sitting on unhealthy or NotReady nodes are not reported as
+    available capacity.
+    """
+    stats = {
+        "healthy": 0,
+        "error": 0,
+        "total": len(nodes),
+        "gpu_avail": 0.0,
+        "gpu_used": 0.0,
+        "gpu_total": 0.0,
+        "cpu_used": 0.0,
+        "cpu_total": 0.0,
+        "mem_used": 0,
+        "mem_total": 0,
+        "disk_used": 0,
+        "disk_total": 0,
     }
+    for node in nodes:
+        usable = _is_node_usable(node)
+        stats["healthy" if usable else "error"] += 1
+
+        resource = node.spec.resource if node.spec else None
+        if not resource:
+            continue
+        if resource.gpu:
+            total = resource.gpu.total or 0
+            used = resource.gpu.allocated or 0
+            stats["gpu_total"] += total
+            stats["gpu_used"] += used
+            if usable:
+                stats["gpu_avail"] += total - used
+        if resource.cpu:
+            stats["cpu_used"] += resource.cpu.allocated or 0
+            stats["cpu_total"] += resource.cpu.total or 0
+        if resource.memory:
+            stats["mem_used"] += resource.memory.allocated or 0
+            stats["mem_total"] += resource.memory.total or 0
+        if resource.disk:
+            stats["disk_used"] += resource.disk.used_bytes or 0
+            stats["disk_total"] += resource.disk.total_bytes or 0
+    return stats
 
 
 def _colorize_status(status):
@@ -102,27 +95,6 @@ def _colorize_status(status):
         return f"[green]{status}[/green]"
     else:  # NotReady or other statuses
         return f"[yellow]{status}[/yellow]"
-
-
-def _format_node_details(node):
-    """Format detailed information for a single node"""
-    node_id = node.metadata.id_
-    node_cpu = (
-        node.spec.resource.cpu.type_
-        if (node.spec and node.spec.resource and node.spec.resource.cpu)
-        else None
-    )
-    node_gpu = (
-        node.spec.resource.gpu.product
-        if (node.spec and node.spec.resource and node.spec.resource.gpu)
-        else None
-    )
-    colored_statuses = [f"{_colorize_status(status)}" for status in node.status.status]
-    return (
-        f"[bold]{node_id}[/bold], ({node_cpu}, {node_gpu},"
-        f" {', '.join(colored_statuses)},"
-        f" {'[green]Idle[/green]' if node.status.workloads is None or len(node.status.workloads) == 0 else '[blue]Used[/blue]'})"
-    )
 
 
 def _format_shape_entry(shape):
@@ -195,14 +167,20 @@ def _format_shape_entry(shape):
 
 
 @node.command(name="list")
-@click.option("--detail", "-d", help="Show all the nodes", is_flag=True)
+@click.option(
+    "--detail",
+    "-d",
+    is_flag=True,
+    hidden=True,
+    help="(removed) per-node detail moved to 'lep node list-nodes'.",
+)
 @click.option(
     "--node-group",
     "-ng",
     help=(
-        "Show all the nodes in specific node groups by their IDs or names. Can use"
-        " partial name/ID (e.g., 'h100' will match any name/ID containing 'h100'). Can"
-        " specify multiple values."
+        "Show only node groups whose IDs or names match. Can use partial name/ID"
+        " (e.g., 'h100' will match any name/ID containing 'h100'). Can specify"
+        " multiple values."
     ),
     type=str,
     required=False,
@@ -210,10 +188,18 @@ def _format_shape_entry(shape):
 )
 def list_command(detail=False, node_group=None):
     """
-    Lists all node groups in the current workspace.
+    List node groups in the current workspace with a capacity summary.
 
-    If the --detail or -d option is provided, additional information about each node will be displayed.
+    For each node group this shows node health (healthy/error/total), whether it
+    is Lepton-managed or customer BYOC, and the aggregated GPU/CPU/memory/disk
+    usage. For per-node detail, use 'lep node list-nodes <node-group>'.
     """
+    if detail:
+        console.print(
+            "[yellow]Note:[/yellow] '-d/--detail' has been removed. For per-node"
+            " detail, use [bold]lep node list-nodes <node-group>[/bold].\n"
+        )
+
     client = get_client()
 
     if node_group:
@@ -221,14 +207,14 @@ def list_command(detail=False, node_group=None):
     else:
         filtered_node_groups = client.nodegroup.list_all()
 
-    # Create base table
     table = Table(title="Node Groups", show_lines=True)
-    table.add_column("Name")
-    table.add_column("ID")
-    table.add_column("Available Nodes (All GPU available)")
-    table.add_column("Unhealthy Nodes")
-    table.add_column("Used Nodes")
-    table.add_column("Ready Nodes")
+    table.add_column("Node Group")
+    table.add_column("Type")
+    table.add_column("Nodes\n[dim](healthy / error / total)[/dim]")
+    table.add_column("GPU\n[dim](avail · used/total)[/dim]")
+    table.add_column("CPU\n[dim](used / total)[/dim]")
+    table.add_column("Memory\n[dim](used / total)[/dim]")
+    table.add_column("Disk\n[dim](used / total)[/dim]")
 
     nodes_results = []
     if filtered_node_groups:
@@ -251,44 +237,189 @@ def list_command(detail=False, node_group=None):
             else:
                 nodes_results.append(item)
 
-    for idx, node_group in enumerate(filtered_node_groups):
-        node_group_name = node_group.metadata.name
-        node_group_id = node_group.metadata.id_
-        ready_nodes = str(node_group.status.ready_nodes or 0)
-
+    for idx, ng in enumerate(filtered_node_groups):
         nodes = nodes_results[idx] if idx < len(nodes_results) else []
-        stats = _get_node_stats(nodes)
+        stats = _get_node_group_stats(nodes)
 
-        if detail:
-            used_details = "\n".join(stats["used_nodes_details"])
-            unhealthy_details = "\n".join(stats["unhealthy_nodes_details"])
-            available_details = "\n".join(stats["available_nodes_details"])
-            ready_nodes_details = "\n".join(stats["ready_nodes_details"])
+        name_id = make_name_id_cell(ng.metadata.name, ng.metadata.id_)
+        error_str = f"[red]{stats['error']}[/red]" if stats["error"] else "[dim]0[/dim]"
+        health = f"[green]{stats['healthy']}[/green] / {error_str} / {stats['total']}"
+        dim = "[dim]-[/dim]"
+        avail_color = "green" if stats["gpu_avail"] > 0 else "dim"
+        gpu_cell = (
+            f"[{avail_color}]{_trim_num(stats['gpu_avail'])} avail[/{avail_color}]"
+            f" · {_format_used_total(stats['gpu_used'], stats['gpu_total'])} used"
+            if stats["gpu_total"]
+            else dim
+        )
+        cpu_cell = (
+            f"{_format_used_total(stats['cpu_used'], stats['cpu_total'])} cores"
+            if stats["cpu_total"]
+            else dim
+        )
+        mem_cell = (
+            f"{_format_bytes(stats['mem_used'] * 1024 * 1024)} /"
+            f" {_format_bytes(stats['mem_total'] * 1024 * 1024)}"
+            if stats["mem_total"]
+            else dim
+        )
+        disk_cell = (
+            f"{_format_bytes(stats['disk_used'])} /"
+            f" {_format_bytes(stats['disk_total'])}"
+            if stats["disk_total"]
+            else dim
+        )
 
-            table.add_row(
-                node_group_name,
-                node_group_id,
-                f"[green]{stats['available']}[/green]/{ready_nodes}\n{available_details}",
-                f"[red]{stats['unhealthy']}[/red]/{ready_nodes}\n{unhealthy_details}",
-                f"[blue]{stats['used']}[/blue]/{ready_nodes}\n{used_details}",
-                f"{ready_nodes}\n{ready_nodes_details}",
-            )
-        else:
-            table.add_row(
-                node_group_name,
-                node_group_id,
-                f"[green]{stats['available']}[/green]/{ready_nodes}",
-                f"[red]{stats['unhealthy']}[/red]/{ready_nodes}",
-                f"[blue]{stats['used']}[/blue]/{ready_nodes}",
-                ready_nodes,
-            )
+        table.add_row(
+            name_id,
+            _node_group_type(ng),
+            health,
+            gpu_cell,
+            cpu_cell,
+            mem_cell,
+            disk_cell,
+        )
 
     console.print(table)
 
     console.print(
-        "[dim]Note:[/dim] If a node appears available but is actually in use, it is"
-        " currently handling only CPU workloads, with all GPUs remaining idle.\n"
+        "[dim]Note:[/dim] GPU 'avail' counts only idle GPUs on healthy, ready,"
+        " schedulable nodes. CPU/memory/disk are summed across the node group.\n"
     )
+
+
+def _trim_num(value):
+    """Render a number without a trailing '.0'; return '?' when missing."""
+    if value is None:
+        return "?"
+    value = float(value)
+    return str(int(value)) if value.is_integer() else f"{value:.1f}"
+
+
+def _format_used_total(allocated, total):
+    """Format an 'allocated/total' pair."""
+    return f"{_trim_num(allocated)}/{_trim_num(total)}"
+
+
+def _format_bytes(num):
+    """Render a byte count in binary units (GiB/TiB...)."""
+    if num is None:
+        return "?"
+    value = float(num)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB", "PiB"):
+        if value < 1024 or unit == "PiB":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+
+
+def _format_gpu_cell(gpu, usable=True):
+    """GPU column: product on line 1, avail and used/total on line 2.
+
+    'avail' mirrors 'lep node list': idle GPUs only count as available when the
+    node is usable (ready/healthy/schedulable); on an unusable node they are not
+    reported as available capacity, so per-node and aggregate views agree.
+    """
+    if not gpu or gpu.total is None:
+        return "[dim]-[/dim]"
+    product = gpu.product or "GPU"
+    allocated = gpu.allocated or 0
+    avail = (gpu.total - allocated) if usable else 0
+    avail_color = "green" if avail > 0 else "dim"
+    return (
+        f"{product}\n[{avail_color}]{_trim_num(avail)} avail[/{avail_color}]"
+        f" · {_format_used_total(allocated, gpu.total)} used"
+    )
+
+
+def _format_cpu_cell(cpu):
+    if not cpu or cpu.total is None:
+        return "[dim]-[/dim]"
+    type_ = cpu.type_ or "cpu"
+    return f"{type_}\n{_format_used_total(cpu.allocated, cpu.total)} cores"
+
+
+def _format_memory_cell(memory):
+    # memory allocated/total are reported in MiB.
+    if not memory or memory.total is None:
+        return "[dim]-[/dim]"
+    used = _format_bytes((memory.allocated or 0) * 1024 * 1024)
+    total = _format_bytes(memory.total * 1024 * 1024)
+    return f"{used} / {total}"
+
+
+def _format_disk_cell(disk):
+    if not disk or disk.total_bytes is None:
+        return "[dim]-[/dim]"
+    used = _format_bytes(disk.used_bytes or 0)
+    total = _format_bytes(disk.total_bytes)
+    return f"{used} / {total}"
+
+
+@node.command(name="list-nodes")
+@click.argument("name", type=str)
+def list_nodes_command(name):
+    """
+    List the nodes under a node group with per-node resource detail.
+
+    NAME is the node group name or ID (partial match supported, e.g. 'h100').
+    For each node it shows the node ID, provider/region, status, GPU
+    availability, and the used/total split for GPU, CPU, memory, and disk.
+    """
+    node_groups = resolve_node_groups([name], is_exact_match=False)
+    if not node_groups:
+        return
+
+    client = get_client()
+
+    for node_group in node_groups:
+        ng_name = node_group.metadata.name
+        ng_id = node_group.metadata.id_
+
+        try:
+            nodes = client.nodegroup.list_nodes(node_group)
+        except Exception as e:
+            console.print(
+                f"[red]Failed to fetch nodes for {ng_name} ({ng_id}):[/red] {e}"
+            )
+            continue
+
+        table = Table(title=f"Nodes in {ng_name} ({ng_id})", show_lines=True)
+        table.add_column("Node ID")
+        table.add_column("Provider / Region")
+        table.add_column("Status")
+        table.add_column("GPU\n[dim](avail · used/total)[/dim]")
+        table.add_column("CPU\n[dim](used / total)[/dim]")
+        table.add_column("Memory\n[dim](used / total)[/dim]")
+        table.add_column("Disk\n[dim](used / total)[/dim]")
+
+        if not nodes:
+            console.print(
+                f"[yellow]No nodes found in node group {ng_name} ({ng_id}).[/yellow]"
+            )
+            continue
+
+        for node in nodes:
+            spec = node.spec
+            resource = spec.resource if spec else None
+            provider = (getattr(spec, "provider", None) if spec else None) or "-"
+            region = (getattr(spec, "provider_region", None) if spec else None) or "-"
+            statuses = (node.status.status if node.status else None) or []
+            status_cell = ", ".join(_colorize_status(s) for s in statuses) or "-"
+
+            table.add_row(
+                make_name_id_cell(node.metadata.id_, None),
+                f"{provider} / {region}",
+                status_cell,
+                _format_gpu_cell(
+                    resource.gpu if resource else None,
+                    usable=_is_node_usable(node),
+                ),
+                _format_cpu_cell(resource.cpu if resource else None),
+                _format_memory_cell(resource.memory if resource else None),
+                _format_disk_cell(resource.disk if resource else None),
+            )
+
+        console.print(table)
 
 
 @node.command(name="resource-shape")


### PR DESCRIPTION

## Summary
- Rework `lep node list` into a per-node-group **capacity summary**: node health (healthy/error/total), Lepton vs BYOC type, and aggregated GPU/CPU/memory/disk usage — replacing the old `available/unhealthy/used/ready` columns. The `-d/--detail` flag is retired (kept hidden with a pointer to the new command).
- Add **`lep node list-nodes <node-group>`** for per-node resource detail (provider/region, status, per-resource used/total).
- Present **GPU availability consistently** across both commands as `avail · used/total`, with `avail` colored green only when `> 0` and counting idle GPUs on *usable* (ready/healthy/schedulable) nodes only — so the aggregate and per-node views agree.
- Extend node types: `DedicatedNodeGroupSpec.node_mode`, `NodeResourceDisk.total_bytes/used_bytes`, and `NodeSpec.provider/provider_region`.

## Verification
- Install: `pip install -U "git+https://github.com/leptonai/leptonai.git@feat/node-list-capacity-summary"`
- `python -m py_compile leptonai/cli/node.py` passes.
- Manual CLI runs need a live workspace; suggested checks:
  - `lep node list` / `lep node list -ng <name>`
  - `lep node list-nodes <node-group>`
  - GPU `avail` is green when `> 0` and dim at `0` in both views

🤖 Generated with [Claude Code](https://claude.com/claude-code)
