### PR TITLE
chore: NVIDIA DGX Cloud rebrand and release-workflow doc rewrite

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,2 @@
-Copyright 2023 Lepton AI Inc
+Copyright 2025 NVIDIA Inc.
+Copyright 2023 Lepton AI Inc.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,70 @@
+# Release Workflow for Python SDK
+
+## How the version is determined
+
+The package version is **not** stored in any source file. It is derived from the
+latest git tag by [`setuptools_scm`](https://github.com/pypa/setuptools-scm)
+(configured under `[tool.setuptools_scm]` in `pyproject.toml`, which writes
+`leptonai/_version.py` at build time). `leptonai/_version.py` is auto-generated —
+do not edit it, and do not commit changes to it.
+
+Bumping the version therefore means creating a git tag; there is no source file to
+edit when cutting a release.
+
+## Releasing an SDK & CLI python package
+
+To release, you tag a commit on `main` and let the release workflow build and
+publish the wheel from that tag.
+
+### 1. Choose the commit and version
+
+- Check out and update main: `git checkout main && git pull`.
+- Make sure the working tree is clean.
+- Pick the new version `<major>.<minor>.<patch>`. To see the current latest,
+  run `git tag --sort=-v:refname | head` or check
+  https://github.com/leptonai/leptonai/tags. Tags use a plain numeric form with
+  **no `v` prefix** (e.g. `0.27.4`).
+
+### 2. Tag and push
+
+- Tag the exact commit you want to release: `git tag <major>.<minor>.<patch>`
+- Push the tag: `git push origin <major>.<minor>.<patch>`
+
+> Important: the release workflow must build from the tagged commit. `setuptools_scm`
+> produces a clean version (e.g. `0.27.4`) only when `HEAD` is exactly on the tag.
+> Building from a commit that is N commits ahead of the tag yields a dev version
+> like `0.27.4.post1.devN+g<sha>`, which is not a publishable release.
+
+### 3. Create release notes
+
+- Go to https://github.com/leptonai/leptonai/releases and click "Draft a new release".
+- Select the tag you just pushed, choose "Generate release notes", and publish.
+
+### 4. Publish to PyPI
+
+- Go to https://github.com/leptonai/leptonai/actions/workflows/release.yaml
+- Click "Run workflow" in the top right corner.
+  - Click the ref selector, open the "Tags" tab, and choose the tag you just
+    created (`<major>.<minor>.<patch>`). Do **not** run it on `main` (see the note
+    above about dev versions).
+  - Enable "Whether publish to PyPI". Optionally enable "Is this a release package"
+    and "Whether run end to end testing".
+  - Run the workflow and wait for it to finish. The `publish-pypi` job builds the
+    wheel (version comes from the tag) and uploads it to PyPI via `twine`.
+
+That concludes the release.
+
+For a quick verification, in a pristine environment, do:
+```
+pip install -U leptonai
+lep -v
+```
+and see if the version is correct.
+
+## Test instructions for CLI
+
+Run the script [here](https://github.com/leptonai/lepton/blob/main/sdk/release_scripts/e2e_sdk_cli_test.sh) and make sure all tests pass as the terminal output shows:
+ 
+```shell
+All tests finished. Errors so far = 0
+```

--- a/leptonai/api/v1/client.py
+++ b/leptonai/api/v1/client.py
@@ -51,7 +51,7 @@ class APIClient(object):
         order:
         - If workspace_id is given, log in to the given workspace. Workspace id could
         also include the token as a complete credential string, which you can obtain
-        from https://dashboard.lepton.ai/credentials.
+        from https://dashboard.dgxc-lepton.nvidia.com/credentials.
         - If workspace_id is not given, but there is LEPTON_WORKSPACE_ID in the environment,
         log into that workspace. We will look for LEPTON_WORKSPACE_TOKEN as the auth token,
         and LEPTON_WORKSPACE_URL as the workspace url, if they exist.

--- a/leptonai/api/v1/client.py
+++ b/leptonai/api/v1/client.py
@@ -76,8 +76,8 @@ class APIClient(object):
                 "You must specify workspace_id or set LEPTON_WORKSPACE_ID in the"
                 " environment, or use commandline `lep login` to log in to a "
                 " workspace. If you do not know your workspace credentials, go to"
-                " https://dashboard.lepton.ai/credentials and login with the"
-                " credential string."
+                " https://dashboard.dgxc-lepton.nvidia.com/credentials and login with"
+                " the credential string."
             )
         # If workspace_id contains colon, it is a credential that also contains the token.
         if ":" in workspace_id and not auth_token:

--- a/misc/benchmark/README.md
+++ b/misc/benchmark/README.md
@@ -16,4 +16,4 @@ python run.py \
 
 If you are benchmarking lepton endpoints and you are logged in, you can use `lep ws token` to obtain the workspace token.
 
-To find the list of `OPENAI_COMPATIBLE_API_BASE` provided by Lepton AI, please refer to the [documentation page](https://www.lepton.ai/references/llm_models).
+To find the list of `OPENAI_COMPATIBLE_API_BASE` provided by Lepton AI, please refer to the [documentation page](https://docs.nvidia.com/dgx-cloud/lepton/references/llm_models).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "leptonai"
-description = "NVIDIA DGCX Lepton AI Platform, SDK and CLI"
+description = "NVIDIA DGXC Lepton AI Platform, SDK and CLI"
 authors = [{name = "Lepton Contributors"}]
 dynamic = ["version"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "leptonai"
-description = "Lepton AI Platform"
-authors = [{name = "Lepton AI Inc.", email = "dev@lepton.ai"}]
+description = "NVIDIA DGCX Lepton AI Platform, SDK and CLI"
+authors = [{name = "Lepton Contributors"}]
 dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.9,<3.14"
@@ -23,7 +23,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://lepton.ai"
+Homepage = "https://docs.nvidia.com/dgx-cloud/lepton"
 
 [project.scripts]
 lep = "leptonai.cli:lep"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "leptonai"
-description = "NVIDIA DGXC Lepton AI Platform, SDK and CLI"
+description = "NVIDIA DGX Cloud Lepton AI Platform, SDK and CLI"
 authors = [{name = "Lepton Contributors"}]
 dynamic = ["version"]
 readme = "README.md"


### PR DESCRIPTION
Two housekeeping changes bundled together.

## 1. Rebrand Lepton references to NVIDIA DGX Cloud

User-facing strings only; no behavior change.

- **NOTICE**: add NVIDIA copyright line
- **pyproject.toml**: `description`, `authors`, and `Homepage` URL
- **leptonai/api/v1/client.py**: login-credentials dashboard URL → `https://dashboard.dgxc-lepton.nvidia.com/credentials`
- **misc/benchmark/README.md**: docs link → NVIDIA docs

## 2. Rewrite the release workflow doc (`docs/workflow.md`)

The doc still described the removed photon-era flow (editing `BASE_IMAGE_VERSION`, building runner images via `docker.yaml`, a non-existent S3 publish step). The package version is now derived purely from the git tag by `setuptools_scm`, so:

- there is no source file to edit; bump the version by creating a git tag
- publish from that tag via `release.yaml`
- documents the pitfall that the workflow must build from the tagged commit, or `setuptools_scm` produces a dev version

🤖 Generated with [Claude Code](https://claude.com/claude-code)