### PR TITLE
refactor: remove deprecated use_hostname_for_hashing from MaglevLoadBalancer

### DIFF
--- a/leptonai/api/v1/types/ingress.py
+++ b/leptonai/api/v1/types/ingress.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from typing import Optional, List, Union, Dict, Any
 from loguru import logger
 
@@ -17,10 +17,7 @@ class LoadBalanceConfig(BaseModel):
 
 
 class MaglevLoadBalancer(BaseModel):
-    # Use hostname instead of resolved IP for hashing
-    use_hostname_for_hashing: Optional[bool] = Field(
-        default=None, alias="useHostnameForHashing"
-    )
+    pass
 
 
 class LeptonIngressEndpoint(BaseModel):

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -1952,22 +1952,18 @@ def update(
     if load_balance:
         lb = load_balance.lower()
         if lb == "least-request":
-            lepton_deployment_spec.load_balance_config = {
-                "least_request": {"choice_count": None},
-                "maglev": None,
-            }
+            lepton_deployment_spec.load_balance_config = LoadBalanceConfig(
+                least_request=LeastRequestLoadBalancer()
+            )
         elif lb == "sticky-routing":
-            lepton_deployment_spec.load_balance_config = {
-                "least_request": None,
-                "maglev": {},
-            }
+            lepton_deployment_spec.load_balance_config = LoadBalanceConfig(
+                maglev=MaglevLoadBalancer()
+            )
 
     if header_based_routing is not None:
-        lepton_deployment_spec.routing_policy = {
-            "enable_header_based_replica_routing": (
-                header_based_routing.lower() == "true"
-            ),
-        }
+        lepton_deployment_spec.routing_policy = LeptonRoutingPolicy(
+            enable_header_based_replica_routing=(header_based_routing.lower() == "true")
+        )
 
     # Set IP access control in auth_config (independent of tokens)
     if public is not None or len(ip_whitelist) > 0:

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -1959,7 +1959,7 @@ def update(
         elif lb == "sticky-routing":
             lepton_deployment_spec.load_balance_config = {
                 "least_request": None,
-                "maglev": {"useHostnameForHashing": None},
+                "maglev": {},
             }
 
     if header_based_routing is not None:


### PR DESCRIPTION
## What

Two related cleanups in the endpoint load-balancing code:

1. Remove the deprecated `use_hostname_for_hashing` field from `MaglevLoadBalancer`.
2. Make `endpoint update` build its load-balance / routing config from the proper pydantic models instead of raw dicts, matching `endpoint create`.

## Why

**(1)** The backend (`deployment-operator/api/v1alpha1/leptondeployment_types.go`) deprecated `MaglevLoadBalancer.useHostnameForHashing` and now **ignores it entirely** — hostname-based hashing is always enabled to keep session affinity consistent across Envoy instances. The Python model still carried the field, so this brings the client back in line with the backend contract.

**(2)** `update` constructed `load_balance_config` and `routing_policy` as raw dicts — one even nested a `MaglevLoadBalancer()` instance inside a plain dict. That is untyped (type checkers flag it) and only serializes correctly by relying on pydantic's implicit `Any`-coercion at dump time. `create` already uses the models, so `update` now does too.

## Changes

- `leptonai/api/v1/types/ingress.py`: drop the field; `MaglevLoadBalancer` is now an empty marker model (the now-unused `Field` import is removed too).
- `leptonai/cli/deployment.py`: `update` now uses `LoadBalanceConfig(...)` / `LeastRequestLoadBalancer()` / `MaglevLoadBalancer()` / `LeptonRoutingPolicy(...)` instead of hand-built dicts.

## Behavior

No wire-level change.

- The backend selects maglev purely by presence (`c != nil && c.Maglev != nil`), so an empty `{}` is the correct "use maglev" signal — identical in effect to the old payload, which only carried a field the backend already ignored.
- The model-based construction in `update` produces byte-identical `model_dump()` output to the previous raw dicts (verified for both load-balance branches and the routing policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)