### PR TITLE
fix(pod): preserve container ports for dev pods

### DIFF
--- a/leptonai/api/v2/pod.py
+++ b/leptonai/api/v2/pod.py
@@ -26,12 +26,6 @@ class PodAPI(APIResourse):
             return None
         if not spec.is_pod:
             raise ValueError("The spec is not a pod spec.")
-        if spec.container and spec.container.ports:
-            warnings.warn(
-                "Container port field does not take effect in pod spec.",
-                RuntimeWarning,
-            )
-            spec.container.ports = None
         if spec.resource_requirement:
             if spec.resource_requirement.min_replicas not in (None, 1):
                 warnings.warn(

--- a/leptonai/tests/test_pod.py
+++ b/leptonai/tests/test_pod.py
@@ -34,23 +34,25 @@ class TestSanityCheckPodSpec(unittest.TestCase):
         self.assertIsNotNone(checked)
         self.assertEqual(checked.container.command, command)
 
-    def test_container_ports_are_stripped(self):
-        # Ports still do not take effect for pods (no service/ingress), so they
-        # should continue to be dropped with a warning.
+    def test_container_ports_are_preserved(self):
+        # Pods support container port exposure (hostmap/proxy strategies) since
+        # the container port exposure strategy feature, so the sanity check must
+        # not strip ports from the spec.
+        ports = [ContainerPort(container_port=8080)]
         spec = LeptonDeploymentUserSpec(
             is_pod=True,
             container=LeptonContainer(
                 image="ubuntu",
                 command=["/bin/bash", "-c", "sleep 1"],
-                ports=[ContainerPort(container_port=8080)],
+                ports=list(ports),
             ),
         )
 
-        with self.assertWarns(RuntimeWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             checked = self.api._sanity_check_pod_spec(spec)
 
-        self.assertIsNone(checked.container.ports)
-        # Command must survive even when ports are present and stripped.
+        self.assertEqual(checked.container.ports, ports)
         self.assertEqual(checked.container.command, ["/bin/bash", "-c", "sleep 1"])
 
 


### PR DESCRIPTION
## Problem

QA case T5360023 (`lep pod create --container-port` → `lep pod get` echoes the port in `spec`) regressed: `container_ports` disappeared from the returned spec.

Root cause is a stale guard, not new code:

- `_sanity_check_pod_spec` has stripped `container.ports` since 2024 (#407), when pods genuinely ignored ports.
- #614 added the container port exposure strategy feature — pods now support `hostmap` (host port mapped on node IP) and `proxy` (public URL) strategies, and the backend operator explicitly implements both for dev pods (`HostPortMapping` / `IngressProxy`).
- The old `photon.run` create path never ran the sanity check, so the strip stayed dormant. When #765 switched `lep pod create` to `pod.create`, the check kicked in and silently dropped user-configured ports — right after the CLI printed `Configured container ports: ...`.

## Fix

Remove the `container.ports` strip from `_sanity_check_pod_spec`. The remaining checks (min/max_replicas, auto_scaler, api_tokens) still hold for pods and are unchanged. The unit test asserting the old strip behavior is flipped to assert ports survive with no warning.

## Verification

- Unit tests pass (`leptonai/tests/test_pod.py`).
- End-to-end on a dev workspace: `lep pod create -n wz-port-probe --container-image nginx --resource-shape cpu.small -ng hsuan-dev-cpu --container-port 8080:tcp:proxy`, then `lep pod get` returns:

```json
"container": {
  "image": "nginx",
  "ports": [
    { "container_port": 8080, "expose_strategies": ["IngressProxy"], "protocol": "TCP" }
  ],
  ...
}
```

and `status.container_port_status` carries the generated proxy URL, confirming ports are meaningful for pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)