### PR TITLE
fix: fix workspace url mismatch

### DIFF
--- a/leptonai/cli/cli.py
+++ b/leptonai/cli/cli.py
@@ -10,8 +10,10 @@ from leptonai.api.v2.utils import (
     WorkspaceUnauthorizedError,
     WorkspaceNotFoundError,
     WorkspaceForbiddenError,
+    _get_full_workspace_api_url,
 )
 from .util import console
+from leptonai.api.v2.client import APIClient
 from leptonai.api.v2.workspace_record import WorkspaceRecord
 from loguru import logger
 from rich.prompt import Prompt
@@ -121,10 +123,12 @@ def login(
     """
     console.print(LOGIN_LOGO)
     need_further_login = False
+    # Login info pending verification; persisted only after info() succeeds.
+    pending_login = None
     if credentials:
         workspace_id, auth_token = credentials.split(":", 1)
-        WorkspaceRecord.set_or_exit(
-            workspace_id,
+        pending_login = dict(
+            workspace_id=workspace_id,
             auth_token=auth_token,
             url=workspace_url,
             workspace_origin_url=workspace_origin_url,
@@ -160,7 +164,12 @@ def login(
             elif len(candidates) == 1:
                 # Only one workspace, so we will simply log in to that one.
                 ws = candidates[0]
-                WorkspaceRecord.set_or_exit(ws.id_, ws.auth_token, ws.url, ws.workspace_origin_url)  # type: ignore
+                pending_login = dict(
+                    workspace_id=ws.id_,
+                    auth_token=ws.auth_token,
+                    url=ws.url,
+                    workspace_origin_url=ws.workspace_origin_url,
+                )
             else:
                 # multiple workspaces. login to one of them.
                 console.print("You have multiple workspaces. Please select one:")
@@ -174,11 +183,12 @@ def login(
                 except ValueError:
                     console.print("Invalid choice. Please enter a number.")
                     sys.exit(1)
-                WorkspaceRecord.set_or_exit(
-                    candidates[choice].id_,  # type: ignore
-                    candidates[choice].auth_token,
-                    candidates[choice].url,
-                    candidates[choice].workspace_origin_url,
+                chosen = candidates[choice]
+                pending_login = dict(
+                    workspace_id=chosen.id_,  # type: ignore
+                    auth_token=chosen.auth_token,
+                    url=chosen.url,
+                    workspace_origin_url=chosen.workspace_origin_url,
                 )
                 console.print(
                     "[dim]Note: If you have multiple workspaces, you can pick the one"
@@ -236,19 +246,36 @@ def login(
             auth_token = parts[1]
             base_url = parts[2] if len(parts) == 3 else None
             print(f"base_url: {base_url}")
-            WorkspaceRecord.set_or_exit(
-                workspace_id,
+            pending_login = dict(
+                workspace_id=workspace_id,
                 auth_token=auth_token,
                 url=base_url,
                 could_be_new_token=True,
             )
         else:
             workspace_id, auth_token = credentials.split(":", 1)
-            WorkspaceRecord.set_or_exit(
-                workspace_id, auth_token=auth_token, could_be_new_token=True
+            pending_login = dict(
+                workspace_id=workspace_id,
+                auth_token=auth_token,
+                could_be_new_token=True,
             )
-    # Try to login and print the info.
-    api_client = WorkspaceRecord.client()
+
+    # Verify workspace access first; the record is persisted only after the
+    # verification succeeds, so a failed login does not pollute local records
+    # or switch the current workspace.
+    if pending_login is not None:
+        if pending_login.get("url") is None:
+            pending_login["url"] = _get_full_workspace_api_url(
+                pending_login["workspace_id"]
+            )
+        api_client = APIClient(
+            pending_login["workspace_id"],
+            pending_login["auth_token"],
+            pending_login["url"],
+            pending_login.get("workspace_origin_url"),
+        )
+    else:
+        api_client = WorkspaceRecord.client()
 
     try:
         # Retry info() in case the new token is not yet propagated.
@@ -258,17 +285,6 @@ def login(
                 if retries == 16:
                     console.print("[bold]Loading workspace...[/bold]")
                 info = api_client.info()
-                ws_name = info.workspace_name
-                tier = info.workspace_tier
-
-                indent = " " * 17  # match logo's left margin for alignment
-                console.print(f"{indent}{'Workspace':>12}: [#76B900]{ws_name}[/]")
-                console.print(f"{indent}{'Tier':>12}: {tier}")
-                WorkspaceRecord.refresh_token_expires_at(skip_if_token_exists=True)
-                version_info_list = api_client.version(info)
-                if version_info_list is not None:
-                    version = ".".join(str(v) for v in version_info_list)
-                    console.print(f"{indent}{'Version':>12}: {version}\n")
                 break
             except WorkspaceUnauthorizedError:
                 retries -= 1
@@ -327,15 +343,32 @@ def login(
     except WorkspaceForbiddenError as e:
         console.print("\n", e)
 
-        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         console.print(f"""
-        [red bold]Workspace Forbidden access[/]
+        [red bold]Workspace Access Forbidden[/]
         [red]Workspace ID:[/red] {e.workspace_id}
-        
-        [red]You may using an invalid token or the token is expired.[/red]
-        [red]Please re-issue a new token and run `lep workspace login` again.[/red]
+        [red]Workspace URL:[/red] {e.workspace_url}
+
+        [bold]If you have access to this workspace, to resolve this issue:[/bold]
+        [yellow]Check that the workspace URL above matches the environment your token was issued from.[/yellow]
+        If not, login again with the correct workspace URL:
+           [green]lep workspace login -i <workspace_id> -t <auth_token> --workspace-url <workspace_url>[/green]
         """)
         sys.exit(1)
+
+    if pending_login is not None:
+        WorkspaceRecord.set_or_exit(**pending_login)
+
+    ws_name = info.workspace_name
+    tier = info.workspace_tier
+
+    indent = " " * 17  # match logo's left margin for alignment
+    console.print(f"{indent}{'Workspace':>12}: [#76B900]{ws_name}[/]")
+    console.print(f"{indent}{'Tier':>12}: {tier}")
+    WorkspaceRecord.refresh_token_expires_at(skip_if_token_exists=True)
+    version_info_list = api_client.version(info)
+    if version_info_list is not None:
+        version = ".".join(str(v) for v in version_info_list)
+        console.print(f"{indent}{'Version':>12}: {version}\n")
 
 
 @lep.command()

--- a/leptonai/cli/tests/test_workspace_cli.py
+++ b/leptonai/cli/tests/test_workspace_cli.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from click.testing import CliRunner
 from loguru import logger
@@ -10,6 +11,8 @@ tmpdir = tempfile.mkdtemp()
 os.environ["LEPTON_CACHE_DIR"] = tmpdir
 
 from leptonai import config
+from leptonai.api.v2.utils import WorkspaceForbiddenError
+from leptonai.api.v2.workspace_record import WorkspaceRecord
 from leptonai.cli import lep as cli
 
 logger.info(f"Using cache dir: {config.CACHE_DIR}")
@@ -34,6 +37,28 @@ class TestWorkspaceCli(unittest.TestCase):
         result = runner.invoke(cli, ["workspace", "logout"])
         self.assertIn("not logged in to any workspace.", result.output.lower())
         self.assertEqual(result.exit_code, 0)
+
+
+class TestWorkspaceLoginForbidden(unittest.TestCase):
+    def test_login_forbidden_prints_url_check_hint(self):
+        runner = CliRunner()
+        fake_client = mock.Mock()
+        fake_client.info.side_effect = WorkspaceForbiddenError(
+            workspace_id="stag",
+            workspace_url=config.API_URL_BASE + "/api/v2/workspaces/stag",
+            auth_token="nv****98",
+        )
+        with (
+            mock.patch.object(WorkspaceRecord, "has", return_value=False),
+            mock.patch.object(WorkspaceRecord, "set_or_exit"),
+            mock.patch.object(WorkspaceRecord, "client", return_value=fake_client),
+        ):
+            result = runner.invoke(
+                cli, ["workspace", "login", "-i", "stag", "-t", "nvapi-faketoken"]
+            )
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Workspace Access Forbidden", result.output)
+        self.assertIn("--workspace-url", result.output)
 
 
 if __name__ == "__main__":

--- a/leptonai/cli/tests/test_workspace_cli.py
+++ b/leptonai/cli/tests/test_workspace_cli.py
@@ -39,8 +39,60 @@ class TestWorkspaceCli(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
 
 
-class TestWorkspaceLoginForbidden(unittest.TestCase):
-    def test_login_forbidden_prints_url_check_hint(self):
+class TestWorkspaceLogin(unittest.TestCase):
+    def _invoke_login(self, fake_client):
+        runner = CliRunner()
+        with (
+            mock.patch.object(WorkspaceRecord, "has", return_value=False),
+            mock.patch.object(WorkspaceRecord, "set_or_exit") as set_or_exit,
+            mock.patch(
+                "leptonai.cli.workspace.APIClient", return_value=fake_client
+            ) as api_client_cls,
+        ):
+            result = runner.invoke(
+                cli, ["workspace", "login", "-i", "stag", "-t", "nvapi-faketoken"]
+            )
+        return result, set_or_exit, api_client_cls
+
+    def test_login_forbidden_prints_url_check_hint_and_does_not_persist(self):
+        fake_client = mock.Mock()
+        fake_client.info.side_effect = WorkspaceForbiddenError(
+            workspace_id="stag",
+            workspace_url=config.API_URL_BASE + "/api/v2/workspaces/stag",
+            auth_token="nv****98",
+        )
+        result, set_or_exit, _ = self._invoke_login(fake_client)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Workspace Access Forbidden", result.output)
+        self.assertIn("--workspace-url", result.output)
+        set_or_exit.assert_not_called()
+
+    def test_login_verifies_default_url_before_persisting(self):
+        fake_client = mock.Mock()
+        fake_client.info.return_value = mock.Mock(
+            workspace_name="lepton-stag", workspace_tier="basic", build_time="today"
+        )
+        fake_client.version.return_value = (0, 1, 0)
+        result, set_or_exit, api_client_cls = self._invoke_login(fake_client)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Logged in to your workspace", result.output)
+        api_client_cls.assert_called_once_with(
+            "stag",
+            "nvapi-faketoken",
+            config.API_URL_BASE + "/api/v2/workspaces/stag",
+            None,
+        )
+        set_or_exit.assert_called_once_with(
+            "stag",
+            auth_token="nvapi-faketoken",
+            url=config.API_URL_BASE + "/api/v2/workspaces/stag",
+            workspace_origin_url=None,
+            could_be_new_token=True,
+        )
+
+
+class TestLepLogin(unittest.TestCase):
+    def test_login_with_credentials_forbidden_does_not_persist(self):
         runner = CliRunner()
         fake_client = mock.Mock()
         fake_client.info.side_effect = WorkspaceForbiddenError(
@@ -49,16 +101,13 @@ class TestWorkspaceLoginForbidden(unittest.TestCase):
             auth_token="nv****98",
         )
         with (
-            mock.patch.object(WorkspaceRecord, "has", return_value=False),
-            mock.patch.object(WorkspaceRecord, "set_or_exit"),
-            mock.patch.object(WorkspaceRecord, "client", return_value=fake_client),
+            mock.patch.object(WorkspaceRecord, "set_or_exit") as set_or_exit,
+            mock.patch("leptonai.cli.cli.APIClient", return_value=fake_client),
         ):
-            result = runner.invoke(
-                cli, ["workspace", "login", "-i", "stag", "-t", "nvapi-faketoken"]
-            )
+            result = runner.invoke(cli, ["login", "-c", "stag:nvapi-faketoken"])
         self.assertEqual(result.exit_code, 1)
         self.assertIn("Workspace Access Forbidden", result.output)
-        self.assertIn("--workspace-url", result.output)
+        set_or_exit.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/leptonai/cli/workspace.py
+++ b/leptonai/cli/workspace.py
@@ -10,7 +10,11 @@ from rich.table import Table
 
 from leptonai.api.v2.workspace_record import WorkspaceRecord
 from .util import click_group, check, sizeof_fmt
-from ..api.v2.utils import WorkspaceNotFoundError, WorkspaceUnauthorizedError
+from ..api.v2.utils import (
+    WorkspaceForbiddenError,
+    WorkspaceNotFoundError,
+    WorkspaceUnauthorizedError,
+)
 
 console = Console(highlight=False)
 
@@ -147,6 +151,20 @@ def login(
         2. [green]Please check the login info you just used above[/green]
         3. [yellow]Login to the workspace with valid credentials:[/yellow]
            [green]lep workspace login -i <valid_workspace_id> -t <valid_workspace_token>[/green]
+        """)
+        sys.exit(1)
+
+    except WorkspaceForbiddenError as e:
+        console.print("\n", e)
+        console.print(f"""
+        [red bold]Workspace Access Forbidden[/]
+        [red]Workspace ID:[/red] {e.workspace_id}
+        [red]Workspace URL:[/red] {e.workspace_url}
+
+        [bold]If you have access to this workspace, to resolve this issue:[/bold]
+        [yellow]Check that the workspace URL above matches the environment your token was issued from.[/yellow]
+        If not, login again with the correct workspace URL:
+           [green]lep workspace login -i <workspace_id> -t <auth_token> --workspace-url <workspace_url>[/green]
         """)
         sys.exit(1)
 

