### PR TITLE
refactor!: remove Lepton Classic support and dead variables

### DIFF
--- a/leptonai/api/v1/template.py
+++ b/leptonai/api/v1/template.py
@@ -2,9 +2,6 @@
 
 Keeping this file allows ``import leptonai.api.v1.template`` code to work
 while the real logic lives in ``leptonai.api.v2.template``.
-
-Users on Lepton Classic won’t be able to call this API, but we keep it
-here to minimize divergence between v1 and v2.
 """
 
 from ..v2.template import TemplateAPI  # re-export

--- a/leptonai/api/v2/client.py
+++ b/leptonai/api/v2/client.py
@@ -58,7 +58,6 @@ class APIClient(object):
         auth_token: Optional[str] = None,
         url: Optional[str] = None,
         workspace_origin_url: Optional[str] = None,
-        is_lepton_classic: Optional[bool] = None,
     ):
         """
         Creates a workspace api client by identifying the workspace in the following
@@ -80,14 +79,6 @@ class APIClient(object):
         #  - environment variable LEPTON_WORKSPACE_ID
         #  - current workspace of the workspace record
         # and if there is still no choice, we will throw an error.
-        is_lepton_classic = (
-            is_lepton_classic
-            or os.environ.get("LEPTON_CLASSIC")
-            or WorkspaceRecord.current().is_lepton_classic
-            if WorkspaceRecord.current()
-            else False
-        )
-
         workspace_id = (
             workspace_id
             or os.environ.get("LEPTON_WORKSPACE_ID")
@@ -126,9 +117,7 @@ class APIClient(object):
                 if WorkspaceRecord.has(workspace_id)
                 else None
             )
-            or _get_full_workspace_api_url(
-                workspace_id, is_lepton_classic=is_lepton_classic
-            )
+            or _get_full_workspace_api_url(workspace_id)
         )
         workspace_origin_url = (
             workspace_origin_url
@@ -151,10 +140,9 @@ class APIClient(object):
         self.auth_token: Optional[str] = auth_token
         self.url: str = url
         self.workspace_origin_url: Optional[str] = workspace_origin_url
-        self.is_lepton_classic: Optional[bool] = is_lepton_classic
         self.token_expires_at: Optional[int] = token_expires_at
 
-        if not self.is_lepton_classic and self.token_expires_at is not None:
+        if self.token_expires_at is not None:
             global HAS_WARNED_TOKEN_EXPIRE
             if not HAS_WARNED_TOKEN_EXPIRE:
                 now_ms = int(time.time() * 1000)
@@ -188,8 +176,7 @@ class APIClient(object):
             f"  id: {self.workspace_id}\n"
             f"  url: {self.url}\n"
             f"  auth_token: {self.auth_token[:2]}****{self.auth_token[-2:]}\n"
-            f"  workspace_origin_url: {self.workspace_origin_url}\n"
-            f"  is_lepton_classic: {self.is_lepton_classic}"
+            f"  workspace_origin_url: {self.workspace_origin_url}"
         )
 
         # In default, timeout for the API calls is set to 120 seconds.
@@ -322,8 +309,6 @@ class APIClient(object):
         """
         Returns the base dashboard URL derived from the current workspace URL.
         """
-        if self.is_lepton_classic:
-            return None
         base = (self.url or "").replace("://gateway", "://dashboard", 1)
         base = base.replace("/api/v2", "", 1)
         base = base.replace("/workspaces", "/workspace", 1)

