### PR TITLE
fix(cli): validate integer options that silently accepted negative/zero values

### DIFF
--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -553,7 +553,7 @@ def _create_workspace_token_secret_var_if_not_existing(client: APIClient):
 )
 @click.option(
     "--min-replicas",
-    type=int,
+    type=click.IntRange(min=0),
     help="(Will be deprecated soon) Minimum number of replicas.",
     default=1,
 )
@@ -716,7 +716,7 @@ def _create_workspace_token_secret_var_if_not_existing(client: APIClient):
     "--replicas-static",
     "-r",
     "-replicas",
-    type=int,
+    type=click.IntRange(min=0),
     default=None,
     help="""
                 Use this option if you want a fixed number of replicas and want to turn off autoscaling.
@@ -1568,7 +1568,7 @@ def log(name, replica):
         " will show the endpoint to be `not ready` until you scale it"
         " back with a positive number of replicas."
     ),
-    type=int,
+    type=click.IntRange(min=0),
     default=None,
 )
 @click.option(
@@ -1636,7 +1636,7 @@ def log(name, replica):
     "--replicas-static",
     "-r",
     "-replicas",
-    type=int,
+    type=click.IntRange(min=0),
     default=None,
     help="""
                 Use this option if you want a fixed number of replicas and want to turn off autoscaling.

--- a/leptonai/cli/finetune.py
+++ b/leptonai/cli/finetune.py
@@ -331,8 +331,18 @@ def _print_finetune_jobs_table(jobs, dashboard_base_url: Optional[str] = None):
 @click.option(
     "--created-by", type=str, required=False, help="Filter by creator email (single)."
 )
-@click.option("--page", type=int, required=False, help="Page number (1-based).")
-@click.option("--page-size", type=int, required=False, help="Items per page.")
+@click.option(
+    "--page",
+    type=click.IntRange(min=1),
+    required=False,
+    help="Page number (1-based).",
+)
+@click.option(
+    "--page-size",
+    type=click.IntRange(min=1),
+    required=False,
+    help="Items per page.",
+)
 @click.option(
     "--include-archived",
     "-ia",
@@ -503,7 +513,7 @@ def list_trainers_command():
         "[job] Number of workers to use for the job. For distributed execution, set"
         " > 1."
     ),
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
 )
 @click.option(
@@ -513,7 +523,7 @@ def list_trainers_command():
         " num_workers, and num_workers % segment_count == 0. Workers within the same"
         " segment are scheduled into one NVL72 domain."
     ),
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
 )
 @click.option(

--- a/leptonai/cli/job.py
+++ b/leptonai/cli/job.py
@@ -357,7 +357,7 @@ def job():
         "Number of workers to use for the job. For example, when you do a distributed"
         " training job of 4 replicas, use --num-workers 4."
     ),
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
 )
 @click.option(
@@ -367,7 +367,7 @@ def job():
         " num_workers, and num_workers % segment_count == 0. Workers within the same"
         " segment are scheduled into one NVL72 domain."
     ),
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
 )
 

--- a/leptonai/cli/log.py
+++ b/leptonai/cli/log.py
@@ -330,7 +330,7 @@ def log():
 )
 @click.option(
     "--limit",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help="[Deprecated] This option is deprecated and not recommended.",
     hidden=True,


### PR DESCRIPTION
## Problem

Several CLI int options were declared as bare `type=int` with no bounds, so they silently accepted nonsensical negative/zero values. The reported case was `lep log get --limit`:

- `lep log get -j <job> --limit 0` → returns 0 lines, exit code 0
- `lep log get -j <job> --limit -1` → returns 0 lines, exit code 0

(the deprecated legacy path loops on `while cur_limit > 0`, so a non-positive limit just yields empty output). The same class of bug exists on other options.

## Fix

Add `click.IntRange` bounds, mirroring the existing `--workers` option (`click.IntRange(1, 128)`). Defaults stay `None`, and Click does not range-check `None`, so the normal (option-omitted) flow is unchanged.

**`min=1` — must be positive (negative/zero invalid):**

| File | Option |
|------|--------|
| `log.py` | `lep log get --limit` (the reported issue) |
| `finetune.py` / `job.py` | `--num-workers`, `--segment-count` |
| `finetune.py` | `--page` (1-based), `--page-size` |

**`min=0` — scale-to-zero is valid, only reject negative:**

| File | Option |
|------|--------|
| `deployment.py` | `--min-replicas`, `--replicas-static` (both `create` and `update`) |

## Verification

Smoke-tested via the CLI (validation happens before any network call):

- `--limit 0` / `--limit -1` → `Error: Invalid value for '--limit': ... is not in the range x>=1.`, exit 2
- `--num-workers 0`, `--segment-count 0`, `--page 0`, `--page-size -5` → rejected with range error
- `--min-replicas -1`, `--replicas-static -3` → rejected (`x>=0`)
- `--min-replicas 0` → accepted (scale-to-zero preserved)
- valid values (`--num-workers 4`, omitted options) → unaffected

Out of scope (would need backend contract confirmation for exact bounds): `--ingress-timeout-seconds` (doc says 300-6000), `--target-gpu-utilization`, `--shared-memory-size`, and other size/timeout options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)