### PR TITLE
fix(cli): sync workload state enums with backend so real states aren't shown as "UNK"

### DIFF
--- a/leptonai/api/v1/types/deployment.py
+++ b/leptonai/api/v1/types/deployment.py
@@ -307,15 +307,23 @@ class LeptonDeploymentUserSpec(BaseModel):
         return v
 
 
+# Keep in sync with the backend's authoritative LeptonDeploymentState enum
+# (deployment-operator/api/v1alpha1/leptondeployment_types.go). Any value missing
+# here falls through to `_missing_` and collapses to Unknown, which previously hid
+# real states such as "Error" from the CLI (shown as a cryptic "UNK").
 class LeptonDeploymentState(str, Enum):
     Ready = "Ready"
     NotReady = "Not Ready"
     Starting = "Starting"
     Updating = "Updating"
-    Deleting = "Deleting"
+    Scaling = "Scaling"
+    Migrating = "Migrating"
     Stopping = "Stopping"
     Stopped = "Stopped"
-    Scaling = "Scaling"
+    Deleting = "Deleting"
+    Restarting = "Restarting"
+    Error = "Error"
+    # Backend represents the unknown state as an empty string ("").
     Unknown = "UNK"
 
     @classmethod

--- a/leptonai/api/v1/types/job.py
+++ b/leptonai/api/v1/types/job.py
@@ -102,6 +102,7 @@ class LeptonJobState(str, Enum):
     Queueing = "Queueing"
     Awaiting = "Awaiting"
     PendingRetry = "PendingRetry"
+    Terminating = "Terminating"
     Unknown = "UNK"
 
     @classmethod

--- a/leptonai/cli/util.py
+++ b/leptonai/cli/util.py
@@ -743,10 +743,16 @@ def _stringify_state(state: Optional[Union[str, Any]]) -> str:
 
 
 def colorize_state(state: Optional[Union[str, Any]]) -> str:
-    """Return rich-markup colored state string (green for Ready/Running)."""
+    """Return rich-markup colored state string.
+
+    Green for healthy states (Ready/Running), red for failure states
+    (Error/Failed), yellow for any other non-empty transitional state.
+    """
     text = _stringify_state(state)
     if text in {"Ready", "Running"}:
         return f"[green]{text}[/]"
+    if text in {"Error", "Failed"}:
+        return f"[red]{text}[/]"
     return f"[yellow]{text}[/]" if text and text != "-" else "-"
 
 

--- a/leptonai/cli/util.py
+++ b/leptonai/cli/util.py
@@ -745,11 +745,11 @@ def _stringify_state(state: Optional[Union[str, Any]]) -> str:
 def colorize_state(state: Optional[Union[str, Any]]) -> str:
     """Return rich-markup colored state string.
 
-    Green for healthy states (Ready/Running), red for failure states
-    (Error/Failed), yellow for any other non-empty transitional state.
+    Green for healthy/success states (Ready/Running/Completed), red for failure
+    states (Error/Failed), yellow for any other non-empty transitional state.
     """
     text = _stringify_state(state)
-    if text in {"Ready", "Running"}:
+    if text in {"Ready", "Running", "Completed"}:
         return f"[green]{text}[/]"
     if text in {"Error", "Failed"}:
         return f"[red]{text}[/]"


### PR DESCRIPTION
## Problem

`lep pod list` showed a dev pod's state as a cryptic `UNK` while the UI showed `Error` for the same workload (reported on staging `stagws02`, pod `test-logs-to-grafana-cloud-2`).

Root cause: the CLI's status enums had drifted from the backend's authoritative enums. `LeptonDeploymentState` was missing `Error`, `Migrating` and `Restarting`; `LeptonJobState` was missing `Terminating`. Both enums route any unrecognized value through `_missing_` → `Unknown`, whose value is `"UNK"`. So when the backend returned `Error`, the CLI couldn't recognize it and collapsed it to `UNK` — inconsistent with the UI and unclear to users.

## Fix

Add the missing states so the Python enums mirror the authoritative Go definitions:

- `LeptonDeploymentState` (← `deployment-operator/api/v1alpha1/leptondeployment_types.go`): add `Migrating`, `Restarting`, `Error`.
- `LeptonJobState` (← `deployment-operator/api/v1alpha1/leptonjob_types.go`): add `Terminating`.

`Unknown` intentionally keeps the `"UNK"` fallback — the backend represents the genuinely-unknown state as an empty string, and `"UNK"` only surfaces for that rare/edge case now.

After the change, both enums are verified in sync with the backend (11/11 deployment states, 14/14 job states), so the CLI displays the same state as the UI (e.g. `Error` instead of `UNK`).

## Test

- Verified each backend state string maps to the correct enum member (no longer collapses to `Unknown`).
- `colorize_state` renders the real state text (e.g. `Error`).
- `black` + `ruff` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)