--- a/leptonai/api/v2/utils.py
+++ b/leptonai/api/v2/utils.py
@@ -3,16 +3,13 @@ Utility functions for the Lepton AI API.
 """
 
 import requests
-from typing import Optional, Dict
+from typing import Optional
 
 from leptonai.config import (
     DGXC_WORKSPACE_API_PATH,
     DGXC_WORKSPACE_URL_RESOLVER_API,
-    WORKSPACE_URL_RESOLVER_API,
-    WORKSPACE_API_PATH,
     API_URL_BASE,
 )
-from leptonai.util import is_valid_url
 
 
 class WorkspaceError(RuntimeError):
@@ -99,9 +96,7 @@ def _print_workspace_not_created_yet_message(workspace_id: str):
     )
 
 
-def _get_workspace_display_name(
-    workspace_id, url=None, is_lepton_classic=False, token=None
-) -> Optional[str]:
+def _get_workspace_display_name(workspace_id, url=None, token=None) -> Optional[str]:
     """
     Gets the workspace display name from the given workspace_id. This calls Lepton's backend server
     to get the workspace display name.
@@ -112,20 +107,10 @@ def _get_workspace_display_name(
     :raises ValueError: if the workspace does not exist
     """
 
-    resolver_api = (
-        WORKSPACE_URL_RESOLVER_API
-        if is_lepton_classic
-        else DGXC_WORKSPACE_URL_RESOLVER_API + "/" + workspace_id
-    )
-    if url:
-        resolver_api = url
+    resolver_api = url or DGXC_WORKSPACE_URL_RESOLVER_API + "/" + workspace_id
 
-    if is_lepton_classic:
-        request_body = {"id": workspace_id}
-        res = requests.get(resolver_api, json=request_body)
-    else:
-        headers = {"Authorization": f"Bearer {token}"} if token else {}
-        res = requests.get(resolver_api, headers=headers)
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    res = requests.get(resolver_api, headers=headers)
 
     if not res.ok:
         raise RuntimeError(
@@ -139,8 +124,7 @@ def _get_workspace_display_name(
             raise RuntimeError(
                 "You hit a programming error: response is not a dictionary. Please"
                 " report this and include the following information: url:"
-                f" {WORKSPACE_URL_RESOLVER_API}, request_body: {request_body},"
-                f" response: {res}."
+                f" {resolver_api}, response: {res}."
             )
         return content["display_name"]
 
@@ -187,85 +171,14 @@ def _get_token_expires_at(workspace_id, url=None, token=None) -> Optional[int]:
         return min(candidate_expires)
 
 
-_workspace_url_cache: Dict[str, str] = {}
-
-
-def _get_full_workspace_url(workspace_id, cached=True, is_lepton_classic=False) -> str:
-    """
-    Gets the workspace url from the given workspace_id. This calls Lepton's backend server
-    to get the workspace url.
-
-    The workspace url is different from the workspace api url: the workspace url is the url
-    that the client uses to call deployments, while the workspace api url is used to call
-    the Lepton API.
-
-    :param str workspace_id: the workspace_id of the workspace
-    :return: the workspace url, or None if the workspace does not exist
-    :raises RuntimeError: if the backend server returns an error
-    :raises ValueError: if the workspace does not exist
-    """
-    if not is_lepton_classic:
-        return API_URL_BASE
-
-    # Process the lepton classic workspace url
-
-    if cached:
-        url = _workspace_url_cache.get(workspace_id)
-
-        if url is None or not is_valid_url(url):
-            url = _get_full_workspace_url(
-                workspace_id, cached=False, is_lepton_classic=is_lepton_classic
-            )
-            _workspace_url_cache[workspace_id] = url
-
-        return url
-    request_body = {"id": workspace_id}
-    res = requests.get(
-        WORKSPACE_URL_RESOLVER_API,
-        json=request_body,
-    )
-    if not res.ok:
-        raise RuntimeError(
-            f"Lepton server returned an error: {res.status_code} {res.content}."
-        )
-    elif res.content == b"":
-        raise RuntimeError(f"Cannot find the workspace with id {workspace_id}.")
-    else:
-        content = res.json()
-        if (not isinstance(content, dict)) or "url" not in content:
-            raise RuntimeError(
-                "You hit a programming error: response is not a dictionary. Please"
-                " report this and include the following information: url:"
-                f" {WORKSPACE_URL_RESOLVER_API}, request_body: {request_body},"
-                f" response: {res}."
-            )
-        elif content["url"] == "":
-            raise WorkspaceNotCreatedYet(workspace_id)
-        return content["url"]
-
-
-def _get_full_workspace_api_url(
-    workspace_id, cached=True, is_lepton_classic=False
-) -> str:
+def _get_full_workspace_api_url(workspace_id) -> str:
     """
     Get the full URL for the API of a workspace.
 
     :param str workspace_id: the workspace_id of the workspace
-    :return: the workspace api url, or None if the workspace does not exist
-    :raises RuntimeError: if the backend server returns an error
-    :raises ValueError: if the workspace does not exist
+    :return: the workspace api url
     """
-    workspace_api_path = (
-        DGXC_WORKSPACE_API_PATH if not is_lepton_classic else WORKSPACE_API_PATH
-    )
-
-    url = (
-        _get_full_workspace_url(workspace_id, cached, is_lepton_classic)
-        + workspace_api_path
-    )
-    if not is_lepton_classic:
-        url += workspace_id
-    return url
+    return API_URL_BASE + DGXC_WORKSPACE_API_PATH + workspace_id
 
 
 def _get_workspace_origin_url(url: str) -> str:

--- a/leptonai/api/v2/workspace_record.py
+++ b/leptonai/api/v2/workspace_record.py
@@ -35,7 +35,6 @@ class LocalWorkspaceInfo(BaseModel):
     display_name: Optional[str] = None
     auth_token: Optional[str] = None
     workspace_origin_url: Optional[str] = None
-    is_lepton_classic: Optional[bool] = False
     token_expires_at: Optional[int] = None
 
 
@@ -109,7 +108,6 @@ class WorkspaceRecord(object):
         auth_token: Optional[str] = None,
         url: Optional[str] = None,
         workspace_origin_url: Optional[str] = None,
-        is_lepton_classic: Optional[bool] = None,
         could_be_new_token: Optional[bool] = False,
     ):
         """
@@ -130,7 +128,7 @@ class WorkspaceRecord(object):
         )
 
         # _get_workspace_display_name is called in two scenarios:
