### PR TITLE
chore: add pre-commit hooks for black + ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 
 # Translations
 *.mo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Auto-format and lint changed files before each commit.
+#
+# One-time setup per clone (after installing the dev deps):
+#   uv pip install -e ".[lint]"   # or: pip install -e ".[lint]"
+#   pre-commit install
+#
+# Run manually on the whole repo:
+#   pre-commit run --all-files
+#
+# Hook tool versions are kept in sync with the `lint` extra in pyproject.toml
+# so manual runs and the hook format identically.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.12.0
+    hooks:
+      - id: black

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,18 @@ pip install -e ".[lint]"
 Then run
 ```
 black .
-ruff .
+ruff check .
 ```
 to check code.
+
+### Auto-format on commit (recommended)
+
+This repo ships a [pre-commit](https://pre-commit.com/) config that runs `ruff --fix` and `black` on the files you are committing, so formatting stays consistent without having to remember to run it by hand.
+
+Installing `.[lint]` (above) installs the `pre-commit` tool, but the git hook is **not** active until you enable it **once per clone**:
+
+```shell
+pre-commit install
+```
+
+After that the hooks run automatically on `git commit`. If a hook reformats a file, the commit is aborted so you can review the change — just `git add` the updated files and commit again. To format the whole repo in one pass, run `pre-commit run --all-files`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ lep = "leptonai.cli:lep"
 [project.optional-dependencies]
 lint = [
     "black==23.12.0",
-    "ruff==0.5.7"
+    "ruff==0.5.7",
+    "pre-commit==4.6.0",
 ]
 test = [
     "pytest",


### PR DESCRIPTION
## What

Adds a pre-commit configuration that auto-formats and lints changed files before each commit, and documents the setup.

## Why

The repo pins `black` and `ruff` in the `lint` extra, but nothing enforced them at commit time, so formatting/style drift only got caught later (in CI or by hand). This wires them into the standard `pre-commit` framework so they run automatically on the files being committed.

## Changes

- `.pre-commit-config.yaml`: runs `ruff --fix` then `black` on changed Python files. Hook tool versions match the `lint` extra (ruff `v0.5.7`, black `23.12.0`) so hook and manual runs format identically. black/ruff still read `[tool.black]` (`preview = true`) and `[tool.ruff]` from `pyproject.toml`.
- `pyproject.toml`: pin `pre-commit==4.6.0` in the `lint` extra.
- `CONTRIBUTING.md`: document that installing `.[lint]` only provides the tool and that each clone must run `pre-commit install` once to activate the hook; also fix the stale `ruff .` → `ruff check .`.
- `.gitignore`: ignore `.ruff_cache/`.

## Setup (once per clone)

```
uv pip install -e ".[lint]"   # or: pip install -e ".[lint]"
pre-commit install
```

## Behavior

pre-commit runs only on staged files. If black/ruff modify a file, the commit aborts with "files were modified by this hook" — re-`git add` the formatted file and commit again. Run `pre-commit run --all-files` to format the whole repo once.

Note: CI already runs `black --check .` / `ruff check .`, so formatting stays enforced even for contributors who never run `pre-commit install`; the hook just gives earlier, local feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)