### PR TITLE
fix(cli): consistent empty-string error for --ip-whitelist

### DIFF
--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -322,13 +322,18 @@ def _parse_ip_whitelist(ip_whitelist_values):
 
 
 def _validate_ip_whitelist_flag_requires_value(ctx, param, value):
-    """Reject option-like tokens and validate IP/CIDR tokens for --ip-whitelist."""
+    """Reject option-like tokens for --ip-whitelist.
+
+    Empty or whitespace-only values are deliberately left to the global
+    empty-string guard (``_ValidatedCommand``) so the error message stays
+    consistent with other options such as ``--env``.
+    """
     if value is None:
         return value
 
     values = value if isinstance(value, tuple) else (value,)
     for v in values:
-        if not isinstance(v, str) or v.strip() == "" or v.strip().startswith("-"):
+        if not isinstance(v, str) or v.strip().startswith("-"):
             opt_name = (
                 param.opts[-1] if getattr(param, "opts", None) else "--ip-whitelist"
             )


### PR DESCRIPTION
## Problem

`lep endpoint create/update --ip-whitelist ''` returned a misleading parser-level error instead of the standard empty-value error used by other options:

```
$ lep endpoint create --name test --ip-whitelist '' --node-group ng
Error: Option '--ip-whitelist' requires an argument.
```

An argument *was* provided — it was just empty. Compare `--env`:

```
$ lep endpoint create --name test --env '' --node-group ng
Error: Invalid value for '--env' / '-e': contains empty value(s). Remove empty items.
```

## Root cause

`--ip-whitelist` has a callback `_validate_ip_whitelist_flag_requires_value` that rejected empty/whitespace values during click parsing and raised `Option ... requires an argument.`. Options like `--env` have no such callback, so their empty values fall through to the command-level `_ValidatedCommand` guard (`cli/util.py`), which raises the friendly `contains empty value(s). Remove empty items.` message.

## Fix

Remove the empty-string condition from the callback so empty/whitespace values fall through to `_ValidatedCommand`, yielding the same message as `--env`. The option-like token check (values starting with `-`) is preserved. The callback is shared by `endpoint create` and `endpoint update`, so both are fixed.

## Verification (`.venv/bin/lep`, all error before any API call)

| Command | Result |
|---|---|
| `create --env ''` (baseline) | `Invalid value for '--env' / '-e': contains empty value(s). Remove empty items.` |
| `create --ip-whitelist ''` | `Invalid value for '--ip-whitelist': contains empty value(s). Remove empty items.` ✅ |
| `create --ip-whitelist '   '` (whitespace) | same ✅ |
| `create --ip-whitelist 1.2.3.4 --ip-whitelist ''` (mixed) | same ✅ |
| `update -n test --ip-whitelist ''` | same ✅ |
| `create --ip-whitelist -foo` (option-like) | `Option '--ip-whitelist' requires an argument.` ✅ unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