-        # 1. Initial CLI login without URL (for both DGXC and CLASSIC workspaces will use default urls)
+        # 1. Initial CLI login without URL (will use the default resolver url)
         # 2. CLI login with URL (will use input url)
         #    Note: This works for DGXC as the resolver api URL matches the workspace URL.
         #    Future workspace types may require additional modifications.
@@ -139,17 +137,15 @@ class WorkspaceRecord(object):
                 display_name = _get_workspace_display_name(
                     workspace_id,
                     url=url,
-                    is_lepton_classic=is_lepton_classic,
                     token=auth_token,
                 )
             except RuntimeError as e:
                 logger.trace(
                     "Failed to fetch workspace display name"
-                    f" (workspace_id={workspace_id}, url={url},"
-                    f" is_lepton_classic={is_lepton_classic}): {e}"
+                    f" (workspace_id={workspace_id}, url={url}): {e}"
                 )
                 display_name = None
-        if token_expires_at is None and not is_lepton_classic:
+        if token_expires_at is None:
             try:
                 token_expires_at = _get_token_expires_at(
                     workspace_id,
@@ -163,9 +159,7 @@ class WorkspaceRecord(object):
                 )
                 token_expires_at = None
         if url is None:
-            url = _get_full_workspace_api_url(
-                workspace_id, is_lepton_classic=is_lepton_classic
-            )
+            url = _get_full_workspace_api_url(workspace_id)
         if not workspace_origin_url:
             workspace_origin_url = _get_workspace_origin_url(url)
         # Create workspace info with optional workspace_origin_url
@@ -175,7 +169,6 @@ class WorkspaceRecord(object):
             display_name=display_name,
             auth_token=auth_token,
             workspace_origin_url=workspace_origin_url,
-            is_lepton_classic=is_lepton_classic,
             token_expires_at=token_expires_at,
         )
         cls._singleton_record.current_workspace = workspace_id
