### PR TITLE
fix(pod): preserve container command for dev pods

### DIFF
--- a/leptonai/api/v1/pod.py
+++ b/leptonai/api/v1/pod.py
@@ -26,13 +26,12 @@ class PodAPI(APIResourse):
             return None
         if not spec.is_pod:
             raise ValueError("The spec is not a pod spec.")
-        if spec.container and (spec.container.ports or spec.container.command):
+        if spec.container and spec.container.ports:
             warnings.warn(
-                "Container port and command fields do not take effect in pod spec.",
+                "Container port field does not take effect in pod spec.",
                 RuntimeWarning,
             )
             spec.container.ports = None
-            spec.container.command = None
         if spec.resource_requirement:
             if spec.resource_requirement.min_replicas not in (None, 1):
                 warnings.warn(

--- a/leptonai/tests/test_pod.py
+++ b/leptonai/tests/test_pod.py
@@ -1,0 +1,58 @@
+import unittest
+import warnings
+
+from leptonai.api.v1.pod import PodAPI
+from leptonai.api.v1.types.deployment import (
+    ContainerPort,
+    LeptonContainer,
+    LeptonDeploymentUserSpec,
+)
+
+
+class TestSanityCheckPodSpec(unittest.TestCase):
+    def setUp(self):
+        # _sanity_check_pod_spec does not touch the API client, so we can build a
+        # bare PodAPI instance without a workspace connection.
+        self.api = PodAPI.__new__(PodAPI)
+
+    def test_container_command_is_preserved(self):
+        # The pod sanity check used to unconditionally strip the container
+        # command (a guard from 2024 when the backend ignored pod commands).
+        # The backend now honors a user-provided command, so the guard must
+        # not drop it -- otherwise a dev pod always falls back to the backend
+        # default ["sleep", "infinity"] no matter what the user requested.
+        command = ["/bin/bash", "-c", "echo DATADOG_POD_MARKER && sleep 120"]
+        spec = LeptonDeploymentUserSpec(
+            is_pod=True,
+            container=LeptonContainer(image="ubuntu", command=list(command)),
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            checked = self.api._sanity_check_pod_spec(spec)
+
+        self.assertIsNotNone(checked)
+        self.assertEqual(checked.container.command, command)
+
+    def test_container_ports_are_stripped(self):
+        # Ports still do not take effect for pods (no service/ingress), so they
+        # should continue to be dropped with a warning.
+        spec = LeptonDeploymentUserSpec(
+            is_pod=True,
+            container=LeptonContainer(
+                image="ubuntu",
+                command=["/bin/bash", "-c", "sleep 1"],
+                ports=[ContainerPort(container_port=8080)],
+            ),
+        )
+
+        with self.assertWarns(RuntimeWarning):
+            checked = self.api._sanity_check_pod_spec(spec)
+
+        self.assertIsNone(checked.container.ports)
+        # Command must survive even when ports are present and stripped.
+        self.assertEqual(checked.container.command, ["/bin/bash", "-c", "sleep 1"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`lep pod create --container-command ...` is accepted and pod creation succeeds, but the resulting pod spec never contains the requested command — `lep pod get` always shows `["sleep", "infinity"]`. The pod therefore never runs the requested command and can't emit the expected log marker, so the Datadog log-export validation for dev pods fails (`T5277297`, `test_verify_logs_in_datadog[dev_pod]`).

## Root cause

`PodAPI._sanity_check_pod_spec()` (`leptonai/api/v1/pod.py`) unconditionally cleared `spec.container.command` before the create request was sent. With no command in the spec, the backend applies its default for the unset entrypoint type — `["sleep", "infinity"]` for unknown images such as `ubuntu`.

The CLI itself builds the command correctly (`["/bin/bash", "-c", <cmd>]`); the API layer was throwing it away.

## Why this surfaced now (not a regression)

This is a **long-standing latent bug**, not a regression:

- The guard dates to **2024-06** (`816ed69`), when the backend genuinely ignored pod commands — stripping + warning was correct then.
- The backend has honored a user-provided command for the **default/unset entrypoint type** since **2025-05** (lep-1 `d1d69ae0e5`, "still use custom command for old frontend"). At that point this CLI guard silently became wrong.
- It only surfaced now because `test_verify_logs_in_datadog[dev_pod]` is the first workflow that actually requires a dev pod to *run a specific command*. Dev pods were previously used interactively (the default command sets up sshd/jupyter), so nobody passed `--container-command` and the stripping had no visible effect.

The Python `LeptonContainer` model has no `entrypoint_type` field, so requests always hit the backend's default branch — which preserves a non-nil command. So simply not stripping the command is sufficient; no `entrypoint_type=Custom` is needed.

## Fix

- Stop clearing `spec.container.command`.
- Keep stripping `ports` (pods have no service/ingress, so container ports still don't apply); the warning is narrowed to ports only.
- Add regression tests in `leptonai/tests/test_pod.py`.

## Verification

```
$ .venv/bin/python -m pytest leptonai/tests/test_pod.py -q
2 passed
```

End-to-end repro from the issue now preserves and runs the requested command (`lep pod get` shows the user's `bash -c "..."` instead of `["sleep", "infinity"]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)