### PR TITLE
refactor(cli): remove client-side concurrent-update check on endpoint update

### DIFF
--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -2017,19 +2017,6 @@ def update(
             if not confirmed:
                 sys.exit(1)
 
-            replicas = client.deployment.get_replicas(lepton_deployment)
-
-            version_str_list = [lepton_deployment.metadata.semantic_version] + [
-                replica.metadata.semantic_version for replica in replicas
-            ]
-
-            updating_ongoing = not _same_major_version(version_str_list)
-            if updating_ongoing:
-                console.print(
-                    "[red]An update is in progress. Please try again later.[/]"
-                )
-                sys.exit(1)
-
             console.print("Proceeding with the update...")
 
     updated_lepton_deployment = client.deployment.update(


### PR DESCRIPTION
## What

Removes the client-side "update in progress" check in `lep deployment update`.

Previously, when an update would trigger a rolling restart, the CLI fetched all replicas and compared the **major version** of the deployment against every replica's version. If they diverged (a sign that a rolling restart was still converging), it aborted with:

> An update is in progress. Please try again later.

## Why

- Concurrent updates are already protected at the backend by Kubernetes optimistic locking (`resourceVersion`).
- The CLI check was a client-side heuristic that only ran for restart-inducing updates, and could be bypassed entirely by calling the SDK / API directly.

## What's kept

The rolling-restart confirmation prompt (*"This update will trigger a rolling restart. Are you sure you want to continue?"*) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)