@@ -188,7 +181,6 @@ class WorkspaceRecord(object):
         auth_token: Optional[str] = None,
         url: Optional[str] = None,
         workspace_origin_url: Optional[str] = None,
-        is_lepton_classic: Optional[bool] = None,
         could_be_new_token: Optional[bool] = False,
     ):
         """
@@ -201,7 +193,6 @@ class WorkspaceRecord(object):
                 auth_token,
                 url,
                 workspace_origin_url,
-                is_lepton_classic,
                 could_be_new_token,
             )
         except WorkspaceNotCreatedYet:
@@ -252,7 +243,6 @@ class WorkspaceRecord(object):
                 ws.auth_token,
                 ws.url,
                 ws.workspace_origin_url,
-                ws.is_lepton_classic,
             )
         else:
             raise ValueError(
@@ -296,7 +286,7 @@ class WorkspaceRecord(object):
         Returns the base dashboard URL derived from the current workspace URL.
         """
         info = cls.get(workspace_id) if workspace_id else cls.current()
-        if not info or info.is_lepton_classic:
+        if not info:
             return None
         base = (info.url or "").replace("://gateway", "://dashboard", 1)
         base = base.replace("/api/v2", "", 1)
@@ -321,7 +311,7 @@ class WorkspaceRecord(object):
             return cls.get(workspace_id).token_expires_at
 
         info = cls.get(workspace_id)