--- a/leptonai/cli/workspace.py
+++ b/leptonai/cli/workspace.py
@@ -8,12 +8,14 @@ from loguru import logger
 from rich.console import Console
 from rich.table import Table
 
+from leptonai.api.v2.client import APIClient
 from leptonai.api.v2.workspace_record import WorkspaceRecord
 from .util import click_group, check, sizeof_fmt
 from ..api.v2.utils import (
     WorkspaceForbiddenError,
     WorkspaceNotFoundError,
     WorkspaceUnauthorizedError,
+    _get_full_workspace_api_url,
 )
 
 console = Console(highlight=False)
@@ -64,10 +66,11 @@ def login(
     """
     Logs in to a workspace. This also verifies that the workspace is accessible.
     """
+    is_new_credentials = bool(auth_token or workspace_url or workspace_origin_url)
     if workspace_id is None:
         # If workspace_id is not given and current workspace is present, we will
         # simply print the info.
-        if auth_token or workspace_url or workspace_origin_url:
+        if is_new_credentials:
             console.print(
                 "\n[bold red]Invalid usage:[/bold red] --auth-token,"
                 " --workspace-url, and"
@@ -80,45 +83,34 @@ def login(
                 " [--workspace-origin-url <url>][/]\n"
             )
             sys.exit(1)
-        if WorkspaceRecord.current():
-            pass
     elif WorkspaceRecord.has(workspace_id):
-        # already has the info: update the auth token if given.
-        info = WorkspaceRecord.get(workspace_id)
-        if auth_token or workspace_url or workspace_origin_url:
-            WorkspaceRecord.set_or_exit(
-                workspace_id,
-                auth_token=auth_token,
-                url=workspace_url,
-                workspace_origin_url=workspace_origin_url,
-                could_be_new_token=True,
-            )
-        else:
-            WorkspaceRecord.set_or_exit(workspace_id, auth_token=info.auth_token, url=info.url, workspace_origin_url=info.workspace_origin_url)  # type: ignore
-    else:
-        if not auth_token:
-            console.print(
-                f"[red]Error[/]: Workspace '{workspace_id}' not found; please provide"
-                " --auth-token."
-            )
-            sys.exit(1)
-
-        WorkspaceRecord.set_or_exit(
-            workspace_id,
-            auth_token=auth_token,
-            url=workspace_url,
-            workspace_origin_url=workspace_origin_url,
-            could_be_new_token=True,
+        # Options that are not given fall back to the stored record, so that
+        # e.g. a token refresh does not reset a custom workspace URL back to
+        # the default gateway.
+        stored = WorkspaceRecord.get(workspace_id)
+        auth_token = auth_token or stored.auth_token  # type: ignore
+        workspace_url = workspace_url or stored.url  # type: ignore
+        workspace_origin_url = workspace_origin_url or stored.workspace_origin_url  # type: ignore
+    elif not auth_token:
+        console.print(
+            f"[red]Error[/]: Workspace '{workspace_id}' not found; please provide"
+            " --auth-token."
         )
-    # Try to login and print the info.
-    api_client = WorkspaceRecord.client()
+        sys.exit(1)
+
+    # Verify workspace access first; the record is persisted only after the
+    # verification succeeds, so a failed login does not pollute local records
+    # or switch the current workspace.
+    if workspace_id is None:
+        api_client = WorkspaceRecord.client()
+    else:
+        if workspace_url is None:
+            workspace_url = _get_full_workspace_api_url(workspace_id)
+        api_client = APIClient(
+            workspace_id, auth_token, workspace_url, workspace_origin_url
+        )
     try:
         info = api_client.info()
-
-        console.print(f"Logged in to your workspace [green]{info.workspace_name}[/].")
-        console.print(f"\t      tier: {info.workspace_tier}")
-        console.print(f"\tbuild time: {info.build_time}")
-        console.print(f"\t   version: {api_client.version()}")
     except WorkspaceUnauthorizedError as e:
         console.print("\n", e)
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -167,6 +159,20 @@ def login(
            [green]lep workspace login -i <workspace_id> -t <auth_token> --workspace-url <workspace_url>[/green]
         """)
         sys.exit(1)
+
+    if workspace_id is not None:
+        WorkspaceRecord.set_or_exit(
+            workspace_id,
+            auth_token=auth_token,
+            url=workspace_url,
+            workspace_origin_url=workspace_origin_url,
+            could_be_new_token=is_new_credentials,
+        )
+
+    console.print(f"Logged in to your workspace [green]{info.workspace_name}[/].")
+    console.print(f"\t      tier: {info.workspace_tier}")
+    console.print(f"\tbuild time: {info.build_time}")
+    console.print(f"\t   version: {api_client.version(info)}")
 
 
 @workspace.command()


### PR DESCRIPTION
## What this PR does

- **Verify before persist.** `lep login` and `lep workspace login` now call the workspace info API first, and only write the record into `workspace_info.yaml` (and switch the current workspace) after the workspace is verified accessible. A failed login no longer leaves broken records behind.
- **Preserve stored values on partial updates.** `lep workspace login -i <id> -t <new-token>` on an existing record now falls back to the stored values for options not given, so a token refresh no longer silently resets a custom workspace URL back to the default gateway.
- **Friendly 403 handling.** `WorkspaceForbiddenError` is now handled in both login commands (previously a raw traceback): the message shows the workspace URL actually used and hints to check that it matches the environment the token was issued from, with a `--workspace-url` example.

## Root cause

The CLI hardcodes the production gateway as the only API base:

```python
# leptonai/config.py
API_URL_BASE = "https://gateway.dgxc-lepton.nvidia.com"
```

When `lep workspace login -i <id> -t <token>` (or `lep login -c <id>:<token>`) is run without `--workspace-url`, the workspace URL is mechanically derived as `API_URL_BASE + "/api/v2/workspaces/" + <id>` — the CLI has no notion of environments, so the request always goes to the **production** gateway no matter where the workspace actually lives. A staging token sent to the production gateway is rejected with **403 Forbidden**.

Three issues compounded the confusion:

1. **Persist-before-verify.** The login flow wrote the record into `~/.cache/lepton/workspace_info.yaml` and switched the current workspace *before* calling the access-check API. A failed login therefore left behind a broken record (wrong URL) as the current workspace, breaking every subsequent `lep` command.
2. **Unhandled 403.** `WorkspaceForbiddenError` was not caught by the login command, so users got a raw Python traceback instead of guidance.
3. **Token refresh reset custom URLs.** Re-logging into an existing record with a new token passed `url=None`, which silently reset a custom workspace URL back to the default production gateway.

## Why `--workspace-url` must be specified manually for stag and other non-prod environments

The workspace-id → URL mapping is **not derivable on the client side**:

- Gateway domains follow a two-tier scheme: production is `gateway.dgxc-lepton.nvidia.com`; non-prod environments live under `dgxc-lepton-dev.nvidia.com` — `dev` has no label, while stag/nightly/citest/dev02 are `gateway.<env>.dgxc-lepton-dev.nvidia.com`. Neither the workspace id nor the token encodes which environment a workspace belongs to, so the CLI cannot compute the right domain from `-i stag` alone.
- Historically (Lepton Classic) the CLI resolved URLs dynamically: it queried a resolver service (`portal.lepton.ai/api/workspace`), which returned the authoritative per-workspace URL. When DGXC support was introduced, this resolution was replaced with the hardcoded production base, and no equivalent id→URL resolver endpoint exists for DGXC.
- Hardcoding the internal environment list into a publicly distributed CLI is not acceptable (it leaks internal domains and goes stale), so until the gateway provides a resolver endpoint, non-prod logins must pass the full workspace URL explicitly:

```
lep workspace login -i stag -t <token> \
  --workspace-url https://gateway.stag.dgxc-lepton-dev.nvidia.com/api/v2/workspaces/stag
```

## Tests

- 403 during `lep workspace login` / `lep login -c`: asserts the friendly message is printed and `set_or_exit` is **not** called.
- Successful fresh login: asserts the URL used for verification is identical to the URL persisted.
- All 29 CLI tests pass; ruff/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)