-        if not info or info.is_lepton_classic:
+        if not info:
             return None
         try:
             token_expires_at = _get_token_expires_at(

--- a/leptonai/cli/cli.py
+++ b/leptonai/cli/cli.py
@@ -94,12 +94,6 @@ finetune.add_command(lep)
     default=None,
 )
 @click.option(
-    "--lepton-classic",
-    "-l",
-    is_flag=True,
-    help="Login to the classic Lepton AI workspace.",
-)
-@click.option(
     "--workspace-origin-url",
     "-o",
     help="The origin url of the workspace to login to.",
@@ -116,7 +110,6 @@ finetune.add_command(lep)
 def login(
     credentials,
     workspace_url,
-    lepton_classic,
     workspace_origin_url,
     credentials_page_url,
 ):
@@ -135,19 +128,18 @@ def login(
             auth_token=auth_token,
             url=workspace_url,
             workspace_origin_url=workspace_origin_url,
-            is_lepton_classic=lepton_classic,
             could_be_new_token=True,
         )
     else:
-        if workspace_url or lepton_classic or workspace_origin_url:
+        if workspace_url or workspace_origin_url:
             console.print(
-                "[bold red]Invalid usage:[/bold red] --workspace-url,"
-                " --workspace-origin-url, and --lepton-classic must be used together"
+                "[bold red]Invalid usage:[/bold red] --workspace-url and"
+                " --workspace-origin-url must be used together"
                 " with --credentials.\n[white]Either provide credentials or remove"
                 " these options to avoid misconfiguring local"
                 " workspaces.[/white]\n[yellow]Example:[/yellow] [#76B900]lep login -c"
                 " <workspace_id>:<auth_token> [--workspace-url <url>]"
-                " [--workspace-origin-url <url>] [--lepton-classic][/]\n"
+                " [--workspace-origin-url <url>][/]\n"
             )
             sys.exit(1)
         if WorkspaceRecord.current():
@@ -159,8 +151,7 @@ def login(
                 f" {current_ws.url}\n  display_name: {current_ws.display_name}\n "
                 " auth_token:"
                 f" {current_ws.auth_token[:2]}****{current_ws.auth_token[-2:] if current_ws.auth_token else None}\n"
-                f"  workspace_origin_url: {current_ws.workspace_origin_url}\n "
-                f" is_lepton_classic: {current_ws.is_lepton_classic}"
+                f"  workspace_origin_url: {current_ws.workspace_origin_url}"
             )
         else:
             candidates = WorkspaceRecord.workspaces()
@@ -169,7 +160,7 @@ def login(
             elif len(candidates) == 1:
                 # Only one workspace, so we will simply log in to that one.
                 ws = candidates[0]
-                WorkspaceRecord.set_or_exit(ws.id_, ws.auth_token, ws.url, ws.workspace_origin_url, ws.is_lepton_classic)  # type: ignore
+                WorkspaceRecord.set_or_exit(ws.id_, ws.auth_token, ws.url, ws.workspace_origin_url)  # type: ignore
             else:
                 # multiple workspaces. login to one of them.
                 console.print("You have multiple workspaces. Please select one:")
@@ -188,7 +179,6 @@ def login(
                     candidates[choice].auth_token,
                     candidates[choice].url,
                     candidates[choice].workspace_origin_url,
-                    candidates[choice].is_lepton_classic,
                 )
                 console.print(
                     "[dim]Note: If you have multiple workspaces, you can pick the one"
@@ -220,8 +210,6 @@ def login(
             credentials_page_url = (
                 "https://dashboard.dgxc-lepton.nvidia.com/credentials"
             )
-            if lepton_classic:
-                credentials_page_url = "https://dashboard.lepton.ai/credentials"
 
         success = webbrowser.open(credentials_page_url)
         if not success:
@@ -297,10 +285,6 @@ def login(
         [white]Workspace ID:[/white] {e.workspace_id}
 
         [#76B900]If you are logging in with a fresh token, please wait for 2-3 minutes and try again.[/#76B900]
-
-        [white]Note: If you are trying to login to a Lepton classic workspace, please use:[/white]
-        [#76B900]'lep login -c <workspace-id>:<token> --lepton-classic'[/#76B900]
-        [white]Make sure to include the --lepton-classic or -l flag. (Ignore if you are DGXC User)[/white]
 
         [bold]To resolve this issue:[/bold]
             1. [#76B900]Verify your login credentials above.[/#76B900]

--- a/leptonai/cli/log.py
+++ b/leptonai/cli/log.py
@@ -245,26 +245,6 @@ def fetch_all_within_time_slot(
             cur_log_result.extend(cur_log_list)
 
 
-log_help_text = """
-    Manage and retrieve the logs history of specific jobs, deployments and replicas.\n
-    IMPORTANT: \n
-    - 'lep log get' and 'lep log get --path' are intended for quick, time-scoped viewing. \n
-    - They are NOT recommended for downloading logs \n
-    - Prefer using Workspace Dashboard -> Settings -> Logs Export for downloading
-      large-volume logs (jobs/endpoints long-running or with many replicas). \n
-    - Concurrency (workers) is applied only when --limit is NOT used. \n
-    - --limit is deprecated and not recommended. When set, logs will be fetched
-      sequentially without parallelism. It will be removed in a future release. \n 
-    - Interactive mode (next/last/time+/time-) is deprecated and not recommended.
-      It will be removed in a future release. \n
-
-    JOB DEFAULT TIME RANGE: \n
-    - For jobs, --start/--end can be omitted. If omitted, the job's creation_time
-      and completion_time (when available) will be used automatically; if the job
-      has not completed, end defaults to 'now'.
-"""
-
-
 @click_group()
 def log():
     """

--- a/leptonai/cli/workspace.py
+++ b/leptonai/cli/workspace.py
@@ -43,11 +43,6 @@ def workspace():
     default=None,
 )
 @click.option(
-    "--lepton-classic",
-    is_flag=True,
-    help="Login to the classic Lepton AI workspace.",
-)
-@click.option(
     "--workspace-origin-url",
     help=(
         "Internal option for setting the Origin header in API calls. Used for workspace"
@@ -60,7 +55,6 @@ def login(
     workspace_id: str,
     auth_token: Optional[str] = None,
     workspace_url: Optional[str] = None,
-    lepton_classic: bool = False,
     workspace_origin_url: Optional[str] = None,
 ):
     """
@@ -69,17 +63,17 @@ def login(
     if workspace_id is None:
         # If workspace_id is not given and current workspace is present, we will
         # simply print the info.
-        if auth_token or workspace_url or workspace_origin_url or lepton_classic:
+        if auth_token or workspace_url or workspace_origin_url:
             console.print(
                 "\n[bold red]Invalid usage:[/bold red] --auth-token,"
-                " --workspace-url,"
-                " --workspace-origin-url, and --lepton-classic must be used together"
+                " --workspace-url, and"
+                " --workspace-origin-url must be used together"
                 " with --workspace-id.\n[white]Either provide workspace id or remove"
                 " these options to avoid misconfiguring local"
                 " workspaces.[/white]\n[yellow]Example:[/yellow] [#76B900]lep workspace"
                 " login -i <workspace_id> [--auth-token <auth_token>]"
                 " [--workspace-url <url>]"
-                " [--workspace-origin-url <url>] [--lepton-classic][/]\n"
+                " [--workspace-origin-url <url>][/]\n"
             )
             sys.exit(1)
         if WorkspaceRecord.current():
@@ -96,7 +90,7 @@ def login(
                 could_be_new_token=True,
             )
         else:
-            WorkspaceRecord.set_or_exit(workspace_id, auth_token=info.auth_token, url=info.url, workspace_origin_url=info.workspace_origin_url, is_lepton_classic=lepton_classic)  # type: ignore
+            WorkspaceRecord.set_or_exit(workspace_id, auth_token=info.auth_token, url=info.url, workspace_origin_url=info.workspace_origin_url)  # type: ignore
     else:
         if not auth_token:
             console.print(
@@ -110,7 +104,6 @@ def login(
             auth_token=auth_token,
             url=workspace_url,
             workspace_origin_url=workspace_origin_url,
-            is_lepton_classic=lepton_classic,
             could_be_new_token=True,
         )
     # Try to login and print the info.
@@ -189,7 +182,6 @@ def list_command(debug):
     table.add_column("Expires")
     if debug:
         table.add_column("Origin URL")
-        table.add_column("Lepton classic")
     for info in workspace_list:
         name_text = info.display_name or ""
         id_text = info.id_ or ""
@@ -245,7 +237,6 @@ def list_command(debug):
         if debug:
             row_data.extend([
                 info.workspace_origin_url,
-                str(info.is_lepton_classic),
             ])
         table.add_row(*row_data)
     if current_workspace:

--- a/leptonai/config.py
+++ b/leptonai/config.py
@@ -27,17 +27,6 @@ VERSION_CHECK_INTERVAL_SEC: int = 60 * 60 * 24  # 24h
 # Configurations you can change to customize Lepton's behavior.
 ################################################################################
 
-# Whether to trust remote code. This is often used in model repositories such as
-# HuggingFace's tokenizer. In default, we will allow users to trust remote code
-# and run such tokenizers. Set the environment variable `LEPTON_TRUST_REMOTE_CODE`
-# to `false` to disable this behavior.
-TRUST_REMOTE_CODE = os.environ.get("LEPTON_TRUST_REMOTE_CODE", "true").lower() in (
-    "true",
-    "1",
-    "t",
-    "on",
-)
-
 # Whether to set deployments to have a default timeout of 1 hour. This is often
 # preferred in a development environment. Set the environment variable `LEPTON_DEFAULT_TIMEOUT`
 # to `false` to disable this behavior.
@@ -166,7 +155,6 @@ else:
 # If you are in need of accessing the cache directory, use the functions `create_cached_dir_if_needed()`
 # in `leptonai.utils`.
 CACHE_DIR = Path(os.environ.get("LEPTON_CACHE_DIR", Path.home() / ".cache" / "lepton"))
-DB_PATH = CACHE_DIR / "lepton.db"
 LOGS_DIR = CACHE_DIR / "logs"
 
 
@@ -212,16 +200,6 @@ except ValueError:
         "You have set an invalid value for LEPTON_TIMEOUT_KEEP_ALIVE."
         f" Using default value of {DEFAULT_TIMEOUT_KEEP_ALIVE} seconds."
     )
-
-# When the server is shut down, we will wait for all the ongoing requests to finish before
-# shutting down. This is the timeout for the graceful shutdown. If the timeout is
-# reached, we will force kill the server. If not set, this is the default that we will use.
-# Implementation note: None means we will use the default behavior of asyncio.
-DEFAULT_TIMEOUT_GRACEFUL_SHUTDOWN = (
-    int(os.environ["LEPTON_TIMEOUT_GRACEFUL_SHUTDOWN"])
-    if os.environ.get("LEPTON_TIMEOUT_GRACEFUL_SHUTDOWN")
-    else None
-)
 
 # During some deployment environments, the server might run behind a load balancer, and during
 # the shutdown time, the load balancer will send a SIGTERM to uvicorn to shut down the server.
@@ -280,9 +258,6 @@ def get_local_deployment_token() -> str:
         return _LOCAL_DEPLOYMENT_TOKEN
 
 
-# In a deployment template, this means you will need to specify env variables.
-ENV_VAR_REQUIRED = "PLEASE_ENTER_YOUR_ENV_VARIABLE_HERE_(LEPTON_ENV_VAR_REQUIRED)"
-
 # Valid resource shapes
 VALID_SHAPES = [
     "cpu.small",
@@ -325,7 +300,6 @@ LEPTON_RESERVED_ENV_NAMES = {
     "LEPTON_DEPLOYMENT_NAME",
     "LEPTON_RESOURCE_ACCELERATOR_TYPE",
     "LEPTON_WORKSPACE_ORIGIN_URL",
-    "LEPTON_CLASSIC",
 }
 
 if "LEPTON_ALLOW_ORIGINS" in os.environ:


### PR DESCRIPTION
## Summary

Lepton Classic workspaces are no longer supported (`is_lepton_classic` was always `False`), so this removes all related code paths, plus a few unused module-level variables left over from earlier refactors.

### Remove Lepton Classic support
- Drop the `--lepton-classic` / `-l` flag from `lep login` and `lep workspace login`, and `LEPTON_CLASSIC` env var support.
- Remove the `is_lepton_classic` parameter from `APIClient` and `WorkspaceRecord`, and the field from the stored workspace record. Existing `workspace_info.yaml` files stay compatible — pydantic v2 ignores the now-unknown key.
- Simplify `api/v2/utils.py`: drop the classic branch in `_get_workspace_display_name`, delete the dead `_get_full_workspace_url` + its cache, and reduce `_get_full_workspace_api_url` to the DGXC path.
- Remove the now-stale "Lepton Classic" comment in `api/v1/template.py`.

### Remove unused, non-exported variables
- `config.py`: `TRUST_REMOTE_CODE`, `DB_PATH`, `DEFAULT_TIMEOUT_GRACEFUL_SHUTDOWN`, `ENV_VAR_REQUIRED` (none referenced anywhere; the env-driven ones were computed-then-never-read, so removal is behavior-neutral).
- `cli/log.py`: orphaned `log_help_text` that just duplicated the `log` command group's docstring.

> Method: `ruff` (E/F) already confirmed no unused locals/imports; an AST scan restricted to module-level assignments + repo-wide `grep` verification found the dead constants. `leptonai/_version.py:version_tuple` was intentionally left alone (auto-generated by setuptools_scm, gitignored).

## Breaking changes
- `--lepton-classic` CLI flag removed.
- `is_lepton_classic` `APIClient`/SDK parameter removed.
- `LEPTON_CLASSIC` environment variable no longer honored.

## Test plan
- [x] `ruff check leptonai/` — clean
- [x] `import` smoke test of CLI + v2 API modules
- [x] `pytest leptonai/cli/tests/` — 17 passed
- [x] `grep is_lepton_classic` — 0 occurrences repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)