### PR TITLE
feat(cli): support new /endpoints + /devpods API behind enable_new_deployment_api

### DIFF
--- a/leptonai/api/v2/__init__.py
+++ b/leptonai/api/v2/__init__.py
@@ -20,7 +20,7 @@ Note that the web API is primarily intended for the ``lep`` CLI and the web
 console; there is no SLA guarantee for high-frequency programmatic use.
 """
 
-from .client import APIClient
+from .client import APIClient, reset_new_deployment_api_flag_cache
 from .workspace_record import WorkspaceRecord
 from .api_resource import APIResourse, ClientError, ServerError
 from .utils import (
@@ -35,6 +35,7 @@ from . import types
 
 __all__ = [
     "APIClient",
+    "reset_new_deployment_api_flag_cache",
     "WorkspaceRecord",
     "APIResourse",
     "ClientError",

--- a/leptonai/api/v2/client.py
+++ b/leptonai/api/v2/client.py
@@ -7,6 +7,7 @@ such as http sessions.
 import os
 import time
 import re
+import threading
 import requests
 from typing import Optional, Union, Dict, Tuple
 
@@ -57,12 +58,41 @@ HAS_WARNED_TOKEN_EXPIRE: bool = False
 # across the legacy /deployments and the new /endpoints|/devpods APIs.
 _NEW_DEPLOYMENT_API_FLAG_CACHE: Dict[str, bool] = {}
 
+# Guards the check-resolve-commit sequence in `new_deployment_api_enabled`. The
+# GIL makes each individual dict op atomic, but not the read-then-/workspace-
+# resolve-then-write span: without this lock, two threads that hit a cold memo
+# concurrently (e.g. `lep log get` workers, each with its own APIClient) could
+# each issue their own /workspace call, get different transient outcomes, and
+# route their in-flight requests to different API families before last-write-wins
+# settles the memo. Single-flight under this lock guarantees exactly one
+# resolution per workspace URL and one committed dispatch decision.
+_FLAG_CACHE_LOCK = threading.Lock()
+
 # Bounded retry for the one-time flag resolution. The CLI is a short-lived
 # process: a couple of quick retries smooth over a transient /workspace blip
 # without a per-command round-trip, and the committed outcome (including a
 # committed False after retries are exhausted) then holds for the process.
 _FLAG_RESOLVE_RETRIES: int = 2
 _FLAG_RESOLVE_BACKOFF_SECONDS: float = 0.25
+
+
+def reset_new_deployment_api_flag_cache(url: Optional[str] = None) -> None:
+    """Drop the memoized new-deployment-API dispatch flag.
+
+    The flag is resolved once and committed for the lifetime of the process (see
+    :attr:`APIClient.new_deployment_api_enabled`). That is correct for the
+    short-lived ``lep`` CLI, but a long-lived SDK consumer (a notebook or a
+    service that ``import leptonai`` and stays up) would otherwise never observe
+    an ``enable_new_deployment_api`` flip on the workspace — the api-server does
+    permit toggling it. Call this to force the next dispatch to re-resolve.
+
+    :param url: clear only the entry for this workspace URL; ``None`` clears all.
+    """
+    with _FLAG_CACHE_LOCK:
+        if url is None:
+            _NEW_DEPLOYMENT_API_FLAG_CACHE.clear()
+        else:
+            _NEW_DEPLOYMENT_API_FLAG_CACHE.pop(url, None)
 
 
 class APIClient(object):
@@ -276,16 +306,39 @@ class APIClient(object):
         such a create with 400), so committing legacy after a genuine, retried
         resolution failure fails loud rather than silently wrong.
 
+        SDK implication: because the commit lasts the whole process, a long-lived
+        consumer (a notebook or service that keeps ``leptonai`` imported) will
+        NOT observe a workspace's ``enable_new_deployment_api`` being toggled
+        after the first dispatch — the api-server permits the toggle, but this
+        client will keep routing to the family it first resolved. That is
+        intentional (freshness is traded for per-operation consistency); a
+        consumer that needs to pick up a flip can call
+        :func:`reset_new_deployment_api_flag_cache` to force a re-resolution.
+
+        Concurrency: the cold-memo resolve-and-commit runs single-flight under
+        ``_FLAG_CACHE_LOCK`` (double-checked), so concurrent first accesses from
+        different threads/clients on the same workspace URL do exactly one
+        /workspace resolution and commit one dispatch decision — they cannot
+        split routing across API families.
+
         @implements LEP-5664, LEP-5665 (flag detection)
         """
         cached = _NEW_DEPLOYMENT_API_FLAG_CACHE.get(self.url)
         if cached is not None:
             self._new_deployment_api_enabled = cached
             return cached
-        resolved = self._resolve_new_deployment_api()
-        _NEW_DEPLOYMENT_API_FLAG_CACHE[self.url] = resolved
-        self._new_deployment_api_enabled = resolved
-        return resolved
+        with _FLAG_CACHE_LOCK:
+            # Re-check under the lock: another thread may have resolved and
+            # committed while we waited, in which case we adopt its decision
+            # rather than issuing a second /workspace call.
+            cached = _NEW_DEPLOYMENT_API_FLAG_CACHE.get(self.url)
+            if cached is not None:
+                self._new_deployment_api_enabled = cached
+                return cached
+            resolved = self._resolve_new_deployment_api()
+            _NEW_DEPLOYMENT_API_FLAG_CACHE[self.url] = resolved
+            self._new_deployment_api_enabled = resolved
+            return resolved
 
     def _resolve_new_deployment_api(self) -> bool:
         """Resolve the new-deployment-API flag from workspace info, once.

--- a/leptonai/api/v2/client.py
+++ b/leptonai/api/v2/client.py
@@ -48,6 +48,23 @@ from loguru import logger
 HAS_WARNED_TOKEN_EXPIRE: bool = False
 
 
+# Process-wide memo of the resolved new-deployment-API flag, keyed by workspace
+# URL. A single `lep` invocation targets exactly one workspace, but it may build
+# several short-lived `APIClient` instances (e.g. the parallel `lep log get`
+# workers each construct their own). Keying the resolved flag on the workspace
+# URL commits one dispatch decision for the whole invocation, so no two clients —
+# and no two reads on one client — can disagree and split a logical operation
+# across the legacy /deployments and the new /endpoints|/devpods APIs.
+_NEW_DEPLOYMENT_API_FLAG_CACHE: Dict[str, bool] = {}
+
+# Bounded retry for the one-time flag resolution. The CLI is a short-lived
+# process: a couple of quick retries smooth over a transient /workspace blip
+# without a per-command round-trip, and the committed outcome (including a
+# committed False after retries are exhausted) then holds for the process.
+_FLAG_RESOLVE_RETRIES: int = 2
+_FLAG_RESOLVE_BACKOFF_SECONDS: float = 0.25
+
+
 class APIClient(object):
     """
     A Lepton API client that is associated with a workspace. This class holds all
@@ -223,56 +240,83 @@ class APIClient(object):
         self._endpoint_api = EndpointAPI(self)
         self._devpod_api = DevPodAPI(self)
 
-        # Memoized resolution of the new-deployment-API workspace flag. None
-        # means "not yet resolved"; resolved to a bool on first access.
+        # Per-instance mirror of the process-wide resolved flag (keyed by
+        # workspace URL in `_NEW_DEPLOYMENT_API_FLAG_CACHE`). None means "not yet
+        # read on this client"; it is populated from the memo on first access.
         self._new_deployment_api_enabled: Optional[bool] = None
 
     @property
     def new_deployment_api_enabled(self) -> bool:
         """Whether the workspace has the new endpoint/devpod API enabled.
 
-        Resolved lazily from a single ``info()`` call the first time it is
-        accessed, then memoized for the lifetime of this client — no extra
-        round-trip per command. The semantics mirror the dashboard's
-        ``useEndpointApiMode``: only an explicit ``true`` for
-        ``features.enable_new_deployment_api`` switches to the new routes.
-        An absent field, ``false``, a missing ``features`` object, or any
-        error resolving the flag all fail safe to the legacy routes.
+        Resolved once, then committed for the lifetime of the *process* (not
+        just this client) via a workspace-URL-keyed memo. The first access on
+        the first client for a workspace does a single ``info()`` resolution
+        with a small bounded retry; the resulting bool — ``True`` OR ``False``,
+        including a ``False`` committed after the retries are exhausted — is
+        stored and returned unconditionally for every later access, on this
+        client and on any other client built for the same workspace in the same
+        invocation. The semantics mirror the dashboard's ``useEndpointApiMode``:
+        only an explicit ``true`` for ``features.enable_new_deployment_api``
+        switches to the new routes; an absent field, ``false``, or a missing
+        ``features`` object stays on the legacy routes.
+
+        Why commit unconditionally (superseding the earlier no-cache-on-failure
+        design): the ``lep`` CLI is a short-lived process, and many operations
+        span several dispatch reads (a preflight list then a create, an update's
+        get-then-patch-then-verify, a pod list then its per-replica IP lookup)
+        or several clients (the parallel ``lep log get`` workers). If a
+        *transient* /workspace failure yielded legacy for one read and a later
+        read recovered the real flag, the operation would split across the
+        legacy /deployments and the new /endpoints|/devpods APIs — the exact
+        multi-call inconsistency class fixed here. Intra-process consistency
+        therefore beats freshness. The earlier concern that fail-to-legacy could
+        silently land an endpoint-flavored create on /deployments in a flag-on
+        workspace is now backstopped SERVER-SIDE (api-server MR !7865 rejects
+        such a create with 400), so committing legacy after a genuine, retried
+        resolution failure fails loud rather than silently wrong.
 
         @implements LEP-5664, LEP-5665 (flag detection)
         """
-        if self._new_deployment_api_enabled is None:
-            resolved = self._resolve_new_deployment_api()
-            if resolved is None:
-                # Could not resolve (transient error). Fail safe to legacy for
-                # THIS access, but do not memoize the failure: a later command on
-                # the same client should retry rather than being pinned to legacy
-                # by one flaky /workspace call. Caching failure→legacy in a
-                # flag-on workspace would route a subsequent create to
-                # /deployments (endpoint-flavored legacy create is only gated by
-                # the sibling api-server MR, so it could silently land on the
-                # wrong API).
-                return False
-            self._new_deployment_api_enabled = resolved
-        return self._new_deployment_api_enabled
+        cached = _NEW_DEPLOYMENT_API_FLAG_CACHE.get(self.url)
+        if cached is not None:
+            self._new_deployment_api_enabled = cached
+            return cached
+        resolved = self._resolve_new_deployment_api()
+        _NEW_DEPLOYMENT_API_FLAG_CACHE[self.url] = resolved
+        self._new_deployment_api_enabled = resolved
+        return resolved
 
-    def _resolve_new_deployment_api(self) -> Optional[bool]:
-        """Resolve the new-deployment-API flag from workspace info.
+    def _resolve_new_deployment_api(self) -> bool:
+        """Resolve the new-deployment-API flag from workspace info, once.
 
-        Returns the definite flag value (``True``/``False``) on a successful
-        resolution, or ``None`` when the flag could not be resolved at all
-        (network error, unauthorized, malformed response). A resolved ``False``
-        — including an absent flag or missing ``features`` object — is a real
-        answer and is cached; ``None`` is transient and is not cached by the
-        caller so the next access retries.
+        Always returns a definite bool: an explicit ``features
+        .enable_new_deployment_api is True`` yields ``True``; an absent flag,
+        missing ``features``, or an unresolvable /workspace call (after a small
+        bounded retry) all yield ``False``. This is called at most once per
+        workspace URL per process — the caller commits the result to the
+        process-wide memo — so a transient blip is retried here rather than
+        being re-litigated on every subsequent dispatch read.
         """
-        try:
-            info = self.info()
-        except Exception as e:
-            logger.trace(
-                f"Could not resolve new deployment API flag, using legacy: {e}"
-            )
-            return None
+        info = None
+        for attempt in range(_FLAG_RESOLVE_RETRIES + 1):
+            try:
+                info = self.info()
+                break
+            except Exception as e:
+                if attempt < _FLAG_RESOLVE_RETRIES:
+                    logger.trace(
+                        "Could not resolve new deployment API flag (attempt"
+                        f" {attempt + 1}), retrying: {e}"
+                    )
+                    time.sleep(_FLAG_RESOLVE_BACKOFF_SECONDS * (2**attempt))
+                else:
+                    logger.trace(
+                        "Could not resolve new deployment API flag after"
+                        f" {_FLAG_RESOLVE_RETRIES + 1} attempts, committing"
+                        f" legacy: {e}"
+                    )
+                    return False
         features = getattr(info, "features", None)
         if features is None:
             return False

--- a/leptonai/api/v2/client.py
+++ b/leptonai/api/v2/client.py
@@ -19,6 +19,8 @@ from .types.workspace import WorkspaceInfo
 from .api_resource import APIResourse
 from .dedicated_node_groups import DedicatedNodeGroupAPI
 from .deployment import DeploymentAPI
+from .endpoint import EndpointAPI
+from .devpod import DevPodAPI
 from .job import JobAPI
 from .secret import SecretAPI
 from .pod import PodAPI
@@ -199,9 +201,7 @@ class APIClient(object):
 
         # Add individual APIs
         self.nodegroup = DedicatedNodeGroupAPI(self)
-        self.deployment = DeploymentAPI(self)
         self.job = JobAPI(self)
-        self.pod = PodAPI(self)
         self.secret = SecretAPI(self)
         self.ingress = IngressAPI(self)
         self.storage = StorageAPI(self)
@@ -210,6 +210,84 @@ class APIClient(object):
         self.finetune = FineTuneAPI(self)
         self.shapes = ResourceShapeAPI(self)
         self.raycluster = RayClusterAPI(self)
+
+        # Deployment ("endpoint") and pod ("devpod") each have two backing
+        # implementations: the legacy /deployments-based API and the new
+        # /endpoints|/devpods-based API. The public `deployment` and `pod`
+        # attributes are @property accessors below that dispatch to one of these
+        # based on the cached `enable_new_deployment_api` workspace flag. Legacy
+        # is the default and the fail-safe. Internal code that must always reach
+        # the legacy /deployments routes (e.g. LogAPI) can use these directly.
+        self._deployment_legacy = DeploymentAPI(self)
+        self._pod_legacy = PodAPI(self)
+        self._endpoint_api = EndpointAPI(self)
+        self._devpod_api = DevPodAPI(self)
+
+        # Memoized resolution of the new-deployment-API workspace flag. None
+        # means "not yet resolved"; resolved to a bool on first access.
+        self._new_deployment_api_enabled: Optional[bool] = None
+
+    @property
+    def new_deployment_api_enabled(self) -> bool:
+        """Whether the workspace has the new endpoint/devpod API enabled.
+
+        Resolved lazily from a single ``info()`` call the first time it is
+        accessed, then memoized for the lifetime of this client — no extra
+        round-trip per command. The semantics mirror the dashboard's
+        ``useEndpointApiMode``: only an explicit ``true`` for
+        ``features.enable_new_deployment_api`` switches to the new routes.
+        An absent field, ``false``, a missing ``features`` object, or any
+        error resolving the flag all fail safe to the legacy routes.
+
+        @implements LEP-5664, LEP-5665 (flag detection)
+        """
+        if self._new_deployment_api_enabled is None:
+            self._new_deployment_api_enabled = self._resolve_new_deployment_api()
+        return self._new_deployment_api_enabled
+
+    def _resolve_new_deployment_api(self) -> bool:
+        """Resolve the new-deployment-API flag from workspace info, fail-safe.
+
+        Any failure (network error, unauthorized, malformed response, missing
+        ``features``) resolves to ``False`` so the CLI keeps working against the
+        legacy routes rather than surfacing a spurious error at command start.
+        """
+        try:
+            info = self.info()
+        except Exception as e:
+            logger.trace(
+                f"Could not resolve new deployment API flag, using legacy: {e}"
+            )
+            return False
+        features = getattr(info, "features", None)
+        if features is None:
+            return False
+        return features.enable_new_deployment_api is True
+
+    @property
+    def deployment(self) -> Union[DeploymentAPI, "EndpointAPI"]:
+        """The deployment (endpoint) API.
+
+        Dispatches to the new /endpoints-based :class:`EndpointAPI` when the
+        workspace flag is on, otherwise the legacy /deployments-based
+        :class:`DeploymentAPI`. Both expose the same method surface and return
+        :class:`LeptonDeployment`-shaped objects, so callers are unaffected.
+        """
+        if self.new_deployment_api_enabled:
+            return self._endpoint_api
+        return self._deployment_legacy
+
+    @property
+    def pod(self) -> Union[PodAPI, "DevPodAPI"]:
+        """The pod (devpod) API.
+
+        Dispatches to the new /devpods-based :class:`DevPodAPI` when the
+        workspace flag is on, otherwise the legacy /deployments-based
+        :class:`PodAPI`.
+        """
+        if self.new_deployment_api_enabled:
+            return self._devpod_api
+        return self._pod_legacy
 
     def _safe_add(self, kwargs: Dict) -> Dict:
         """

--- a/leptonai/api/v2/client.py
+++ b/leptonai/api/v2/client.py
@@ -242,15 +242,29 @@ class APIClient(object):
         @implements LEP-5664, LEP-5665 (flag detection)
         """
         if self._new_deployment_api_enabled is None:
-            self._new_deployment_api_enabled = self._resolve_new_deployment_api()
+            resolved = self._resolve_new_deployment_api()
+            if resolved is None:
+                # Could not resolve (transient error). Fail safe to legacy for
+                # THIS access, but do not memoize the failure: a later command on
+                # the same client should retry rather than being pinned to legacy
+                # by one flaky /workspace call. Caching failure→legacy in a
+                # flag-on workspace would route a subsequent create to
+                # /deployments (endpoint-flavored legacy create is only gated by
+                # the sibling api-server MR, so it could silently land on the
+                # wrong API).
+                return False
+            self._new_deployment_api_enabled = resolved
         return self._new_deployment_api_enabled
 
-    def _resolve_new_deployment_api(self) -> bool:
-        """Resolve the new-deployment-API flag from workspace info, fail-safe.
+    def _resolve_new_deployment_api(self) -> Optional[bool]:
+        """Resolve the new-deployment-API flag from workspace info.
 
-        Any failure (network error, unauthorized, malformed response, missing
-        ``features``) resolves to ``False`` so the CLI keeps working against the
-        legacy routes rather than surfacing a spurious error at command start.
+        Returns the definite flag value (``True``/``False``) on a successful
+        resolution, or ``None`` when the flag could not be resolved at all
+        (network error, unauthorized, malformed response). A resolved ``False``
+        — including an absent flag or missing ``features`` object — is a real
+        answer and is cached; ``None`` is transient and is not cached by the
+        caller so the next access retries.
         """
         try:
             info = self.info()
@@ -258,7 +272,7 @@ class APIClient(object):
             logger.trace(
                 f"Could not resolve new deployment API flag, using legacy: {e}"
             )
-            return False
+            return None
         features = getattr(info, "features", None)
         if features is None:
             return False

--- a/leptonai/api/v2/client.py
+++ b/leptonai/api/v2/client.py
@@ -4,12 +4,13 @@ information such as the url auth token, as well as caching runtime objects
 such as http sessions.
 """
 
+import hashlib
 import os
-import time
 import re
 import threading
+import time
 import requests
-from typing import Optional, Union, Dict, Tuple
+from typing import Dict, Optional, Set, Tuple, Union
 
 from .log import LogAPI
 
@@ -49,24 +50,28 @@ from loguru import logger
 HAS_WARNED_TOKEN_EXPIRE: bool = False
 
 
-# Process-wide memo of the resolved new-deployment-API flag, keyed by workspace
-# URL. A single `lep` invocation targets exactly one workspace, but it may build
-# several short-lived `APIClient` instances (e.g. the parallel `lep log get`
-# workers each construct their own). Keying the resolved flag on the workspace
-# URL commits one dispatch decision for the whole invocation, so no two clients —
-# and no two reads on one client — can disagree and split a logical operation
-# across the legacy /deployments and the new /endpoints|/devpods APIs.
-_NEW_DEPLOYMENT_API_FLAG_CACHE: Dict[str, bool] = {}
+# Process-wide memo of the resolved new-deployment-API flag. The credential is
+# part of the key because /workspace is authenticated: an expired or otherwise
+# unauthorized token must not commit the legacy fallback for a different token
+# targeting the same workspace URL. Only a one-way digest is retained in this
+# cache; raw credentials never become cache keys.
+_FlagCacheKey = Tuple[str, str]
+_NEW_DEPLOYMENT_API_FLAG_CACHE: Dict[_FlagCacheKey, bool] = {}
 
-# Guards the check-resolve-commit sequence in `new_deployment_api_enabled`. The
-# GIL makes each individual dict op atomic, but not the read-then-/workspace-
-# resolve-then-write span: without this lock, two threads that hit a cold memo
-# concurrently (e.g. `lep log get` workers, each with its own APIClient) could
-# each issue their own /workspace call, get different transient outcomes, and
-# route their in-flight requests to different API families before last-write-wins
-# settles the memo. Single-flight under this lock guarantees exactly one
-# resolution per workspace URL and one committed dispatch decision.
-_FLAG_CACHE_LOCK = threading.Lock()
+# Condition-protected single-flight state. The condition is held only for cache
+# bookkeeping, never across /workspace I/O or retry sleeps. Therefore unrelated
+# workspaces/credentials can resolve concurrently while callers sharing an exact
+# key wait for one committed result.
+_FLAG_CACHE_CONDITION = threading.Condition()
+_FLAG_CACHE_RESOLVING: Set[_FlagCacheKey] = set()
+
+# A reset registers its scope before waiting for matching in-flight resolutions.
+# New readers in that scope wait until the old result has been committed and
+# removed, preventing a pre-reset resolution from repopulating the cache after
+# reset returns. Counters allow overlapping reset calls without releasing
+# readers early.
+_FLAG_CACHE_RESETTING_URLS: Dict[str, int] = {}
+_FLAG_CACHE_RESETTING_ALL: int = 0
 
 # Bounded retry for the one-time flag resolution. The CLI is a short-lived
 # process: a couple of quick retries smooth over a transient /workspace blip
@@ -74,6 +79,47 @@ _FLAG_CACHE_LOCK = threading.Lock()
 # committed False after retries are exhausted) then holds for the process.
 _FLAG_RESOLVE_RETRIES: int = 2
 _FLAG_RESOLVE_BACKOFF_SECONDS: float = 0.25
+# Feature discovery is on the critical path for every first deployment/pod API
+# access. Keep each /workspace attempt short rather than inheriting the 120-second
+# timeout intended for ordinary (potentially long-running) API operations.
+_FLAG_RESOLVE_REQUEST_TIMEOUT_SECONDS: float = 5.0
+_API_RESOURCE_OVERRIDE_UNSET = object()
+
+
+def _new_deployment_api_credential_fingerprint(
+    auth_token: Optional[str],
+) -> str:
+    """Return a deterministic, one-way cache identity for a credential."""
+    digest = hashlib.sha256()
+    if auth_token is None:
+        digest.update(b"leptonai:new-deployment-api:unauthenticated")
+    else:
+        digest.update(b"leptonai:new-deployment-api:authenticated\0")
+        digest.update(auth_token.encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _reset_new_deployment_api_flag_cache_after_fork() -> None:
+    """Reinitialize inherited synchronization state in a forked child.
+
+    A lock held by a non-forking thread can never be released in the child.
+    Replacing the condition and dropping inherited in-flight/reset markers makes
+    the first child access safe. Completed cache entries remain valid and are
+    intentionally preserved.
+    """
+    global _FLAG_CACHE_CONDITION
+    global _FLAG_CACHE_RESOLVING
+    global _FLAG_CACHE_RESETTING_URLS
+    global _FLAG_CACHE_RESETTING_ALL
+
+    _FLAG_CACHE_CONDITION = threading.Condition()
+    _FLAG_CACHE_RESOLVING = set()
+    _FLAG_CACHE_RESETTING_URLS = {}
+    _FLAG_CACHE_RESETTING_ALL = 0
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_new_deployment_api_flag_cache_after_fork)
 
 
 def reset_new_deployment_api_flag_cache(url: Optional[str] = None) -> None:
@@ -88,11 +134,38 @@ def reset_new_deployment_api_flag_cache(url: Optional[str] = None) -> None:
 
     :param url: clear only the entry for this workspace URL; ``None`` clears all.
     """
-    with _FLAG_CACHE_LOCK:
+    global _FLAG_CACHE_RESETTING_ALL
+
+    with _FLAG_CACHE_CONDITION:
         if url is None:
-            _NEW_DEPLOYMENT_API_FLAG_CACHE.clear()
+            _FLAG_CACHE_RESETTING_ALL += 1
         else:
-            _NEW_DEPLOYMENT_API_FLAG_CACHE.pop(url, None)
+            _FLAG_CACHE_RESETTING_URLS[url] = _FLAG_CACHE_RESETTING_URLS.get(url, 0) + 1
+        _FLAG_CACHE_CONDITION.notify_all()
+
+        try:
+            _FLAG_CACHE_CONDITION.wait_for(
+                lambda: not any(
+                    url is None or cache_key[0] == url
+                    for cache_key in _FLAG_CACHE_RESOLVING
+                )
+            )
+            if url is None:
+                _NEW_DEPLOYMENT_API_FLAG_CACHE.clear()
+            else:
+                for cache_key in list(_NEW_DEPLOYMENT_API_FLAG_CACHE):
+                    if cache_key[0] == url:
+                        del _NEW_DEPLOYMENT_API_FLAG_CACHE[cache_key]
+        finally:
+            if url is None:
+                _FLAG_CACHE_RESETTING_ALL -= 1
+            else:
+                reset_count = _FLAG_CACHE_RESETTING_URLS[url] - 1
+                if reset_count:
+                    _FLAG_CACHE_RESETTING_URLS[url] = reset_count
+                else:
+                    del _FLAG_CACHE_RESETTING_URLS[url]
+            _FLAG_CACHE_CONDITION.notify_all()
 
 
 class APIClient(object):
@@ -270,9 +343,16 @@ class APIClient(object):
         self._endpoint_api = EndpointAPI(self)
         self._devpod_api = DevPodAPI(self)
 
+        # Preserve the historically writable public attributes for SDK users
+        # and tests that inject API doubles. The sentinel distinguishes "no
+        # override" from an intentional assignment of None.
+        self._deployment_override = _API_RESOURCE_OVERRIDE_UNSET
+        self._pod_override = _API_RESOURCE_OVERRIDE_UNSET
+
         # Per-instance mirror of the process-wide resolved flag (keyed by
-        # workspace URL in `_NEW_DEPLOYMENT_API_FLAG_CACHE`). None means "not yet
-        # read on this client"; it is populated from the memo on first access.
+        # workspace URL and credential fingerprint in
+        # `_NEW_DEPLOYMENT_API_FLAG_CACHE`). None means "not yet read on this
+        # client"; it is populated from the memo on first access.
         self._new_deployment_api_enabled: Optional[bool] = None
 
     @property
@@ -280,16 +360,16 @@ class APIClient(object):
         """Whether the workspace has the new endpoint/devpod API enabled.
 
         Resolved once, then committed for the lifetime of the *process* (not
-        just this client) via a workspace-URL-keyed memo. The first access on
-        the first client for a workspace does a single ``info()`` resolution
-        with a small bounded retry; the resulting bool — ``True`` OR ``False``,
+        just this client) via a workspace-URL-and-credential-keyed memo. The
+        first access for a cache key does a single ``info()`` resolution with a
+        small bounded retry; the resulting bool — ``True`` OR ``False``,
         including a ``False`` committed after the retries are exhausted — is
-        stored and returned unconditionally for every later access, on this
-        client and on any other client built for the same workspace in the same
-        invocation. The semantics mirror the dashboard's ``useEndpointApiMode``:
-        only an explicit ``true`` for ``features.enable_new_deployment_api``
-        switches to the new routes; an absent field, ``false``, or a missing
-        ``features`` object stays on the legacy routes.
+        stored and returned unconditionally for every later access using that
+        URL and credential. The semantics mirror the dashboard's
+        ``useEndpointApiMode``: only an explicit ``true`` for
+        ``features.enable_new_deployment_api`` switches to the new routes; an
+        absent field, ``false``, or a missing ``features`` object stays on the
+        legacy routes.
 
         Why commit unconditionally (superseding the earlier no-cache-on-failure
         design): the ``lep`` CLI is a short-lived process, and many operations
@@ -315,30 +395,53 @@ class APIClient(object):
         consumer that needs to pick up a flip can call
         :func:`reset_new_deployment_api_flag_cache` to force a re-resolution.
 
-        Concurrency: the cold-memo resolve-and-commit runs single-flight under
-        ``_FLAG_CACHE_LOCK`` (double-checked), so concurrent first accesses from
-        different threads/clients on the same workspace URL do exactly one
-        /workspace resolution and commit one dispatch decision — they cannot
-        split routing across API families.
+        Concurrency: cold-memo resolution is single-flight per workspace URL and
+        credential fingerprint. Concurrent callers for one key share exactly
+        one /workspace resolution, while unrelated keys resolve concurrently.
+        The global condition is never held during network I/O or retry sleeps.
 
         @implements LEP-5664, LEP-5665 (flag detection)
         """
-        cached = _NEW_DEPLOYMENT_API_FLAG_CACHE.get(self.url)
-        if cached is not None:
-            self._new_deployment_api_enabled = cached
-            return cached
-        with _FLAG_CACHE_LOCK:
-            # Re-check under the lock: another thread may have resolved and
-            # committed while we waited, in which case we adopt its decision
-            # rather than issuing a second /workspace call.
-            cached = _NEW_DEPLOYMENT_API_FLAG_CACHE.get(self.url)
-            if cached is not None:
-                self._new_deployment_api_enabled = cached
-                return cached
+        cache_key = (
+            self.url,
+            _new_deployment_api_credential_fingerprint(self.auth_token),
+        )
+
+        while True:
+            with _FLAG_CACHE_CONDITION:
+                _FLAG_CACHE_CONDITION.wait_for(
+                    lambda: not _FLAG_CACHE_RESETTING_ALL
+                    and not _FLAG_CACHE_RESETTING_URLS.get(self.url)
+                )
+
+                cached = _NEW_DEPLOYMENT_API_FLAG_CACHE.get(cache_key)
+                if cached is not None:
+                    self._new_deployment_api_enabled = cached
+                    return cached
+
+                if cache_key not in _FLAG_CACHE_RESOLVING:
+                    _FLAG_CACHE_RESOLVING.add(cache_key)
+                    break
+
+                # A caller for this exact URL/credential is already resolving.
+                # Wake on either its commit or a reset, then re-check all state.
+                _FLAG_CACHE_CONDITION.wait()
+
+        try:
             resolved = self._resolve_new_deployment_api()
-            _NEW_DEPLOYMENT_API_FLAG_CACHE[self.url] = resolved
-            self._new_deployment_api_enabled = resolved
-            return resolved
+        except BaseException:
+            with _FLAG_CACHE_CONDITION:
+                _FLAG_CACHE_RESOLVING.discard(cache_key)
+                _FLAG_CACHE_CONDITION.notify_all()
+            raise
+
+        with _FLAG_CACHE_CONDITION:
+            _NEW_DEPLOYMENT_API_FLAG_CACHE[cache_key] = resolved
+            _FLAG_CACHE_RESOLVING.discard(cache_key)
+            _FLAG_CACHE_CONDITION.notify_all()
+
+        self._new_deployment_api_enabled = resolved
+        return resolved
 
     def _resolve_new_deployment_api(self) -> bool:
         """Resolve the new-deployment-API flag from workspace info, once.
@@ -347,14 +450,14 @@ class APIClient(object):
         .enable_new_deployment_api is True`` yields ``True``; an absent flag,
         missing ``features``, or an unresolvable /workspace call (after a small
         bounded retry) all yield ``False``. This is called at most once per
-        workspace URL per process — the caller commits the result to the
-        process-wide memo — so a transient blip is retried here rather than
-        being re-litigated on every subsequent dispatch read.
+        workspace URL and credential per process — the caller commits the
+        result to the process-wide memo — so a transient blip is retried here
+        rather than being re-litigated on every subsequent dispatch read.
         """
         info = None
         for attempt in range(_FLAG_RESOLVE_RETRIES + 1):
             try:
-                info = self.info()
+                info = self.info(timeout=_FLAG_RESOLVE_REQUEST_TIMEOUT_SECONDS)
                 break
             except Exception as e:
                 if attempt < _FLAG_RESOLVE_RETRIES:
@@ -384,8 +487,41 @@ class APIClient(object):
         :class:`DeploymentAPI`. Both expose the same method surface and return
         :class:`LeptonDeployment`-shaped objects, so callers are unaffected.
         """
+        if self._deployment_override is not _API_RESOURCE_OVERRIDE_UNSET:
+            return self._deployment_override  # type: ignore[return-value]
         if self.new_deployment_api_enabled:
             return self._endpoint_api
+        return self._deployment_legacy
+
+    @deployment.setter
+    def deployment(self, value) -> None:
+        """Override the deployment API, preserving the legacy writable surface."""
+        self._deployment_override = value
+        # Keep a public-name mirror so unittest.mock.patch.object can tell an
+        # explicit instance override from the value produced dynamically by
+        # this property.  Without it, a nested patch sees the outer override
+        # only through getattr(), treats it as inherited, and drops it during
+        # cleanup instead of restoring it.
+        self.__dict__["deployment"] = value
+
+    @deployment.deleter
+    def deployment(self) -> None:
+        """Clear an injected deployment API override."""
+        self._deployment_override = _API_RESOURCE_OVERRIDE_UNSET
+        self.__dict__.pop("deployment", None)
+
+    def _deployment_api_for_legacy_pod(self):
+        """Return an injected deployment wrapper or the stable legacy API.
+
+        Legacy :class:`PodAPI` methods historically delegate to the deployment
+        wrapper. Tests and SDK callers can replace that wrapper through the
+        writable ``deployment`` property, so honor an explicit replacement.
+        In the normal case, avoid the public dispatching getter: resolving it in
+        a flag-on workspace would incorrectly send a legacy PodAPI call to the
+        new EndpointAPI.
+        """
+        if self._deployment_override is not _API_RESOURCE_OVERRIDE_UNSET:
+            return self._deployment_override
         return self._deployment_legacy
 
     @property
@@ -396,9 +532,25 @@ class APIClient(object):
         workspace flag is on, otherwise the legacy /deployments-based
         :class:`PodAPI`.
         """
+        if self._pod_override is not _API_RESOURCE_OVERRIDE_UNSET:
+            return self._pod_override  # type: ignore[return-value]
         if self.new_deployment_api_enabled:
             return self._devpod_api
         return self._pod_legacy
+
+    @pod.setter
+    def pod(self, value) -> None:
+        """Override the pod API, preserving the legacy writable surface."""
+        self._pod_override = value
+        # See the deployment setter: this mirror preserves an existing outer
+        # override across a temporary unittest.mock.patch.object assignment.
+        self.__dict__["pod"] = value
+
+    @pod.deleter
+    def pod(self) -> None:
+        """Clear an injected pod API override."""
+        self._pod_override = _API_RESOURCE_OVERRIDE_UNSET
+        self.__dict__.pop("pod", None)
 
     def _safe_add(self, kwargs: Dict) -> Dict:
         """
@@ -429,12 +581,19 @@ class APIClient(object):
     def _head(self, path: str, *args, **kwargs):
         return self._session.head(self.url + path, *args, **self._safe_add(kwargs))
 
-    def info(self) -> WorkspaceInfo:
+    def info(self, timeout: Optional[float] = None) -> WorkspaceInfo:
         """
         Returns the workspace info.
+
+        :param timeout: optional request timeout in seconds. When omitted, use
+            the client's normal request timeout.
         """
         ws_api = APIResourse(self)
-        response = self._get("/workspace")
+        response = (
+            self._get("/workspace", timeout=timeout)
+            if timeout is not None
+            else self._get("/workspace")
+        )
         auth_token_hint = (
             self.auth_token[:2] + "****" + self.auth_token[-2:]
             if self.auth_token

--- a/leptonai/api/v2/devpod.py
+++ b/leptonai/api/v2/devpod.py
@@ -9,17 +9,16 @@ exposes the same method surface and returns the same
 Route coverage (verified against api-server refs/base/main devpod/handler.go):
 - list/create/get/update/delete + ``/:did/restart`` + ``/:did/history``
 - ``/:did/shell``, ``/:did/network-connectivity``
+- ``/:did/log`` (api-server/httpapi/log/handler_log.go) — a devpod runs a single
+  pod, so logs stream by devpod id with no replica id required.
 
 Deliberately NOT available (no route exists on the devpod surface):
 - ``/devpods/:did/events`` — verified missing; ``get_events`` is unsupported.
-- per-replica log path — devpods run a single pod; the legacy PodAPI derived
-  logs from the single replica. The new devpod API has no replica log route, so
-  ``get_log`` degrades explicitly.
 
 Stop/start uses the ``spec.stopped`` boolean switch (PATCH), not scale-to-zero.
 """
 
-from typing import Union, List, Optional
+from typing import Union, List, Iterator, Optional
 import warnings
 
 from .api_resource import APIResourse
@@ -154,13 +153,23 @@ class DevPodAPI(APIResourse):
         self,
         name_or_deployment: Union[str, LeptonDeployment],
         timeout: Optional[int] = None,
-    ):
-        """Not available on the new devpod API.
+    ) -> Iterator[str]:
+        """Stream the devpod's logs.
 
-        The new devpod surface has no per-replica log route. ``lep pod log``
-        degrades to a clear message rather than 404.
+        The new devpod API serves logs at ``GET /devpods/:did/log`` (devpod runs a
+        single pod, so no replica id is needed — the backend streams the pod's
+        logs by name). Mirrors :meth:`EndpointAPI.get_log`'s streaming behavior.
         """
-        raise NewDevPodAPIUnsupported(
-            "streaming logs is not yet supported by the new devpod API; use the"
-            " web portal to view devpod logs"
+        response = self._get(
+            f"/devpods/{self._to_name(name_or_deployment)}/log",
+            stream=True,
+            timeout=timeout,
         )
+        if not response.ok:
+            raise RuntimeError(
+                f"API call failed with status code {response.status_code}. Details:"
+                f" {response.text}"
+            )
+        for chunk in response.iter_content(chunk_size=None):
+            if chunk:
+                yield chunk.decode("utf8")

--- a/leptonai/api/v2/devpod.py
+++ b/leptonai/api/v2/devpod.py
@@ -1,0 +1,166 @@
+"""DevPodAPI — the new /devpods-based implementation of the pod API.
+
+This is the flag-on counterpart of :class:`leptonai.api.v2.pod.PodAPI`. It
+exposes the same method surface and returns the same
+:class:`LeptonDeployment`-shaped (pod) objects, but talks to the new
+``/devpods`` routes (LEP-5665) and translates request/response bodies via
+:mod:`leptonai.api.v2.translation`.
+
+Route coverage (verified against api-server refs/base/main devpod/handler.go):
+- list/create/get/update/delete + ``/:did/restart`` + ``/:did/history``
+- ``/:did/shell``, ``/:did/network-connectivity``
+
+Deliberately NOT available (no route exists on the devpod surface):
+- ``/devpods/:did/events`` — verified missing; ``get_events`` is unsupported.
+- per-replica log path — devpods run a single pod; the legacy PodAPI derived
+  logs from the single replica. The new devpod API has no replica log route, so
+  ``get_log`` degrades explicitly.
+
+Stop/start uses the ``spec.stopped`` boolean switch (PATCH), not scale-to-zero.
+"""
+
+from typing import Union, List, Optional
+import warnings
+
+from .api_resource import APIResourse
+from .types.deployment import LeptonDeployment, LeptonDeploymentUserSpec
+from .types.readiness import ReadinessIssue
+from .types.termination import DeploymentTerminations
+from . import translation
+
+
+class NewDevPodAPIUnsupported(RuntimeError):
+    """Raised when a legacy sub-operation has no equivalent on the new devpod
+    API and cannot be silently emulated. Carries a user-facing message.
+    """
+
+
+class DevPodAPI(APIResourse):
+    def _to_name(self, name_or_pod: Union[str, LeptonDeployment]) -> str:
+        return (  # type: ignore
+            name_or_pod if isinstance(name_or_pod, str) else name_or_pod.metadata.id_
+        )
+
+    def _http_devpod_to_model(self, raw: dict) -> LeptonDeployment:
+        return LeptonDeployment(**translation.http_devpod_to_legacy(raw))
+
+    def _sanity_check_pod_spec(self, spec: Optional[LeptonDeploymentUserSpec]):
+        """Mirror the legacy PodAPI sanity checks so behavior is identical
+        regardless of mode. Fields with no effect in a pod are warned + cleared;
+        the translation layer additionally drops them from the devpod payload.
+        """
+        if spec is None:
+            warnings.warn(
+                "You have not specified a pod spec - is that intentional?",
+                RuntimeWarning,
+            )
+            return None
+        if not spec.is_pod:
+            raise ValueError("The spec is not a pod spec.")
+        if spec.resource_requirement:
+            if spec.resource_requirement.min_replicas not in (None, 1):
+                warnings.warn(
+                    "min_replicas does not take effect in pod spec.", RuntimeWarning
+                )
+                spec.resource_requirement.min_replicas = 1
+            if spec.resource_requirement.max_replicas not in (None, 1):
+                warnings.warn(
+                    "max_replicas does not take effect in pod spec.", RuntimeWarning
+                )
+                spec.resource_requirement.max_replicas = 1
+        if spec.auto_scaler:
+            warnings.warn(
+                "Auto scaler does not take effect in pod spec.", RuntimeWarning
+            )
+            spec.auto_scaler = None
+        if spec.api_tokens:
+            warnings.warn("API tokens do not take effect in pod spec.", RuntimeWarning)
+            spec.api_tokens = None
+        return spec
+
+    def list_all(self) -> List[LeptonDeployment]:
+        # GET /devpods returns a bare array of HTTPDevPod by default.
+        response = self._get("/devpods")
+        items = self.ensure_json(response)
+        return [self._http_devpod_to_model(item) for item in items]
+
+    def create(self, spec: LeptonDeployment) -> bool:
+        """Create a devpod from a legacy pod deployment spec.
+
+        @implements LEP-5665 (devpod create via new API)
+        """
+        spec.spec = self._sanity_check_pod_spec(spec.spec)
+        payload = translation.legacy_to_http_devpod(self.safe_json(spec))
+        response = self._post("/devpods", json=payload)
+        return self.ensure_ok(response)
+
+    def get(self, name_or_pod: Union[str, LeptonDeployment]) -> LeptonDeployment:
+        response = self._get(f"/devpods/{self._to_name(name_or_pod)}")
+        self._raise_if_not_ok(response)
+        return self._http_devpod_to_model(response.json())
+
+    def update(
+        self, name_or_deployment: Union[str, LeptonDeployment], spec: LeptonDeployment
+    ) -> LeptonDeployment:
+        # Matches legacy PodAPI: updating a pod is not supported.
+        raise RuntimeError(
+            "Updating a pod is not supported. Updating a pod will cause all pod"
+            " resources (including local storage) to be lost, and we strongly recommend"
+            " you to be careful in doing so."
+        )
+
+    def stop(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> LeptonDeployment:
+        """Stop the devpod via the ``spec.stopped`` switch (PATCH).
+
+        The new devpod API uses ``{"spec": {"stopped": true}}`` rather than
+        scaling to zero replicas (devpod-api.ts ``podStopPatch``).
+        """
+        name = self._to_name(name_or_deployment)
+        response = self._patch(f"/devpods/{name}", json={"spec": {"stopped": True}})
+        self._raise_if_not_ok(response)
+        return self._http_devpod_to_model(response.json())
+
+    def delete(self, name_or_deployment: Union[str, LeptonDeployment]) -> bool:
+        response = self._delete(f"/devpods/{self._to_name(name_or_deployment)}")
+        return self.ensure_ok(response)
+
+    def restart(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> LeptonDeployment:
+        # PUT /devpods/:did/restart (devpod/handler.go).
+        response = self._put(f"/devpods/{self._to_name(name_or_deployment)}/restart")
+        self._raise_if_not_ok(response)
+        return self._http_devpod_to_model(response.json())
+
+    def get_readiness(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> ReadinessIssue:
+        """Not available on the new devpod API — no standalone readiness route."""
+        raise NewDevPodAPIUnsupported(
+            "readiness detail is not yet supported by the new devpod API"
+        )
+
+    def get_termination(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> DeploymentTerminations:
+        """Not available on the new devpod API — no standalone termination route."""
+        raise NewDevPodAPIUnsupported(
+            "termination detail is not yet supported by the new devpod API"
+        )
+
+    def get_log(
+        self,
+        name_or_deployment: Union[str, LeptonDeployment],
+        timeout: Optional[int] = None,
+    ):
+        """Not available on the new devpod API.
+
+        The new devpod surface has no per-replica log route. ``lep pod log``
+        degrades to a clear message rather than 404.
+        """
+        raise NewDevPodAPIUnsupported(
+            "streaming logs is not yet supported by the new devpod API; use the"
+            " web portal to view devpod logs"
+        )

--- a/leptonai/api/v2/devpod.py
+++ b/leptonai/api/v2/devpod.py
@@ -9,8 +9,9 @@ exposes the same method surface and returns the same
 Route coverage (verified against api-server refs/base/main devpod/handler.go):
 - list/create/get/update/delete + ``/:did/restart`` + ``/:did/history``
 - ``/:did/shell``, ``/:did/network-connectivity``
-- ``/:did/log`` (api-server/httpapi/log/handler_log.go) — a devpod runs a single
-  pod, so logs stream by devpod id with no replica id required.
+- ``/:did/log`` (api-server/httpapi/log/handler_log.go) — historical Loki JSON
+  is available by DevPod ID, but the legacy live-text stream requires a replica
+  ID that the DevPod API does not expose.
 
 Deliberately NOT available (no route exists on the devpod surface):
 - ``/devpods/:did/events`` — verified missing; ``get_events`` is unsupported.
@@ -18,6 +19,7 @@ Deliberately NOT available (no route exists on the devpod surface):
 Stop/start uses the ``spec.stopped`` boolean switch (PATCH), not scale-to-zero.
 """
 
+import sys
 from typing import Union, List, Iterator, Optional
 import warnings
 
@@ -41,7 +43,12 @@ class DevPodAPI(APIResourse):
         )
 
     def _http_devpod_to_model(self, raw: dict) -> LeptonDeployment:
-        return LeptonDeployment(**translation.http_devpod_to_legacy(raw))
+        if not isinstance(raw, dict):
+            raise TypeError(f"expected a DevPod object, got {type(raw).__name__}")
+        model = LeptonDeployment(**translation.http_devpod_to_legacy(raw))
+        if model.metadata is None or not (model.metadata.name or model.metadata.id_):
+            raise ValueError("DevPod response is missing metadata.name")
+        return model
 
     def _sanity_check_pod_spec(self, spec: Optional[LeptonDeploymentUserSpec]):
         """Mirror the legacy PodAPI sanity checks so behavior is identical
@@ -78,10 +85,31 @@ class DevPodAPI(APIResourse):
         return spec
 
     def list_all(self) -> List[LeptonDeployment]:
-        # GET /devpods returns a bare array of HTTPDevPod by default.
+        # GET /devpods returns a bare array of HTTPDevPod by default. Preserve
+        # ensure_list's per-item tolerance for compatibility with legacy lists.
         response = self._get("/devpods")
         items = self.ensure_json(response)
-        return [self._http_devpod_to_model(item) for item in items]
+        valid_items = []
+        errors = []
+        for index, item in enumerate(items):
+            try:
+                valid_items.append(self._http_devpod_to_model(item))
+            except Exception as e:
+                errors.append(f"\n index {index}: {e}\nitem: {item}")
+        if errors:
+            sys.stderr.write(
+                f"[lepton-error] Skipped {len(errors)} invalid devpod(s) when parsing"
+                " list response:"
+                + "".join(errors)
+                + "\n"
+            )
+        return valid_items
+
+    def validate_create(self, spec: LeptonDeployment) -> None:
+        """Validate a create locally without mutating the supplied model."""
+        if spec.spec is not None and spec.spec.is_pod is not True:
+            raise ValueError("The spec is not a pod spec.")
+        translation.legacy_to_http_devpod(self.safe_json(spec))
 
     def create(self, spec: LeptonDeployment) -> bool:
         """Create a devpod from a legacy pod deployment spec.
@@ -154,22 +182,15 @@ class DevPodAPI(APIResourse):
         name_or_deployment: Union[str, LeptonDeployment],
         timeout: Optional[int] = None,
     ) -> Iterator[str]:
-        """Stream the devpod's logs.
+        """Reject the unavailable legacy live-text stream explicitly.
 
-        The new devpod API serves logs at ``GET /devpods/:did/log`` (devpod runs a
-        single pod, so no replica id is needed — the backend streams the pod's
-        logs by name). Mirrors :meth:`EndpointAPI.get_log`'s streaming behavior.
+        ``GET /devpods/:did/log`` without ``replica=`` returns a bounded Loki
+        JSON response. The backend selects its live kubelet stream only when a
+        replica ID is supplied, but no DevPod replica-list/status contract
+        exposes that ID. Yielding the JSON transport as if it were live log text
+        would silently violate :meth:`PodAPI.get_log` semantics.
         """
-        response = self._get(
-            f"/devpods/{self._to_name(name_or_deployment)}/log",
-            stream=True,
-            timeout=timeout,
+        raise NewDevPodAPIUnsupported(
+            "live DevPod log streaming is not yet supported by the new DevPod API; "
+            "the dedicated route only exposes bounded historical logs"
         )
-        if not response.ok:
-            raise RuntimeError(
-                f"API call failed with status code {response.status_code}. Details:"
-                f" {response.text}"
-            )
-        for chunk in response.iter_content(chunk_size=None):
-            if chunk:
-                yield chunk.decode("utf8")

--- a/leptonai/api/v2/endpoint.py
+++ b/leptonai/api/v2/endpoint.py
@@ -1,0 +1,188 @@
+"""EndpointAPI — the new /endpoints-based implementation of the deployment API.
+
+This is the flag-on counterpart of :class:`leptonai.api.v2.deployment.DeploymentAPI`.
+It exposes the same method surface and returns the same
+:class:`LeptonDeployment`-shaped objects, but talks to the new ``/endpoints``
+routes (LEP-5664) and translates request/response bodies via
+:mod:`leptonai.api.v2.translation`, so CLI commands and SDK callers are
+unaffected by the mode switch.
+
+Route coverage (verified against api-server refs/base/main):
+- list/create/get/update/delete + ``/:eid/restart`` + ``/:eid/history``
+  (endpoint/handler.go)
+- ``/:eid/replicas``, ``/:eid/replicas/:rid/log`` (handler_replica.go)
+- ``/:eid/events`` (events/handler_events.go)
+
+Deliberately NOT available on the new endpoint surface (no route exists), so
+these degrade explicitly rather than 404:
+- standalone readiness / termination: folded into per-replica status server
+  side; there is no ``/endpoints/:eid/readiness`` or ``/termination`` route.
+"""
+
+from typing import Union, List, Iterator, Optional
+
+from .api_resource import APIResourse
+from .types.deployment import LeptonDeployment
+from .types.events import LeptonEvent
+from .types.readiness import ReadinessIssue
+from .types.termination import DeploymentTerminations
+from .types.replica import Replica
+from . import translation
+
+
+class NewEndpointAPIUnsupported(RuntimeError):
+    """Raised when a legacy sub-operation has no equivalent on the new endpoint
+    API and cannot be silently emulated. Carries a user-facing message.
+    """
+
+
+class EndpointAPI(APIResourse):
+    def _to_name(self, name_or_deployment: Union[str, LeptonDeployment]) -> str:
+        return (  # type: ignore
+            name_or_deployment
+            if isinstance(name_or_deployment, str)
+            else name_or_deployment.metadata.id_
+        )
+
+    def _http_endpoint_to_model(self, raw: dict) -> LeptonDeployment:
+        return LeptonDeployment(**translation.http_endpoint_to_legacy(raw))
+
+    def list_all(self) -> List[LeptonDeployment]:
+        # GET /endpoints returns a bare array by default (no pagination params
+        # sent); ensure_json yields that list. Each item is an HTTPEndpoint.
+        response = self._get("/endpoints")
+        items = self.ensure_json(response)
+        return [self._http_endpoint_to_model(item) for item in items]
+
+    def create(self, spec: LeptonDeployment) -> bool:
+        """Create an endpoint from a legacy deployment spec.
+
+        The legacy spec is translated into the HTTPEndpoint create body
+        (single "default" component; endpoint-level fields lifted out).
+
+        @implements LEP-5664 (endpoint create via new API)
+        """
+        payload = translation.legacy_to_http_endpoint(self.safe_json(spec))
+        response = self._post("/endpoints", json=payload)
+        return self.ensure_ok(response)
+
+    def get(self, name_or_deployment: Union[str, LeptonDeployment]) -> LeptonDeployment:
+        response = self._get(f"/endpoints/{self._to_name(name_or_deployment)}")
+        self._raise_if_not_ok(response)
+        return self._http_endpoint_to_model(response.json())
+
+    def _get_raw(self, name: str) -> dict:
+        response = self._get(f"/endpoints/{name}")
+        self._raise_if_not_ok(response)
+        return response.json()
+
+    def update(
+        self,
+        name_or_deployment: Union[str, LeptonDeployment],
+        spec: LeptonDeployment,
+        dryrun: bool = False,
+    ) -> LeptonDeployment:
+        """Update an endpoint from a legacy deployment spec.
+
+        The new API replaces ``spec.components`` wholesale, so the current
+        endpoint is fetched first and the patch resends the full component array
+        with the form's fields overlaid onto the frontend component (RFC7386
+        merge). See :func:`translation.legacy_to_http_endpoint_patch`.
+
+        @implements LEP-5664 (endpoint update via new API)
+        """
+        name = self._to_name(name_or_deployment)
+        raw = self._get_raw(name)
+        payload = translation.legacy_to_http_endpoint_patch(raw, self.safe_json(spec))
+        dryrun_param = "?dryrun=true" if dryrun else ""
+        response = self._patch(f"/endpoints/{name}{dryrun_param}", json=payload)
+        self._raise_if_not_ok(response)
+        return self._http_endpoint_to_model(response.json())
+
+    def stop(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> LeptonDeployment:
+        """Scale the endpoint down to zero replicas via PATCH.
+
+        The new API replaces ``spec.components`` wholesale, so the current
+        endpoint is fetched first and every component's ``min_replicas`` is set
+        to 0 (the "terminate" case in the dashboard's builder).
+        """
+        name = self._to_name(name_or_deployment)
+        raw = self._get_raw(name)
+        payload = translation.build_endpoint_stop_patch(raw)
+        response = self._patch(f"/endpoints/{name}", json=payload)
+        self._raise_if_not_ok(response)
+        return self._http_endpoint_to_model(response.json())
+
+    def delete(self, name_or_deployment: Union[str, LeptonDeployment]) -> bool:
+        response = self._delete(f"/endpoints/{self._to_name(name_or_deployment)}")
+        return self.ensure_ok(response)
+
+    def restart(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> LeptonDeployment:
+        # PUT /endpoints/:eid/restart (endpoint/handler.go) — same verb as legacy.
+        response = self._put(f"/endpoints/{self._to_name(name_or_deployment)}/restart")
+        self._raise_if_not_ok(response)
+        return self._http_endpoint_to_model(response.json())
+
+    def get_readiness(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> ReadinessIssue:
+        """Not available on the new endpoint API.
+
+        The new endpoint surface has no standalone ``/readiness`` route;
+        readiness is folded into per-replica status. ``lep endpoint status``
+        degrades this sub-call to an empty result and prints a note.
+        """
+        raise NewEndpointAPIUnsupported(
+            "per-deployment readiness is not yet supported by the new endpoint"
+            " API; readiness detail is available per-replica"
+        )
+
+    def get_termination(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> DeploymentTerminations:
+        """Not available on the new endpoint API (see :meth:`get_readiness`)."""
+        raise NewEndpointAPIUnsupported(
+            "per-deployment termination history is not yet supported by the new"
+            " endpoint API; termination detail is available per-replica"
+        )
+
+    def get_replicas(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> List[Replica]:
+        # GET /endpoints/:eid/replicas returns the same Replica shape as the
+        # legacy deployment replicas route (handler_replica.go).
+        response = self._get(f"/endpoints/{self._to_name(name_or_deployment)}/replicas")
+        return self.ensure_list(response, Replica)
+
+    def get_log(
+        self,
+        name_or_deployment: Union[str, LeptonDeployment],
+        replica: Union[str, Replica],
+        timeout: Optional[int] = None,
+    ) -> Iterator[str]:
+        replica_id = replica if isinstance(replica, str) else replica.metadata.id_
+        response = self._get(
+            f"/endpoints/{self._to_name(name_or_deployment)}/replicas/{replica_id}/log",
+            stream=True,
+            timeout=timeout,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f"API call failed with status code {response.status_code}. Details:"
+                f" {response.text}"
+            )
+        for chunk in response.iter_content(chunk_size=None):
+            if chunk:
+                yield chunk.decode("utf8")
+
+    def get_events(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> List[LeptonEvent]:
+        # GET /endpoints/:eid/events returns the same event array shape as the
+        # legacy deployment events route (events/handler_events.go).
+        response = self._get(f"/endpoints/{self._to_name(name_or_deployment)}/events")
+        return self.ensure_list(response, LeptonEvent)

--- a/leptonai/api/v2/endpoint.py
+++ b/leptonai/api/v2/endpoint.py
@@ -19,6 +19,8 @@ these degrade explicitly rather than 404:
   side; there is no ``/endpoints/:eid/readiness`` or ``/termination`` route.
 """
 
+import sys
+import warnings
 from typing import Union, List, Iterator, Optional
 
 from .api_resource import APIResourse
@@ -37,7 +39,20 @@ class NewEndpointAPIUnsupported(RuntimeError):
 
 
 class EndpointAPI(APIResourse):
+    @staticmethod
+    def _is_pod_object(value: Union[str, LeptonDeployment]) -> bool:
+        return (
+            not isinstance(value, str)
+            and value.spec is not None
+            and value.spec.is_pod is True
+        )
+
     def _to_name(self, name_or_deployment: Union[str, LeptonDeployment]) -> str:
+        if self._is_pod_object(name_or_deployment):
+            raise ValueError(
+                "A pod-flavoured LeptonDeployment must be handled through the"
+                " DevPod API."
+            )
         return (  # type: ignore
             name_or_deployment
             if isinstance(name_or_deployment, str)
@@ -45,14 +60,45 @@ class EndpointAPI(APIResourse):
         )
 
     def _http_endpoint_to_model(self, raw: dict) -> LeptonDeployment:
-        return LeptonDeployment(**translation.http_endpoint_to_legacy(raw))
+        if not isinstance(raw, dict):
+            raise TypeError(f"expected an endpoint object, got {type(raw).__name__}")
+        model = LeptonDeployment(**translation.http_endpoint_to_legacy(raw))
+        if model.metadata is None or not (model.metadata.name or model.metadata.id_):
+            raise ValueError("endpoint response is missing metadata.name")
+        return model
 
     def list_all(self) -> List[LeptonDeployment]:
         # GET /endpoints returns a bare array by default (no pagination params
-        # sent); ensure_json yields that list. Each item is an HTTPEndpoint.
+        # sent). Match APIResourse.ensure_list's compatibility behavior: one
+        # malformed server item must not make every valid endpoint disappear.
         response = self._get("/endpoints")
         items = self.ensure_json(response)
-        return [self._http_endpoint_to_model(item) for item in items]
+        valid_items = []
+        errors = []
+        for index, item in enumerate(items):
+            try:
+                valid_items.append(self._http_endpoint_to_model(item))
+            except Exception as e:
+                errors.append(f"\n index {index}: {e}\nitem: {item}")
+        if errors:
+            sys.stderr.write(
+                f"[lepton-error] Skipped {len(errors)} invalid endpoint(s) when"
+                " parsing list response:"
+                + "".join(errors)
+                + "\n"
+            )
+        return valid_items
+
+    def validate_create(self, spec: LeptonDeployment) -> None:
+        """Validate a create locally without issuing a request.
+
+        The CLI uses this before deleting an existing workload for ``--rerun``
+        so a translation error cannot turn rerun into delete-only.
+        """
+        if spec.spec is not None and spec.spec.is_pod is True:
+            self._client.pod.validate_create(spec)
+            return
+        translation.legacy_to_http_endpoint(self.safe_json(spec))
 
     def create(self, spec: LeptonDeployment) -> bool:
         """Create an endpoint from a legacy deployment spec.
@@ -62,11 +108,31 @@ class EndpointAPI(APIResourse):
 
         @implements LEP-5664 (endpoint create via new API)
         """
+        # DeploymentAPI historically accepts pod-flavoured specs as well as
+        # exposing create_pod().  Preserve that public surface when the flag
+        # swaps in EndpointAPI; otherwise is_pod is silently dropped and an
+        # endpoint is created instead of a DevPod.
+        if spec.spec is not None and spec.spec.is_pod is True:
+            return self._client.pod.create(spec)
         payload = translation.legacy_to_http_endpoint(self.safe_json(spec))
         response = self._post("/endpoints", json=payload)
         return self.ensure_ok(response)
 
+    def create_pod(self, spec: LeptonDeployment) -> bool:
+        """Deprecated DeploymentAPI-compatible DevPod creation shim."""
+        warnings.warn(
+            "create_pod is deprecated. Use the api under leptonai.api.v2.pod"
+            " instead, which is more explicit and gives more strict param checking.",
+            DeprecationWarning,
+        )
+        if spec.spec is None:
+            raise ValueError("LeptonDeploymentUserSpec must not be None.")
+        spec.spec.is_pod = True
+        return self._client.pod.create(spec)
+
     def get(self, name_or_deployment: Union[str, LeptonDeployment]) -> LeptonDeployment:
+        if self._is_pod_object(name_or_deployment):
+            return self._client.pod.get(name_or_deployment)
         response = self._get(f"/endpoints/{self._to_name(name_or_deployment)}")
         self._raise_if_not_ok(response)
         return self._http_endpoint_to_model(response.json())
@@ -91,6 +157,10 @@ class EndpointAPI(APIResourse):
 
         @implements LEP-5664 (endpoint update via new API)
         """
+        if self._is_pod_object(name_or_deployment) or (
+            spec.spec is not None and spec.spec.is_pod is True
+        ):
+            return self._client.pod.update(name_or_deployment, spec)
         name = self._to_name(name_or_deployment)
         raw = self._get_raw(name)
         payload = translation.legacy_to_http_endpoint_patch(raw, self.safe_json(spec))
@@ -108,6 +178,8 @@ class EndpointAPI(APIResourse):
         endpoint is fetched first and every component's ``min_replicas`` is set
         to 0 (the "terminate" case in the dashboard's builder).
         """
+        if self._is_pod_object(name_or_deployment):
+            return self._client.pod.stop(name_or_deployment)
         name = self._to_name(name_or_deployment)
         raw = self._get_raw(name)
         payload = translation.build_endpoint_stop_patch(raw)
@@ -116,12 +188,16 @@ class EndpointAPI(APIResourse):
         return self._http_endpoint_to_model(response.json())
 
     def delete(self, name_or_deployment: Union[str, LeptonDeployment]) -> bool:
+        if self._is_pod_object(name_or_deployment):
+            return self._client.pod.delete(name_or_deployment)
         response = self._delete(f"/endpoints/{self._to_name(name_or_deployment)}")
         return self.ensure_ok(response)
 
     def restart(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> LeptonDeployment:
+        if self._is_pod_object(name_or_deployment):
+            return self._client.pod.restart(name_or_deployment)
         # PUT /endpoints/:eid/restart (endpoint/handler.go) — same verb as legacy.
         response = self._put(f"/endpoints/{self._to_name(name_or_deployment)}/restart")
         self._raise_if_not_ok(response)
@@ -136,6 +212,8 @@ class EndpointAPI(APIResourse):
         readiness is folded into per-replica status. ``lep endpoint status``
         degrades this sub-call to an empty result and prints a note.
         """
+        if self._is_pod_object(name_or_deployment):
+            return self._client.pod.get_readiness(name_or_deployment)
         raise NewEndpointAPIUnsupported(
             "per-deployment readiness is not yet supported by the new endpoint"
             " API; readiness detail is available per-replica"
@@ -145,6 +223,8 @@ class EndpointAPI(APIResourse):
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> DeploymentTerminations:
         """Not available on the new endpoint API (see :meth:`get_readiness`)."""
+        if self._is_pod_object(name_or_deployment):
+            return self._client.pod.get_termination(name_or_deployment)
         raise NewEndpointAPIUnsupported(
             "per-deployment termination history is not yet supported by the new"
             " endpoint API; termination detail is available per-replica"
@@ -153,6 +233,10 @@ class EndpointAPI(APIResourse):
     def get_replicas(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> List[Replica]:
+        if self._is_pod_object(name_or_deployment):
+            raise NewEndpointAPIUnsupported(
+                "replica listing is not exposed by the new DevPod API"
+            )
         # GET /endpoints/:eid/replicas returns the same Replica shape as the
         # legacy deployment replicas route (handler_replica.go).
         response = self._get(f"/endpoints/{self._to_name(name_or_deployment)}/replicas")
@@ -164,6 +248,9 @@ class EndpointAPI(APIResourse):
         replica: Union[str, Replica],
         timeout: Optional[int] = None,
     ) -> Iterator[str]:
+        if self._is_pod_object(name_or_deployment):
+            yield from self._client.pod.get_log(name_or_deployment, timeout=timeout)
+            return
         replica_id = replica if isinstance(replica, str) else replica.metadata.id_
         response = self._get(
             f"/endpoints/{self._to_name(name_or_deployment)}/replicas/{replica_id}/log",
@@ -182,6 +269,10 @@ class EndpointAPI(APIResourse):
     def get_events(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> List[LeptonEvent]:
+        if self._is_pod_object(name_or_deployment):
+            raise NewEndpointAPIUnsupported(
+                "events are not exposed by the new DevPod API"
+            )
         # GET /endpoints/:eid/events returns the same event array shape as the
         # legacy deployment events route (events/handler_events.go).
         response = self._get(f"/endpoints/{self._to_name(name_or_deployment)}/events")

--- a/leptonai/api/v2/log.py
+++ b/leptonai/api/v2/log.py
@@ -8,6 +8,17 @@ from leptonai.api.v2.types.job import LeptonJobQueryMode
 
 
 class LogAPI(APIResourse):
+    def _workload_log_param(self) -> str:
+        """The query key the shared ``/logs*`` routes use for a deployment/endpoint.
+
+        When the new deployment API is enabled the workload is a LeptonEndpoint,
+        and the backend keys its logs under ``endpoint=`` (a distinct branch in
+        ``api-server/httpapi/log/handler_log.go``); the legacy ``deployment=``
+        key resolves a /deployments resource that does not exist in that mode, so
+        the query would silently return no logs. Off, the legacy key is correct.
+        """
+        return "endpoint" if self._client.new_deployment_api_enabled else "deployment"
+
     def get_log_time_series(
         self,
         name_or_deployment: Union[str, LeptonDeployment] = None,
@@ -62,7 +73,7 @@ class LogAPI(APIResourse):
                 if isinstance(name_or_deployment, str)
                 else name_or_deployment.metadata.id_
             )
-            query_kwargs["deployment"] = deployment_id
+            query_kwargs[self._workload_log_param()] = deployment_id
         elif name_or_job:
             job_id = (
                 name_or_job
@@ -119,7 +130,7 @@ class LogAPI(APIResourse):
                 if isinstance(name_or_deployment, str)
                 else name_or_deployment.metadata.id_
             )
-            query_kwargs["deployment"] = deployment_id
+            query_kwargs[self._workload_log_param()] = deployment_id
 
         elif name_or_job:
             job_id = (

--- a/leptonai/api/v2/pod.py
+++ b/leptonai/api/v2/pod.py
@@ -61,8 +61,13 @@ class PodAPI(APIResourse):
         response = self._post("/deployments", json=self.safe_json(spec))
         return self.ensure_ok(response)
 
+    # Implementation note: this legacy pod API delegates to the legacy
+    # deployment API explicitly (``_deployment_legacy``) rather than the
+    # dispatching ``client.deployment`` property, so its behavior is unaffected
+    # by the new-deployment-API flag. When the flag is on, callers reach the new
+    # DevPodAPI instead of this class entirely.
     def get(self, name_or_pod: Union[str, LeptonDeployment]) -> LeptonDeployment:
-        return self._client.deployment.get(name_or_pod)
+        return self._client._deployment_legacy.get(name_or_pod)
 
     def update(
         self, name_or_deployment: Union[str, LeptonDeployment], spec: LeptonDeployment
@@ -74,22 +79,27 @@ class PodAPI(APIResourse):
         )
 
     def delete(self, name_or_deployment: Union[str, LeptonDeployment]) -> bool:
-        return self._client.deployment.delete(name_or_deployment)
+        return self._client._deployment_legacy.delete(name_or_deployment)
+
+    def stop(
+        self, name_or_deployment: Union[str, LeptonDeployment]
+    ) -> LeptonDeployment:
+        return self._client._deployment_legacy.stop(name_or_deployment)
 
     def restart(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> LeptonDeployment:
-        return self._client.deployment.restart(name_or_deployment)
+        return self._client._deployment_legacy.restart(name_or_deployment)
 
     def get_readiness(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> ReadinessIssue:
-        return self._client.deployment.get_readiness(name_or_deployment)
+        return self._client._deployment_legacy.get_readiness(name_or_deployment)
 
     def get_termination(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> DeploymentTerminations:
-        return self._client.deployment.get_termination(name_or_deployment)
+        return self._client._deployment_legacy.get_termination(name_or_deployment)
 
     # Implementation note: pod does not support get_replicas.
 
@@ -104,13 +114,15 @@ class PodAPI(APIResourse):
         streamed indefinitely, although you should not rely on this behavior as connections
         can be dropped when streamed for a long time.
         """
-        replicas = self._client.deployment.get_replicas(name_or_deployment)
+        replicas = self._client._deployment_legacy.get_replicas(name_or_deployment)
         if len(replicas) != 1:
             raise RuntimeError(
                 "You encountered a programming error: number of replicas should be 1"
                 " for pods."
             )
-        return self._client.deployment.get_log(name_or_deployment, replicas[0], timeout)
+        return self._client._deployment_legacy.get_log(
+            name_or_deployment, replicas[0], timeout
+        )
 
     # TODO: implement api for the various metrics, but for now we will simply ask users
     # to view the metrics from the web portal.

--- a/leptonai/api/v2/pod.py
+++ b/leptonai/api/v2/pod.py
@@ -61,13 +61,15 @@ class PodAPI(APIResourse):
         response = self._post("/deployments", json=self.safe_json(spec))
         return self.ensure_ok(response)
 
-    # Implementation note: this legacy pod API delegates to the legacy
-    # deployment API explicitly (``_deployment_legacy``) rather than the
-    # dispatching ``client.deployment`` property, so its behavior is unaffected
-    # by the new-deployment-API flag. When the flag is on, callers reach the new
-    # DevPodAPI instead of this class entirely.
+    # Implementation note: this legacy pod API delegates through an internal
+    # accessor that honors an explicitly injected deployment wrapper while
+    # otherwise returning ``_deployment_legacy`` directly. It intentionally does
+    # not read the dispatching ``client.deployment`` property: in a flag-on
+    # workspace that property returns EndpointAPI, not the legacy API PodAPI was
+    # built around. When the flag is on, ordinary callers reach DevPodAPI instead
+    # of this class entirely.
     def get(self, name_or_pod: Union[str, LeptonDeployment]) -> LeptonDeployment:
-        return self._client._deployment_legacy.get(name_or_pod)
+        return self._client._deployment_api_for_legacy_pod().get(name_or_pod)
 
     def update(
         self, name_or_deployment: Union[str, LeptonDeployment], spec: LeptonDeployment
@@ -79,27 +81,31 @@ class PodAPI(APIResourse):
         )
 
     def delete(self, name_or_deployment: Union[str, LeptonDeployment]) -> bool:
-        return self._client._deployment_legacy.delete(name_or_deployment)
+        return self._client._deployment_api_for_legacy_pod().delete(name_or_deployment)
 
     def stop(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> LeptonDeployment:
-        return self._client._deployment_legacy.stop(name_or_deployment)
+        return self._client._deployment_api_for_legacy_pod().stop(name_or_deployment)
 
     def restart(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> LeptonDeployment:
-        return self._client._deployment_legacy.restart(name_or_deployment)
+        return self._client._deployment_api_for_legacy_pod().restart(name_or_deployment)
 
     def get_readiness(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> ReadinessIssue:
-        return self._client._deployment_legacy.get_readiness(name_or_deployment)
+        return self._client._deployment_api_for_legacy_pod().get_readiness(
+            name_or_deployment
+        )
 
     def get_termination(
         self, name_or_deployment: Union[str, LeptonDeployment]
     ) -> DeploymentTerminations:
-        return self._client._deployment_legacy.get_termination(name_or_deployment)
+        return self._client._deployment_api_for_legacy_pod().get_termination(
+            name_or_deployment
+        )
 
     # Implementation note: pod does not support get_replicas.
 
@@ -114,15 +120,14 @@ class PodAPI(APIResourse):
         streamed indefinitely, although you should not rely on this behavior as connections
         can be dropped when streamed for a long time.
         """
-        replicas = self._client._deployment_legacy.get_replicas(name_or_deployment)
+        deployment_api = self._client._deployment_api_for_legacy_pod()
+        replicas = deployment_api.get_replicas(name_or_deployment)
         if len(replicas) != 1:
             raise RuntimeError(
                 "You encountered a programming error: number of replicas should be 1"
                 " for pods."
             )
-        return self._client._deployment_legacy.get_log(
-            name_or_deployment, replicas[0], timeout
-        )
+        return deployment_api.get_log(name_or_deployment, replicas[0], timeout)
 
     # TODO: implement api for the various metrics, but for now we will simply ask users
     # to view the metrics from the web portal.

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -1,0 +1,429 @@
+"""Tests for the new /endpoints + /devpods API dispatch (LEP-5664 / LEP-5665).
+
+These use ``responses`` to mock the HTTP layer. The SDK talks to the backend
+through ``requests.Session`` (see APIClient), so ``responses`` — not ``respx``
+(which mocks httpx) — is the correct mocking library here.
+
+Coverage:
+- flag detection: features.enable_new_deployment_api explicit-true semantics,
+  fail-safe to legacy on absent / false / missing-features / info() error
+- flag caching: a single /workspace call resolves the flag for the client
+- flag OFF: deployment/pod command paths hit the legacy /deployments routes
+  byte-identically
+- flag ON: endpoint command paths hit /endpoints; devpod paths hit /devpods
+- pod create path: legacy POST /deployments (off) vs POST /devpods (on)
+"""
+
+import os
+import tempfile
+
+# Set cache dir to a temp dir before importing anything from leptonai, matching
+# the existing CLI test suite so tests never touch a real workspace record.
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+import unittest
+
+import responses
+
+from leptonai.api.v2.client import APIClient
+from leptonai.api.v2.types.common import Metadata
+from leptonai.api.v2.types.deployment import (
+    LeptonDeployment,
+    LeptonDeploymentUserSpec,
+    LeptonContainer,
+    ResourceRequirement,
+)
+
+BASE = "https://gw.example/api/v2/workspaces/ws1"
+
+
+def _make_client() -> APIClient:
+    return APIClient(workspace_id="ws1", auth_token="tok", url=BASE)
+
+
+def _workspace_info(enable_new_deployment_api=None, include_features=True):
+    """A minimal but schema-valid /workspace info body."""
+    info = {
+        "build_time": "t",
+        "git_commit": "0.1.2",
+        "workspace_name": "ws1",
+        "workspace_tier": "basic",
+        "workspace_state": "normal",
+        "supported_shapes": {},
+        "workspace_disk_usage_bytes": 0,
+        "workloads": {
+            "num_deployments": 0,
+            "num_jobs": 0,
+            "num_pods": 0,
+            "num_secrets": 0,
+            "num_image_pull_secrets": 0,
+        },
+        "resource_quota": {
+            "limit": {"cpu": 0.0, "memory": 0, "accelerator_num": 0.0},
+            "used": {"cpu": 0.0, "memory": 0, "accelerator_num": 0.0},
+        },
+    }
+    if include_features:
+        features = {}
+        if enable_new_deployment_api is not None:
+            features["enable_new_deployment_api"] = enable_new_deployment_api
+        info["features"] = features
+    return info
+
+
+def _register_workspace(enable_new_deployment_api=None, include_features=True):
+    responses.add(
+        responses.GET,
+        f"{BASE}/workspace",
+        json=_workspace_info(enable_new_deployment_api, include_features),
+        status=200,
+    )
+
+
+def _endpoint_body(name="my-ep"):
+    return {
+        "metadata": {"id": name, "name": name, "created_at": 1},
+        "spec": {
+            "components": [{
+                "name": "default",
+                "image": "nginx",
+                "resource_shape": "cpu.small",
+                "min_replicas": 1,
+            }]
+        },
+        "status": {"state": "Ready", "external_url": "https://x.example"},
+    }
+
+
+def _devpod_body(name="my-pod", stopped=False):
+    return {
+        "metadata": {"name": name, "created_at": 1},
+        "spec": {
+            "container": {"image": "ubuntu"},
+            "resource_shape": "cpu.small",
+            "stopped": stopped,
+        },
+        "status": {"state": "Ready"},
+    }
+
+
+def _pod_spec(name="my-pod"):
+    return LeptonDeployment(
+        metadata=Metadata(name=name),
+        spec=LeptonDeploymentUserSpec(
+            container=LeptonContainer(image="ubuntu"),
+            resource_requirement=ResourceRequirement(resource_shape="cpu.small"),
+            is_pod=True,
+        ),
+    )
+
+
+def _deployment_spec(name="my-ep"):
+    return LeptonDeployment(
+        metadata=Metadata(name=name),
+        spec=LeptonDeploymentUserSpec(
+            container=LeptonContainer(image="nginx"),
+            resource_requirement=ResourceRequirement(
+                resource_shape="cpu.small", min_replicas=1
+            ),
+        ),
+    )
+
+
+def _urls_called():
+    return [c.request.url for c in responses.calls]
+
+
+class TestFlagDetection(unittest.TestCase):
+    @responses.activate
+    def test_explicit_true_enables_new_api(self):
+        _register_workspace(enable_new_deployment_api=True)
+        client = _make_client()
+        self.assertTrue(client.new_deployment_api_enabled)
+
+    @responses.activate
+    def test_explicit_false_stays_legacy(self):
+        _register_workspace(enable_new_deployment_api=False)
+        client = _make_client()
+        self.assertFalse(client.new_deployment_api_enabled)
+
+    @responses.activate
+    def test_absent_flag_stays_legacy(self):
+        # features present but flag key absent -> legacy
+        _register_workspace(enable_new_deployment_api=None)
+        client = _make_client()
+        self.assertFalse(client.new_deployment_api_enabled)
+
+    @responses.activate
+    def test_missing_features_object_stays_legacy(self):
+        _register_workspace(include_features=False)
+        client = _make_client()
+        self.assertFalse(client.new_deployment_api_enabled)
+
+    @responses.activate
+    def test_info_error_fails_safe_to_legacy(self):
+        responses.add(responses.GET, f"{BASE}/workspace", status=500)
+        client = _make_client()
+        self.assertFalse(client.new_deployment_api_enabled)
+
+    @responses.activate
+    def test_flag_is_cached_single_workspace_call(self):
+        _register_workspace(enable_new_deployment_api=True)
+        client = _make_client()
+        # Access several times; only one /workspace call should be made.
+        for _ in range(5):
+            self.assertTrue(client.new_deployment_api_enabled)
+        workspace_calls = [
+            c for c in responses.calls if c.request.url == f"{BASE}/workspace"
+        ]
+        self.assertEqual(len(workspace_calls), 1)
+
+
+class TestFlagOffLegacyRoutes(unittest.TestCase):
+    @responses.activate
+    def test_list_uses_legacy_deployments(self):
+        _register_workspace(enable_new_deployment_api=False)
+        responses.add(responses.GET, f"{BASE}/deployments", json=[], status=200)
+        client = _make_client()
+        client.deployment.list_all()
+        self.assertIn(f"{BASE}/deployments", _urls_called())
+
+    @responses.activate
+    def test_create_uses_legacy_deployments(self):
+        _register_workspace(enable_new_deployment_api=False)
+        responses.add(responses.POST, f"{BASE}/deployments", json={}, status=200)
+        client = _make_client()
+        client.deployment.create(_deployment_spec())
+        posts = [c.request.url for c in responses.calls if c.request.method == "POST"]
+        self.assertEqual(posts, [f"{BASE}/deployments"])
+
+    @responses.activate
+    def test_pod_create_uses_legacy_deployments(self):
+        _register_workspace(enable_new_deployment_api=False)
+        responses.add(responses.POST, f"{BASE}/deployments", json={}, status=200)
+        client = _make_client()
+        client.pod.create(_pod_spec())
+        posts = [c.request.url for c in responses.calls if c.request.method == "POST"]
+        self.assertEqual(posts, [f"{BASE}/deployments"])
+
+
+class TestFlagOnEndpointRoutes(unittest.TestCase):
+    @responses.activate
+    def test_list_uses_endpoints(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET, f"{BASE}/endpoints", json=[_endpoint_body()], status=200
+        )
+        client = _make_client()
+        result = client.deployment.list_all()
+        self.assertIn(f"{BASE}/endpoints", _urls_called())
+        self.assertNotIn(f"{BASE}/deployments", _urls_called())
+        self.assertEqual(result[0].metadata.name, "my-ep")
+        self.assertEqual(result[0].spec.container.image, "nginx")
+
+    @responses.activate
+    def test_get_uses_endpoints_and_translates(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET, f"{BASE}/endpoints/my-ep", json=_endpoint_body(), status=200
+        )
+        client = _make_client()
+        dep = client.deployment.get("my-ep")
+        self.assertIn(f"{BASE}/endpoints/my-ep", _urls_called())
+        self.assertEqual(dep.spec.resource_requirement.resource_shape, "cpu.small")
+        self.assertEqual(dep.status.endpoint.external_endpoint, "https://x.example")
+
+    @responses.activate
+    def test_create_posts_component_payload_to_endpoints(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(responses.POST, f"{BASE}/endpoints", json={}, status=200)
+        client = _make_client()
+        client.deployment.create(_deployment_spec())
+        post_calls = [c for c in responses.calls if c.request.method == "POST"]
+        self.assertEqual(len(post_calls), 1)
+        self.assertEqual(post_calls[0].request.url, f"{BASE}/endpoints")
+        import json as _json
+
+        body = _json.loads(post_calls[0].request.body)
+        # legacy container/resource_requirement collapse into a component
+        self.assertIn("components", body["spec"])
+        self.assertEqual(body["spec"]["components"][0]["image"], "nginx")
+
+    @responses.activate
+    def test_update_fetches_then_patches_full_components(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET, f"{BASE}/endpoints/my-ep", json=_endpoint_body(), status=200
+        )
+        responses.add(
+            responses.PATCH,
+            f"{BASE}/endpoints/my-ep",
+            json=_endpoint_body(),
+            status=200,
+        )
+        client = _make_client()
+        spec = _deployment_spec()
+        spec.spec.container.image = "nginx:2"
+        client.deployment.update("my-ep", spec)
+        methods = [(c.request.method, c.request.url) for c in responses.calls]
+        # a GET (fetch live) precedes the PATCH (full component array)
+        self.assertIn(("GET", f"{BASE}/endpoints/my-ep"), methods)
+        self.assertIn(("PATCH", f"{BASE}/endpoints/my-ep"), methods)
+
+    @responses.activate
+    def test_restart_puts_to_endpoints(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.PUT,
+            f"{BASE}/endpoints/my-ep/restart",
+            json=_endpoint_body(),
+            status=200,
+        )
+        client = _make_client()
+        client.deployment.restart("my-ep")
+        self.assertIn(f"{BASE}/endpoints/my-ep/restart", _urls_called())
+
+    @responses.activate
+    def test_replicas_and_events_use_endpoint_subroutes(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET, f"{BASE}/endpoints/my-ep/replicas", json=[], status=200
+        )
+        responses.add(
+            responses.GET, f"{BASE}/endpoints/my-ep/events", json=[], status=200
+        )
+        client = _make_client()
+        client.deployment.get_replicas("my-ep")
+        client.deployment.get_events("my-ep")
+        urls = _urls_called()
+        self.assertIn(f"{BASE}/endpoints/my-ep/replicas", urls)
+        self.assertIn(f"{BASE}/endpoints/my-ep/events", urls)
+
+    @responses.activate
+    def test_readiness_and_termination_degrade(self):
+        from leptonai.api.v2.endpoint import NewEndpointAPIUnsupported
+
+        _register_workspace(enable_new_deployment_api=True)
+        client = _make_client()
+        with self.assertRaises(NewEndpointAPIUnsupported):
+            client.deployment.get_readiness("my-ep")
+        with self.assertRaises(NewEndpointAPIUnsupported):
+            client.deployment.get_termination("my-ep")
+
+
+class TestFlagOnDevPodRoutes(unittest.TestCase):
+    @responses.activate
+    def test_list_uses_devpods(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET, f"{BASE}/devpods", json=[_devpod_body()], status=200
+        )
+        client = _make_client()
+        result = client.pod.list_all()
+        self.assertIn(f"{BASE}/devpods", _urls_called())
+        self.assertTrue(result[0].spec.is_pod)
+
+    @responses.activate
+    def test_pod_create_posts_to_devpods(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(responses.POST, f"{BASE}/devpods", json={}, status=200)
+        client = _make_client()
+        client.pod.create(_pod_spec())
+        post_calls = [c for c in responses.calls if c.request.method == "POST"]
+        self.assertEqual(len(post_calls), 1)
+        self.assertEqual(post_calls[0].request.url, f"{BASE}/devpods")
+        import json as _json
+
+        body = _json.loads(post_calls[0].request.body)
+        # resource_shape lifted to spec level; no resource_requirement / is_pod
+        self.assertEqual(body["spec"]["resource_shape"], "cpu.small")
+        self.assertNotIn("resource_requirement", body["spec"])
+        self.assertNotIn("is_pod", body["spec"])
+
+    @responses.activate
+    def test_get_uses_devpods_and_translates(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET, f"{BASE}/devpods/my-pod", json=_devpod_body(), status=200
+        )
+        client = _make_client()
+        pod = client.pod.get("my-pod")
+        self.assertIn(f"{BASE}/devpods/my-pod", _urls_called())
+        self.assertTrue(pod.spec.is_pod)
+        self.assertEqual(pod.spec.resource_requirement.resource_shape, "cpu.small")
+
+    @responses.activate
+    def test_stop_uses_stopped_switch(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.PATCH,
+            f"{BASE}/devpods/my-pod",
+            json=_devpod_body(stopped=True),
+            status=200,
+        )
+        client = _make_client()
+        client.pod.stop("my-pod")
+        patch_calls = [c for c in responses.calls if c.request.method == "PATCH"]
+        self.assertEqual(len(patch_calls), 1)
+        self.assertEqual(patch_calls[0].request.url, f"{BASE}/devpods/my-pod")
+        import json as _json
+
+        body = _json.loads(patch_calls[0].request.body)
+        self.assertEqual(body, {"spec": {"stopped": True}})
+
+    @responses.activate
+    def test_delete_uses_devpods(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(responses.DELETE, f"{BASE}/devpods/my-pod", json={}, status=200)
+        client = _make_client()
+        client.pod.delete("my-pod")
+        self.assertIn(f"{BASE}/devpods/my-pod", _urls_called())
+
+    @responses.activate
+    def test_restart_puts_to_devpods(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.PUT,
+            f"{BASE}/devpods/my-pod/restart",
+            json=_devpod_body(),
+            status=200,
+        )
+        client = _make_client()
+        client.pod.restart("my-pod")
+        self.assertIn(f"{BASE}/devpods/my-pod/restart", _urls_called())
+
+    @responses.activate
+    def test_log_degrades(self):
+        from leptonai.api.v2.devpod import NewDevPodAPIUnsupported
+
+        _register_workspace(enable_new_deployment_api=True)
+        client = _make_client()
+        with self.assertRaises(NewDevPodAPIUnsupported):
+            client.pod.get_log("my-pod")
+
+
+class TestGate403SurfacesCleanly(unittest.TestCase):
+    @responses.activate
+    def test_devpod_gate_403_raises_client_error_with_message(self):
+        from leptonai.api.v2.api_resource import ClientError
+
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET,
+            f"{BASE}/devpods",
+            json={
+                "code": "StatusForbidden",
+                "message": "the new devpod API is not enabled for this workspace",
+            },
+            status=403,
+        )
+        client = _make_client()
+        with self.assertRaises(ClientError) as ctx:
+            client.pod.list_all()
+        # The gate message is carried in the error for the CLI to render.
+        self.assertIn("not enabled for this workspace", str(ctx.exception))
+        self.assertEqual(ctx.exception.response.status_code, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -167,6 +167,29 @@ class TestFlagDetection(unittest.TestCase):
         self.assertFalse(client.new_deployment_api_enabled)
 
     @responses.activate
+    def test_resolution_failure_is_not_cached_and_retries(self):
+        # A transient /workspace failure fails safe to legacy for that access but
+        # must NOT be memoized: a later access retries and can flip to the new
+        # API once resolution succeeds. Caching failure->legacy in a flag-on
+        # workspace would route a later create to the wrong API.
+        responses.add(responses.GET, f"{BASE}/workspace", status=500)
+        responses.add(
+            responses.GET,
+            f"{BASE}/workspace",
+            json=_workspace_info(enable_new_deployment_api=True),
+            status=200,
+        )
+        client = _make_client()
+        self.assertFalse(client.new_deployment_api_enabled)  # first: error -> legacy
+        self.assertTrue(client.new_deployment_api_enabled)  # retry: resolves -> new
+        # And now it is cached: no third /workspace call.
+        self.assertTrue(client.new_deployment_api_enabled)
+        workspace_calls = [
+            c for c in responses.calls if c.request.url == f"{BASE}/workspace"
+        ]
+        self.assertEqual(len(workspace_calls), 2)
+
+    @responses.activate
     def test_flag_is_cached_single_workspace_call(self):
         _register_workspace(enable_new_deployment_api=True)
         client = _make_client()
@@ -599,6 +622,24 @@ class TestSameMajorVersionGuard(unittest.TestCase):
         self.assertFalse(_same_major_version([None, None]))
         self.assertTrue(_same_major_version(["1.0", "1.3"]))
         self.assertFalse(_same_major_version(["1.0", "2.1"]))
+
+
+class TestReadyReplicasFallback(unittest.TestCase):
+    def test_static_endpoint_carries_ready_replicas(self):
+        from leptonai.api.v2 import translation
+        from leptonai.api.v2.types.deployment import LeptonDeployment
+
+        # Static endpoint: no auto_scaler_status, but ready_replicas is set.
+        ep = {
+            "metadata": {"name": "ep", "id": "ep"},
+            "spec": {"components": [{"name": "default", "image": "svc"}]},
+            "status": {"state": "Ready", "ready_replicas": 3},
+        }
+        legacy = translation.http_endpoint_to_legacy(ep)
+        self.assertEqual(legacy["status"]["ready_replicas"], 3)
+        model = LeptonDeployment(**legacy)
+        self.assertIsNone(model.status.autoscaler_status)
+        self.assertEqual(model.status.ready_replicas, 3)
 
 
 class TestLogRoutingDispatch(unittest.TestCase):

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -353,6 +353,18 @@ class TestFlagOnDevPodRoutes(unittest.TestCase):
         self.assertEqual(pod.spec.resource_requirement.resource_shape, "cpu.small")
 
     @responses.activate
+    def test_get_surfaces_public_ip_on_status(self):
+        _register_workspace(enable_new_deployment_api=True)
+        body = _devpod_body()
+        body["status"]["public_ip"] = "203.0.113.7"
+        responses.add(responses.GET, f"{BASE}/devpods/my-pod", json=body, status=200)
+        client = _make_client()
+        pod = client.pod.get("my-pod")
+        # The bare public IP flows through to the model status so the CLI can read
+        # it directly instead of parsing a port's external URL.
+        self.assertEqual(pod.status.public_ip, "203.0.113.7")
+
+    @responses.activate
     def test_stop_uses_stopped_switch(self):
         _register_workspace(enable_new_deployment_api=True)
         responses.add(
@@ -393,13 +405,99 @@ class TestFlagOnDevPodRoutes(unittest.TestCase):
         self.assertIn(f"{BASE}/devpods/my-pod/restart", _urls_called())
 
     @responses.activate
-    def test_log_degrades(self):
-        from leptonai.api.v2.devpod import NewDevPodAPIUnsupported
-
+    def test_log_streams_from_devpod_log_route(self):
+        # A devpod runs a single pod; logs stream by devpod id at
+        # GET /devpods/:did/log (no replica id required).
         _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET,
+            f"{BASE}/devpods/my-pod/log",
+            body="line1\nline2\n",
+            status=200,
+        )
         client = _make_client()
-        with self.assertRaises(NewDevPodAPIUnsupported):
-            client.pod.get_log("my-pod")
+        chunks = list(client.pod.get_log("my-pod"))
+        self.assertIn(f"{BASE}/devpods/my-pod/log", _urls_called())
+        self.assertEqual("".join(chunks), "line1\nline2\n")
+
+
+class TestTranslationFidelity(unittest.TestCase):
+    def test_endpoint_host_network_round_trips_through_resource_requirement(self):
+        from leptonai.api.v2 import translation
+
+        # host_network lives at resource_requirement.host_network in the legacy
+        # model, but at component level on the new wire. Outbound must lift it
+        # into the component; inbound must fold it back.
+        legacy = {
+            "metadata": {"name": "ep"},
+            "spec": {
+                "container": {"image": "nginx"},
+                "resource_requirement": {
+                    "resource_shape": "cpu.small",
+                    "host_network": True,
+                },
+            },
+        }
+        wire = translation.legacy_to_http_endpoint(legacy)
+        self.assertTrue(wire["spec"]["components"][0]["host_network"])
+
+        # inbound: component host_network -> resource_requirement.host_network
+        ep = {
+            "metadata": {"name": "ep"},
+            "spec": {
+                "components": [{
+                    "name": "default",
+                    "resource_shape": "cpu.small",
+                    "host_network": True,
+                }]
+            },
+            "status": {"state": "Ready"},
+        }
+        back = translation.http_endpoint_to_legacy(ep)
+        self.assertTrue(back["spec"]["resource_requirement"]["host_network"])
+        # never placed at spec top level (the model has no such field)
+        self.assertNotIn("host_network", back["spec"])
+
+    def test_devpod_host_network_round_trips_through_resource_requirement(self):
+        from leptonai.api.v2 import translation
+
+        legacy = {
+            "metadata": {"name": "pod"},
+            "spec": {
+                "is_pod": True,
+                "container": {"image": "ubuntu"},
+                "resource_requirement": {
+                    "resource_shape": "cpu.small",
+                    "host_network": True,
+                },
+            },
+        }
+        wire = translation.legacy_to_http_devpod(legacy)
+        self.assertTrue(wire["spec"]["host_network"])
+
+        dp = {
+            "metadata": {"name": "pod"},
+            "spec": {
+                "container": {"image": "ubuntu"},
+                "resource_shape": "cpu.small",
+                "host_network": True,
+            },
+            "status": {"state": "Ready"},
+        }
+        back = translation.http_devpod_to_legacy(dp)
+        self.assertTrue(back["spec"]["resource_requirement"]["host_network"])
+        self.assertNotIn("host_network", back["spec"])
+
+    def test_devpod_public_ip_surfaced_from_status(self):
+        from leptonai.api.v2 import translation
+
+        dp = {
+            "metadata": {"name": "pod"},
+            "spec": {"container": {"image": "ubuntu"}, "resource_shape": "cpu.small"},
+            "status": {"state": "Ready", "public_ip": "203.0.113.7"},
+        }
+        back = translation.http_devpod_to_legacy(dp)
+        self.assertEqual(back["status"]["public_ip"], "203.0.113.7")
 
 
 class TestGate403SurfacesCleanly(unittest.TestCase):

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -16,12 +16,16 @@ Coverage:
 
 import os
 import tempfile
+import itertools
+import threading
+import time
 
 # Set cache dir to a temp dir before importing anything from leptonai, matching
 # the existing CLI test suite so tests never touch a real workspace record.
 os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
 
 import unittest
+import unittest.mock
 
 import responses
 
@@ -41,9 +45,11 @@ BASE = "https://gw.example/api/v2/workspaces/ws1"
 def _make_client() -> APIClient:
     # The new-deployment-API flag is committed process-wide (keyed by workspace
     # URL) once resolved, so a resolution from an earlier test would otherwise
-    # leak into later tests that reuse BASE. Clear the memo per client build to
-    # keep each test's flag resolution independent.
-    client_module._NEW_DEPLOYMENT_API_FLAG_CACHE.clear()
+    # leak into later tests that reuse BASE. Reset the memo per client build to
+    # keep each test's flag resolution independent. This is the public hook SDK
+    # consumers use to drop a stale flag; a consumer test suite can call it in an
+    # autouse fixture for the same isolation.
+    client_module.reset_new_deployment_api_flag_cache()
     return APIClient(workspace_id="ws1", auth_token="tok", url=BASE)
 
 
@@ -240,6 +246,65 @@ class TestFlagDetection(unittest.TestCase):
             c for c in responses.calls if c.request.url == f"{BASE}/workspace"
         ]
         self.assertEqual(len(workspace_calls), 1)
+
+    def test_concurrent_cold_resolution_is_single_flight(self):
+        # A cold memo hit by many threads at once (the shape of the parallel
+        # `lep log get` workers, each with its own APIClient) must resolve the
+        # flag EXACTLY ONCE and commit ONE dispatch decision. Without the
+        # single-flight lock, threads could each issue their own /workspace call,
+        # get different transient outcomes, and route to different API families.
+        client_module.reset_new_deployment_api_flag_cache()
+
+        n_threads = 16
+        start = threading.Barrier(n_threads)
+        resolve_count = itertools.count()
+        total_resolutions = []
+
+        def slow_resolve(self_client):
+            # Count each real resolution; the sleep widens the check-resolve-commit
+            # window so an unlocked implementation would reliably resolve twice.
+            total_resolutions.append(next(resolve_count))
+            time.sleep(0.05)
+            return True
+
+        results = []
+        results_lock = threading.Lock()
+
+        def worker():
+            # Every worker builds its OWN client (same workspace URL) — the
+            # process-wide memo is what must coordinate them, not a shared client.
+            c = APIClient(workspace_id="ws1", auth_token="tok", url=BASE)
+            start.wait()
+            value = c.new_deployment_api_enabled
+            with results_lock:
+                results.append(value)
+
+        with unittest.mock.patch.object(
+            APIClient, "_resolve_new_deployment_api", slow_resolve
+        ):
+            threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # Exactly one resolution despite n_threads concurrent cold accesses.
+        self.assertEqual(len(total_resolutions), 1)
+        # Every thread agreed on the one committed decision.
+        self.assertEqual(results, [True] * n_threads)
+
+    @responses.activate
+    def test_reset_hook_forces_reresolution(self):
+        # A long-lived SDK consumer can pick up a workspace flag flip by calling
+        # reset_new_deployment_api_flag_cache(); the next access re-resolves.
+        _register_workspace(enable_new_deployment_api=False)
+        client = _make_client()
+        self.assertFalse(client.new_deployment_api_enabled)
+        # Flip the workspace flag on the server side and reset the memo.
+        responses.reset()
+        _register_workspace(enable_new_deployment_api=True)
+        client_module.reset_new_deployment_api_flag_cache(BASE)
+        self.assertTrue(client.new_deployment_api_enabled)
 
 
 class TestFlagOffLegacyRoutes(unittest.TestCase):

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -601,6 +601,33 @@ class TestSameMajorVersionGuard(unittest.TestCase):
         self.assertFalse(_same_major_version(["1.0", "2.1"]))
 
 
+class TestLogRoutingDispatch(unittest.TestCase):
+    @responses.activate
+    def test_timeseries_uses_endpoint_key_when_flag_on(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET, f"{BASE}/logs/timeseries", json={"data": {}}, status=200
+        )
+        client = _make_client()
+        client.log.get_log_time_series(name_or_deployment="my-ep")
+        call = next(c for c in responses.calls if "/logs/timeseries" in c.request.url)
+        # Flag on: the workload is a LeptonEndpoint, keyed under endpoint=.
+        self.assertIn("endpoint=my-ep", call.request.url)
+        self.assertNotIn("deployment=", call.request.url)
+
+    @responses.activate
+    def test_timeseries_uses_deployment_key_when_flag_off(self):
+        _register_workspace(enable_new_deployment_api=False)
+        responses.add(
+            responses.GET, f"{BASE}/logs/timeseries", json={"data": {}}, status=200
+        )
+        client = _make_client()
+        client.log.get_log_time_series(name_or_deployment="my-dep")
+        call = next(c for c in responses.calls if "/logs/timeseries" in c.request.url)
+        self.assertIn("deployment=my-dep", call.request.url)
+        self.assertNotIn("endpoint=", call.request.url)
+
+
 class TestGate403SurfacesCleanly(unittest.TestCase):
     @responses.activate
     def test_devpod_gate_403_raises_client_error_with_message(self):

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -719,5 +719,105 @@ class TestGate403SurfacesCleanly(unittest.TestCase):
         self.assertEqual(ctx.exception.response.status_code, 403)
 
 
+class TestReplicaPublicIPSharesCallerClient(unittest.TestCase):
+    """`_get_only_replica_public_ip` must reuse the caller's client so it shares
+    the caller's already-resolved dispatch decision, rather than resolving the
+    new-deployment-API flag a second time on the get_client() singleton.
+
+    Regression: with the flag ON, the caller routes the pod through /devpods,
+    but an independent second flag resolution on a different client could
+    transiently fail (uncached -> legacy) and hit /deployments/<name>/replicas,
+    which 404s for a devpod. Passing the caller's client keeps it on /devpods.
+    """
+
+    @responses.activate
+    def test_helper_uses_passed_client_and_hits_devpod_route(self):
+        from leptonai.cli.util import _get_only_replica_public_ip
+
+        _register_workspace(enable_new_deployment_api=True)
+        body = _devpod_body("my-pod")
+        body["status"]["public_ip"] = "1.2.3.4"
+        responses.add(responses.GET, f"{BASE}/devpods/my-pod", json=body, status=200)
+
+        client = _make_client()
+        # Caller resolves the flag first (as pod list/ssh/storage do).
+        client.pod.get("my-pod")
+
+        ip = _get_only_replica_public_ip("my-pod", client)
+
+        self.assertEqual(ip, "1.2.3.4")
+        # The devpod status route was used; the legacy replicas route never was.
+        self.assertIn(f"{BASE}/devpods/my-pod", _urls_called())
+        self.assertNotIn(f"{BASE}/deployments/my-pod/replicas", _urls_called())
+        # Only one /workspace resolution happened — the helper did not resolve
+        # the flag again on a different client.
+        workspace_calls = [
+            c for c in responses.calls if c.request.url == f"{BASE}/workspace"
+        ]
+        self.assertEqual(len(workspace_calls), 1)
+
+
+class TestCreateBindsDispatcherOnce(unittest.TestCase):
+    """The endpoint create flow (list -> optional rerun delete -> create) must
+    bind the deployment dispatcher once. Otherwise a transient /workspace
+    failure on the preflight list (uncached -> legacy) followed by a recovered
+    resolution on create could split the operation across APIs, POSTing a
+    duplicate to /endpoints (409) instead of rerunning it.
+
+    We assert the property directly: repeated access to `client.deployment`
+    after the flag has resolved yields the same backing API instance, and a
+    single bound reference is stable across the whole operation.
+    """
+
+    @responses.activate
+    def test_deployment_dispatcher_is_stable_once_resolved(self):
+        _register_workspace(enable_new_deployment_api=True)
+        client = _make_client()
+
+        dep_api = client.deployment
+        # After the first resolution the flag is cached; the bound reference and
+        # any later access agree on the same (endpoint) backing API.
+        self.assertIs(dep_api, client._endpoint_api)
+        self.assertIs(dep_api, client.deployment)
+
+    @responses.activate
+    def test_rerun_delete_and_create_stay_on_endpoints(self):
+        _register_workspace(enable_new_deployment_api=True)
+        responses.add(
+            responses.GET,
+            f"{BASE}/endpoints",
+            json=[_endpoint_body("my-ep")],
+            status=200,
+        )
+        responses.add(responses.DELETE, f"{BASE}/endpoints/my-ep", json={}, status=200)
+        responses.add(
+            responses.POST,
+            f"{BASE}/endpoints",
+            json=_endpoint_body("my-ep"),
+            status=201,
+        )
+
+        client = _make_client()
+        # Simulate the create flow's bound-dispatcher sequence.
+        dep_api = client.deployment
+        existing = dep_api.list_all()
+        self.assertIn("my-ep", [d.metadata.name for d in existing])
+        dep_api.delete("my-ep")
+        dep_api.create(
+            LeptonDeployment(
+                metadata=Metadata(id="my-ep", name="my-ep"),
+                spec=LeptonDeploymentUserSpec(
+                    resource_requirement=ResourceRequirement(resource_shape="cpu.small")
+                ),
+            )
+        )
+
+        urls = _urls_called()
+        # Every mutating call stayed on /endpoints; none leaked to /deployments.
+        self.assertTrue(any(u == f"{BASE}/endpoints" for u in urls))
+        self.assertIn(f"{BASE}/endpoints/my-ep", urls)
+        self.assertFalse(any("/deployments" in u for u in urls))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -499,6 +499,84 @@ class TestTranslationFidelity(unittest.TestCase):
         back = translation.http_devpod_to_legacy(dp)
         self.assertEqual(back["status"]["public_ip"], "203.0.113.7")
 
+    def test_devpod_not_ready_state_maps_to_legacy_spelling(self):
+        from leptonai.api.v2 import translation
+        from leptonai.api.v2.types.deployment import (
+            LeptonDeployment,
+            LeptonDeploymentState,
+        )
+
+        # Backend DevPodState is "NotReady" (no space); the CLI enum expects
+        # "Not Ready". Without the remap this collapses to UNK.
+        dp = {
+            "metadata": {"name": "pod"},
+            "spec": {"container": {"image": "ubuntu"}, "resource_shape": "cpu.small"},
+            "status": {"state": "NotReady"},
+        }
+        back = translation.http_devpod_to_legacy(dp)
+        self.assertEqual(back["status"]["state"], "Not Ready")
+        model = LeptonDeployment(**back)
+        self.assertEqual(model.status.state, LeptonDeploymentState.NotReady)
+
+    def test_endpoint_app_protocol_round_trips(self):
+        from leptonai.api.v2 import translation
+
+        # app_protocol ("grpc") selects ingress routing and must survive an
+        # image-only update (inbound get -> outbound patch).
+        legacy = {
+            "metadata": {"name": "ep"},
+            "spec": {
+                "container": {
+                    "image": "svc",
+                    "ports": [{
+                        "container_port": 8080,
+                        "protocol": "TCP",
+                        "app_protocol": "grpc",
+                    }],
+                },
+                "resource_requirement": {"resource_shape": "cpu.small"},
+            },
+        }
+        wire = translation.legacy_to_http_endpoint(legacy)
+        self.assertEqual(
+            wire["spec"]["components"][0]["ports"][0]["app_protocol"], "grpc"
+        )
+
+        ep = {
+            "metadata": {"name": "ep"},
+            "spec": {
+                "components": [{
+                    "name": "default",
+                    "ports": [{
+                        "container_port": 8080,
+                        "protocol": "TCP",
+                        "app_protocol": "grpc",
+                    }],
+                }]
+            },
+            "status": {"state": "Ready"},
+        }
+        back = translation.http_endpoint_to_legacy(ep)
+        self.assertEqual(back["spec"]["container"]["ports"][0]["app_protocol"], "grpc")
+        # and the patch (full component array) preserves it for an image update
+        raw = ep
+        patch = translation.legacy_to_http_endpoint_patch(raw, back)
+        self.assertEqual(
+            patch["spec"]["components"][0]["ports"][0]["app_protocol"], "grpc"
+        )
+
+
+class TestSameMajorVersionGuard(unittest.TestCase):
+    def test_none_semantic_version_does_not_raise(self):
+        from leptonai.cli.deployment import _same_major_version
+
+        # New-endpoint replicas carry no semantic_version (None); the helper must
+        # not raise TypeError on re.match(None).
+        self.assertFalse(_same_major_version(["1.0", None]))
+        self.assertFalse(_same_major_version([None, None]))
+        self.assertTrue(_same_major_version(["1.0", "1.3"]))
+        self.assertFalse(_same_major_version(["1.0", "2.1"]))
+
 
 class TestGate403SurfacesCleanly(unittest.TestCase):
     @responses.activate

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -25,6 +25,7 @@ import unittest
 
 import responses
 
+from leptonai.api.v2 import client as client_module
 from leptonai.api.v2.client import APIClient
 from leptonai.api.v2.types.common import Metadata
 from leptonai.api.v2.types.deployment import (
@@ -38,6 +39,11 @@ BASE = "https://gw.example/api/v2/workspaces/ws1"
 
 
 def _make_client() -> APIClient:
+    # The new-deployment-API flag is committed process-wide (keyed by workspace
+    # URL) once resolved, so a resolution from an earlier test would otherwise
+    # leak into later tests that reuse BASE. Clear the memo per client build to
+    # keep each test's flag resolution independent.
+    client_module._NEW_DEPLOYMENT_API_FLAG_CACHE.clear()
     return APIClient(workspace_id="ws1", auth_token="tok", url=BASE)
 
 
@@ -161,17 +167,31 @@ class TestFlagDetection(unittest.TestCase):
         self.assertFalse(client.new_deployment_api_enabled)
 
     @responses.activate
-    def test_info_error_fails_safe_to_legacy(self):
+    def test_persistent_info_error_commits_legacy(self):
+        # A /workspace error that survives the bounded retry commits legacy for
+        # the process (fail-safe). Committing legacy after a genuine, retried
+        # failure is fail-loud now: an endpoint-flavored legacy create in a
+        # flag-on workspace is rejected 400 server-side (api-server MR !7865).
         responses.add(responses.GET, f"{BASE}/workspace", status=500)
         client = _make_client()
         self.assertFalse(client.new_deployment_api_enabled)
+        # The committed False is memoized process-wide; no further /workspace
+        # calls on repeat access.
+        before = len(
+            [c for c in responses.calls if c.request.url == f"{BASE}/workspace"]
+        )
+        self.assertFalse(client.new_deployment_api_enabled)
+        after = len(
+            [c for c in responses.calls if c.request.url == f"{BASE}/workspace"]
+        )
+        self.assertEqual(before, after)
 
     @responses.activate
-    def test_resolution_failure_is_not_cached_and_retries(self):
-        # A transient /workspace failure fails safe to legacy for that access but
-        # must NOT be memoized: a later access retries and can flip to the new
-        # API once resolution succeeds. Caching failure->legacy in a flag-on
-        # workspace would route a later create to the wrong API.
+    def test_transient_failure_absorbed_by_bounded_retry(self):
+        # A transient /workspace blip on the first attempt is absorbed by the
+        # bounded retry inside a SINGLE resolution, then the recovered flag is
+        # committed. The dispatch decision never splits: there is no window where
+        # one read sees legacy and a later read sees the new API.
         responses.add(responses.GET, f"{BASE}/workspace", status=500)
         responses.add(
             responses.GET,
@@ -180,14 +200,34 @@ class TestFlagDetection(unittest.TestCase):
             status=200,
         )
         client = _make_client()
-        self.assertFalse(client.new_deployment_api_enabled)  # first: error -> legacy
-        self.assertTrue(client.new_deployment_api_enabled)  # retry: resolves -> new
-        # And now it is cached: no third /workspace call.
+        # First access already returns the committed, recovered value (True) —
+        # not a transient legacy False.
         self.assertTrue(client.new_deployment_api_enabled)
+        self.assertTrue(client.new_deployment_api_enabled)
+        # Two /workspace calls: the failed attempt + the successful retry, both
+        # inside the one resolution. No third call on repeat access.
         workspace_calls = [
             c for c in responses.calls if c.request.url == f"{BASE}/workspace"
         ]
         self.assertEqual(len(workspace_calls), 2)
+
+    @responses.activate
+    def test_flag_committed_process_wide_across_fresh_clients(self):
+        # One CLI invocation may build several APIClient instances for the same
+        # workspace (e.g. the parallel `lep log get` workers). The flag resolves
+        # once and every later client on the same workspace URL reuses it, so no
+        # two clients can disagree and split an operation across APIs.
+        _register_workspace(enable_new_deployment_api=True)
+        first = _make_client()
+        self.assertTrue(first.new_deployment_api_enabled)
+        # A fresh client built WITHOUT clearing the memo reuses the committed
+        # decision and makes no second /workspace call.
+        second = APIClient(workspace_id="ws1", auth_token="tok", url=BASE)
+        self.assertTrue(second.new_deployment_api_enabled)
+        workspace_calls = [
+            c for c in responses.calls if c.request.url == f"{BASE}/workspace"
+        ]
+        self.assertEqual(len(workspace_calls), 1)
 
     @responses.activate
     def test_flag_is_cached_single_workspace_call(self):
@@ -751,6 +791,38 @@ class TestReplicaPublicIPSharesCallerClient(unittest.TestCase):
         self.assertNotIn(f"{BASE}/deployments/my-pod/replicas", _urls_called())
         # Only one /workspace resolution happened — the helper did not resolve
         # the flag again on a different client.
+        workspace_calls = [
+            c for c in responses.calls if c.request.url == f"{BASE}/workspace"
+        ]
+        self.assertEqual(len(workspace_calls), 1)
+
+    @responses.activate
+    def test_helper_on_separate_client_still_agrees_via_process_memo(self):
+        # Root-fix proof for the multi-call split class: even if the helper falls
+        # back to a SEPARATE client (the historical get_client() singleton path),
+        # the process-wide committed flag keeps it on /devpods. There is no
+        # window where the caller routes to /devpods and the helper re-resolves
+        # (transiently) to the legacy /deployments/<name>/replicas route.
+        from leptonai.cli.util import _get_only_replica_public_ip
+
+        _register_workspace(enable_new_deployment_api=True)
+        body = _devpod_body("my-pod")
+        body["status"]["public_ip"] = "1.2.3.4"
+        responses.add(responses.GET, f"{BASE}/devpods/my-pod", json=body, status=200)
+
+        caller = _make_client()
+        # Caller commits the flag (True) for the process.
+        self.assertTrue(caller.new_deployment_api_enabled)
+
+        # A separate, fresh client for the same workspace — built WITHOUT
+        # clearing the memo — reuses the committed decision.
+        helper_client = APIClient(workspace_id="ws1", auth_token="tok", url=BASE)
+        ip = _get_only_replica_public_ip("my-pod", helper_client)
+
+        self.assertEqual(ip, "1.2.3.4")
+        self.assertIn(f"{BASE}/devpods/my-pod", _urls_called())
+        self.assertNotIn(f"{BASE}/deployments/my-pod/replicas", _urls_called())
+        # One resolution total, shared across both clients.
         workspace_calls = [
             c for c in responses.calls if c.request.url == f"{BASE}/workspace"
         ]

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -499,6 +499,29 @@ class TestTranslationFidelity(unittest.TestCase):
         back = translation.http_devpod_to_legacy(dp)
         self.assertEqual(back["status"]["public_ip"], "203.0.113.7")
 
+    def test_devpod_create_carries_visibility(self):
+        from leptonai.api.v2 import translation
+
+        # HTTPDevPodMetadata inlines LeptonMetadata, so visibility sits directly
+        # on metadata. Dropping it silently makes a private devpod public.
+        legacy = {
+            "metadata": {"name": "pod", "visibility": "private"},
+            "spec": {
+                "is_pod": True,
+                "container": {"image": "ubuntu"},
+                "resource_requirement": {"resource_shape": "cpu.small"},
+            },
+        }
+        wire = translation.legacy_to_http_devpod(legacy)
+        self.assertEqual(wire["metadata"]["visibility"], "private")
+        # absent visibility must not inject an empty key
+        legacy_no_vis = {
+            "metadata": {"name": "pod"},
+            "spec": {"is_pod": True, "container": {"image": "ubuntu"}},
+        }
+        wire2 = translation.legacy_to_http_devpod(legacy_no_vis)
+        self.assertNotIn("visibility", wire2["metadata"])
+
     def test_devpod_not_ready_state_maps_to_legacy_spelling(self):
         from leptonai.api.v2 import translation
         from leptonai.api.v2.types.deployment import (

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -642,6 +642,33 @@ class TestReadyReplicasFallback(unittest.TestCase):
         self.assertEqual(model.status.ready_replicas, 3)
 
 
+class TestPortsEmptyVsUnspecified(unittest.TestCase):
+    def _patch_ports(self, legacy_container):
+        from leptonai.api.v2 import translation
+
+        raw = {
+            "spec": {
+                "components": [{
+                    "name": "default",
+                    "ports": [{"container_port": 8080, "protocol": "TCP"}],
+                }]
+            }
+        }
+        legacy = {"metadata": {}, "spec": {"container": legacy_container}}
+        patch = translation.legacy_to_http_endpoint_patch(raw, legacy)
+        return patch["spec"]["components"][0]
+
+    def test_absent_ports_preserve_live_ports(self):
+        # No ports key -> not carried -> merge keeps the live port.
+        comp = self._patch_ports({"image": "svc"})
+        self.assertEqual(comp["ports"], [{"container_port": 8080, "protocol": "TCP"}])
+
+    def test_empty_ports_clear_live_ports(self):
+        # Explicit [] -> sent verbatim -> RFC7386 replaces the live ports with [].
+        comp = self._patch_ports({"image": "svc", "ports": []})
+        self.assertEqual(comp["ports"], [])
+
+
 class TestLogRoutingDispatch(unittest.TestCase):
     @responses.activate
     def test_timeseries_uses_endpoint_key_when_flag_on(self):

--- a/leptonai/api/v2/tests/test_new_api_dispatch.py
+++ b/leptonai/api/v2/tests/test_new_api_dispatch.py
@@ -31,6 +31,7 @@ import responses
 
 from leptonai.api.v2 import client as client_module
 from leptonai.api.v2.client import APIClient
+from leptonai.api.v2.devpod import NewDevPodAPIUnsupported
 from leptonai.api.v2.types.common import Metadata
 from leptonai.api.v2.types.deployment import (
     LeptonDeployment,
@@ -399,6 +400,74 @@ class TestFlagOnEndpointRoutes(unittest.TestCase):
         self.assertIn(("PATCH", f"{BASE}/endpoints/my-ep"), methods)
 
     @responses.activate
+    def test_update_rejects_missing_or_empty_live_components_before_patch(self):
+        malformed_specs = {
+            "missing": {},
+            "empty": {"components": []},
+        }
+        for case, malformed_spec in malformed_specs.items():
+            with self.subTest(case=case):
+                responses.reset()
+                _register_workspace(enable_new_deployment_api=True)
+                responses.add(
+                    responses.GET,
+                    f"{BASE}/endpoints/my-ep",
+                    json={"metadata": {"name": "my-ep"}, "spec": malformed_spec},
+                    status=200,
+                )
+                responses.add(
+                    responses.PATCH,
+                    f"{BASE}/endpoints/my-ep",
+                    json=_endpoint_body(),
+                    status=200,
+                )
+
+                client = _make_client()
+                with self.assertRaises(ValueError):
+                    client.deployment.update("my-ep", _deployment_spec())
+
+                endpoint_methods = [
+                    call.request.method
+                    for call in responses.calls
+                    if call.request.url == f"{BASE}/endpoints/my-ep"
+                ]
+                self.assertEqual(endpoint_methods, ["GET"])
+
+    @responses.activate
+    def test_stop_rejects_missing_or_empty_live_components_before_patch(self):
+        malformed_specs = {
+            "missing": {},
+            "empty": {"components": []},
+        }
+        for case, malformed_spec in malformed_specs.items():
+            with self.subTest(case=case):
+                responses.reset()
+                _register_workspace(enable_new_deployment_api=True)
+                responses.add(
+                    responses.GET,
+                    f"{BASE}/endpoints/my-ep",
+                    json={"metadata": {"name": "my-ep"}, "spec": malformed_spec},
+                    status=200,
+                )
+                responses.add(
+                    responses.PATCH,
+                    f"{BASE}/endpoints/my-ep",
+                    json=_endpoint_body(),
+                    status=200,
+                )
+
+                client = _make_client()
+                with self.assertRaises(ValueError):
+                    client.deployment.stop("my-ep")
+
+                endpoint_methods = [
+                    call.request.method
+                    for call in responses.calls
+                    if call.request.url == f"{BASE}/endpoints/my-ep"
+                ]
+                self.assertEqual(endpoint_methods, ["GET"])
+
+    @responses.activate
     def test_restart_puts_to_endpoints(self):
         _register_workspace(enable_new_deployment_api=True)
         responses.add(
@@ -533,20 +602,12 @@ class TestFlagOnDevPodRoutes(unittest.TestCase):
         self.assertIn(f"{BASE}/devpods/my-pod/restart", _urls_called())
 
     @responses.activate
-    def test_log_streams_from_devpod_log_route(self):
-        # A devpod runs a single pod; logs stream by devpod id at
-        # GET /devpods/:did/log (no replica id required).
+    def test_live_log_stream_fails_explicitly_without_request(self):
         _register_workspace(enable_new_deployment_api=True)
-        responses.add(
-            responses.GET,
-            f"{BASE}/devpods/my-pod/log",
-            body="line1\nline2\n",
-            status=200,
-        )
         client = _make_client()
-        chunks = list(client.pod.get_log("my-pod"))
-        self.assertIn(f"{BASE}/devpods/my-pod/log", _urls_called())
-        self.assertEqual("".join(chunks), "line1\nline2\n")
+        with self.assertRaisesRegex(NewDevPodAPIUnsupported, "historical logs"):
+            client.pod.get_log("my-pod")
+        self.assertNotIn(f"{BASE}/devpods/my-pod/log", _urls_called())
 
 
 class TestTranslationFidelity(unittest.TestCase):
@@ -666,8 +727,32 @@ class TestTranslationFidelity(unittest.TestCase):
         }
         back = translation.http_devpod_to_legacy(dp)
         self.assertEqual(back["status"]["state"], "Not Ready")
+        self.assertEqual(back["status"]["phase"], "Not Ready")
         model = LeptonDeployment(**back)
         self.assertEqual(model.status.state, LeptonDeploymentState.NotReady)
+        self.assertEqual(model.status.phase, LeptonDeploymentState.NotReady)
+
+    def test_endpoint_phase_distinguishes_stopped_from_running_not_ready(self):
+        from leptonai.api.v2 import translation
+
+        base = {
+            "metadata": {"name": "ep"},
+            "spec": {"components": [{"name": "default", "min_replicas": 1}]},
+        }
+
+        stopped = translation.http_endpoint_to_legacy({
+            **base,
+            "status": {"state": "Stopped"},
+        })
+        self.assertEqual(stopped["status"]["state"], "Not Ready")
+        self.assertEqual(stopped["status"]["phase"], "Stopped")
+
+        not_ready = translation.http_endpoint_to_legacy({
+            **base,
+            "status": {"state": "NotReady"},
+        })
+        self.assertEqual(not_ready["status"]["state"], "Not Ready")
+        self.assertEqual(not_ready["status"]["phase"], "Not Ready")
 
     def test_endpoint_app_protocol_round_trips(self):
         from leptonai.api.v2 import translation
@@ -769,7 +854,7 @@ class TestPortsEmptyVsUnspecified(unittest.TestCase):
         self.assertEqual(comp["ports"], [{"container_port": 8080, "protocol": "TCP"}])
 
     def test_empty_ports_clear_live_ports(self):
-        # Explicit [] -> sent verbatim -> RFC7386 replaces the live ports with [].
+        # Explicit [] must reach the merge patch and replace the live list.
         comp = self._patch_ports({"image": "svc", "ports": []})
         self.assertEqual(comp["ports"], [])
 

--- a/leptonai/api/v2/tests/test_new_api_flag_cache.py
+++ b/leptonai/api/v2/tests/test_new_api_flag_cache.py
@@ -1,0 +1,579 @@
+"""Concurrency and isolation tests for new-deployment-API flag caching."""
+
+import os
+import tempfile
+import threading
+import unittest
+import unittest.mock
+from types import SimpleNamespace
+
+# Never consult a developer's real workspace record while constructing clients.
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+from pydantic import ValidationError
+
+import leptonai.api.v2 as api_v2
+from leptonai.api.v2 import client as client_module
+from leptonai.api.v2.client import APIClient
+from leptonai.api.v2.types.workspace import WorkspaceFeatures
+from leptonai.cli.util import _get_only_replica_public_ip
+
+
+BASE = "https://gw.example/api/v2/workspaces/ws1"
+OTHER_BASE = "https://gw.example/api/v2/workspaces/ws2"
+
+
+def _client(url=BASE, token="token"):
+    return APIClient(
+        workspace_id="ws1",
+        auth_token=token,
+        url=url,
+        workspace_origin_url="https://console.example",
+    )
+
+
+class TestNewDeploymentAPIFlagCache(unittest.TestCase):
+    def setUp(self):
+        client_module.reset_new_deployment_api_flag_cache()
+
+    def tearDown(self):
+        client_module.reset_new_deployment_api_flag_cache()
+
+    def test_cache_isolated_by_non_reversible_credential_fingerprint(self):
+        resolutions = []
+
+        def resolve(client):
+            resolutions.append(client.auth_token)
+            return client.auth_token == "fresh-token"
+
+        stale = _client(token="stale-token")
+        fresh = _client(token="fresh-token")
+        with unittest.mock.patch.object(
+            APIClient, "_resolve_new_deployment_api", resolve
+        ):
+            self.assertFalse(stale.new_deployment_api_enabled)
+            self.assertTrue(fresh.new_deployment_api_enabled)
+            self.assertFalse(stale.new_deployment_api_enabled)
+            self.assertTrue(fresh.new_deployment_api_enabled)
+
+        self.assertCountEqual(resolutions, ["stale-token", "fresh-token"])
+        cache_keys = list(client_module._NEW_DEPLOYMENT_API_FLAG_CACHE)
+        self.assertEqual(len(cache_keys), 2)
+        self.assertEqual({key[0] for key in cache_keys}, {BASE})
+        for _, fingerprint in cache_keys:
+            self.assertEqual(len(fingerprint), 64)
+            self.assertNotIn("stale-token", fingerprint)
+            self.assertNotIn("fresh-token", fingerprint)
+
+        unauthenticated = client_module._new_deployment_api_credential_fingerprint(None)
+        self.assertEqual(
+            unauthenticated,
+            client_module._new_deployment_api_credential_fingerprint(None),
+        )
+
+    def test_same_key_resolves_exactly_once(self):
+        clients = [_client(token="shared-token") for _ in range(12)]
+        start = threading.Barrier(len(clients))
+        entered = threading.Event()
+        release = threading.Event()
+        resolution_count = 0
+        count_lock = threading.Lock()
+        results = []
+        errors = []
+
+        def resolve(_client):
+            nonlocal resolution_count
+            with count_lock:
+                resolution_count += 1
+            entered.set()
+            if not release.wait(timeout=2):
+                raise AssertionError("test did not release flag resolution")
+            return True
+
+        def read_flag(client):
+            try:
+                start.wait(timeout=2)
+                results.append(client.new_deployment_api_enabled)
+            except BaseException as exc:
+                errors.append(exc)
+
+        with unittest.mock.patch.object(
+            APIClient, "_resolve_new_deployment_api", resolve
+        ):
+            threads = [threading.Thread(target=read_flag, args=(c,)) for c in clients]
+            for thread in threads:
+                thread.start()
+            self.assertTrue(entered.wait(timeout=2))
+            release.set()
+            for thread in threads:
+                thread.join(timeout=2)
+                self.assertFalse(thread.is_alive())
+
+        self.assertEqual(errors, [])
+        self.assertEqual(resolution_count, 1)
+        self.assertEqual(results, [True] * len(clients))
+
+    def test_different_keys_resolve_concurrently_without_convoy(self):
+        scenarios = {
+            "different-workspaces": [
+                _client(url=BASE, token="token-a"),
+                _client(url=OTHER_BASE, token="token-a"),
+            ],
+            "same-workspace-different-credentials": [
+                _client(url=BASE, token="token-a"),
+                _client(url=BASE, token="token-b"),
+            ],
+        }
+
+        for scenario, clients in scenarios.items():
+            with self.subTest(scenario=scenario):
+                client_module.reset_new_deployment_api_flag_cache()
+                both_resolving = threading.Barrier(2)
+                results = {}
+                errors = []
+
+                def resolve(client):
+                    # This barrier can only complete if no global mutex is held
+                    # across resolution. A serialized implementation times out.
+                    both_resolving.wait(timeout=2)
+                    return client.auth_token == "token-a"
+
+                def read_flag(client):
+                    try:
+                        identity = (client.url, client.auth_token)
+                        results[identity] = client.new_deployment_api_enabled
+                    except BaseException as exc:
+                        errors.append(exc)
+
+                with unittest.mock.patch.object(
+                    APIClient, "_resolve_new_deployment_api", resolve
+                ):
+                    threads = [
+                        threading.Thread(target=read_flag, args=(c,)) for c in clients
+                    ]
+                    for thread in threads:
+                        thread.start()
+                    for thread in threads:
+                        thread.join(timeout=3)
+                        self.assertFalse(thread.is_alive())
+
+                self.assertEqual(errors, [])
+                self.assertEqual(len(results), 2)
+                for client in clients:
+                    self.assertEqual(
+                        results[(client.url, client.auth_token)],
+                        client.auth_token == "token-a",
+                    )
+
+    def test_url_and_global_resets_clear_all_matching_credentials(self):
+        outcomes = {
+            (BASE, "token-a"): False,
+            (BASE, "token-b"): True,
+            (OTHER_BASE, "token-c"): True,
+        }
+        resolutions = []
+
+        def resolve(client):
+            identity = (client.url, client.auth_token)
+            resolutions.append(identity)
+            return outcomes[identity]
+
+        first = _client(token="token-a")
+        second = _client(token="token-b")
+        other = _client(url=OTHER_BASE, token="token-c")
+        with unittest.mock.patch.object(
+            APIClient, "_resolve_new_deployment_api", resolve
+        ):
+            self.assertFalse(first.new_deployment_api_enabled)
+            self.assertTrue(second.new_deployment_api_enabled)
+            self.assertTrue(other.new_deployment_api_enabled)
+
+            outcomes[(BASE, "token-a")] = True
+            outcomes[(BASE, "token-b")] = False
+            outcomes[(OTHER_BASE, "token-c")] = False
+            client_module.reset_new_deployment_api_flag_cache(BASE)
+
+            self.assertTrue(first.new_deployment_api_enabled)
+            self.assertFalse(second.new_deployment_api_enabled)
+            # URL-scoped reset leaves the other workspace's entry intact.
+            self.assertTrue(other.new_deployment_api_enabled)
+
+            client_module.reset_new_deployment_api_flag_cache()
+            self.assertFalse(other.new_deployment_api_enabled)
+
+        self.assertEqual(resolutions.count((BASE, "token-a")), 2)
+        self.assertEqual(resolutions.count((BASE, "token-b")), 2)
+        self.assertEqual(resolutions.count((OTHER_BASE, "token-c")), 2)
+
+    def test_reset_waits_for_inflight_result_then_removes_it(self):
+        for reset_scope in (BASE, None):
+            with self.subTest(reset_scope=reset_scope):
+                client_module.reset_new_deployment_api_flag_cache()
+                client = _client()
+                entered = threading.Event()
+                release = threading.Event()
+                reset_done = threading.Event()
+                resolutions = 0
+                result = []
+
+                def resolve(_client):
+                    nonlocal resolutions
+                    resolutions += 1
+                    if resolutions == 1:
+                        entered.set()
+                        if not release.wait(timeout=2):
+                            raise AssertionError("test did not release flag resolution")
+                        return False
+                    return True
+
+                def reset_cache():
+                    client_module.reset_new_deployment_api_flag_cache(reset_scope)
+                    reset_done.set()
+
+                with unittest.mock.patch.object(
+                    APIClient, "_resolve_new_deployment_api", resolve
+                ):
+                    reader = threading.Thread(
+                        target=lambda: result.append(client.new_deployment_api_enabled)
+                    )
+                    reader.start()
+                    self.assertTrue(entered.wait(timeout=2))
+
+                    resetter = threading.Thread(target=reset_cache)
+                    resetter.start()
+                    with client_module._FLAG_CACHE_CONDITION:
+                        self.assertTrue(
+                            client_module._FLAG_CACHE_CONDITION.wait_for(
+                                lambda: (
+                                    bool(client_module._FLAG_CACHE_RESETTING_ALL)
+                                    if reset_scope is None
+                                    else bool(
+                                        client_module._FLAG_CACHE_RESETTING_URLS.get(
+                                            BASE
+                                        )
+                                    )
+                                ),
+                                timeout=2,
+                            )
+                        )
+                    self.assertFalse(reset_done.is_set())
+
+                    release.set()
+                    reader.join(timeout=2)
+                    resetter.join(timeout=2)
+                    self.assertFalse(reader.is_alive())
+                    self.assertFalse(resetter.is_alive())
+                    self.assertTrue(reset_done.is_set())
+                    self.assertEqual(result, [False])
+
+                    # The pre-reset False was removed rather than reappearing.
+                    self.assertTrue(client.new_deployment_api_enabled)
+                    self.assertEqual(resolutions, 2)
+
+    def test_after_fork_helper_drops_inflight_state_but_keeps_cache(self):
+        cache_key = (
+            BASE,
+            client_module._new_deployment_api_credential_fingerprint("token"),
+        )
+        old_condition = client_module._FLAG_CACHE_CONDITION
+        with old_condition:
+            client_module._NEW_DEPLOYMENT_API_FLAG_CACHE[cache_key] = True
+            client_module._FLAG_CACHE_RESOLVING.add(cache_key)
+            client_module._FLAG_CACHE_RESETTING_URLS[BASE] = 1
+            client_module._FLAG_CACHE_RESETTING_ALL = 1
+
+        client_module._reset_new_deployment_api_flag_cache_after_fork()
+
+        self.assertIsNot(client_module._FLAG_CACHE_CONDITION, old_condition)
+        self.assertEqual(
+            client_module._NEW_DEPLOYMENT_API_FLAG_CACHE, {cache_key: True}
+        )
+        self.assertEqual(client_module._FLAG_CACHE_RESOLVING, set())
+        self.assertEqual(client_module._FLAG_CACHE_RESETTING_URLS, {})
+        self.assertEqual(client_module._FLAG_CACHE_RESETTING_ALL, 0)
+
+    def test_resolution_uses_bounded_timeout_on_every_attempt(self):
+        client = _client()
+
+        with (
+            unittest.mock.patch.object(
+                client, "info", side_effect=RuntimeError("workspace unavailable")
+            ) as info,
+            unittest.mock.patch.object(client_module.time, "sleep"),
+        ):
+            self.assertFalse(client._resolve_new_deployment_api())
+
+        self.assertEqual(
+            info.call_args_list,
+            [
+                unittest.mock.call(
+                    timeout=client_module._FLAG_RESOLVE_REQUEST_TIMEOUT_SECONDS
+                )
+            ]
+            * (client_module._FLAG_RESOLVE_RETRIES + 1),
+        )
+        self.assertEqual(client_module._FLAG_RESOLVE_REQUEST_TIMEOUT_SECONDS, 5.0)
+
+    def test_info_forwards_optional_timeout_without_changing_default(self):
+        client = _client()
+        response = unittest.mock.Mock(status_code=200)
+        workspace_info = object()
+
+        with (
+            unittest.mock.patch.object(client, "_get", return_value=response) as get,
+            unittest.mock.patch.object(
+                client_module.APIResourse, "ensure_type", return_value=workspace_info
+            ),
+        ):
+            self.assertIs(client.info(timeout=2.5), workspace_info)
+            get.assert_called_once_with("/workspace", timeout=2.5)
+
+        with (
+            unittest.mock.patch.object(client, "_get", return_value=response) as get,
+            unittest.mock.patch.object(
+                client_module.APIResourse, "ensure_type", return_value=workspace_info
+            ),
+        ):
+            self.assertIs(client.info(), workspace_info)
+            get.assert_called_once_with("/workspace")
+
+    def test_deployment_and_pod_properties_accept_injected_overrides(self):
+        client = _client()
+        deployment_override = object()
+        pod_override = object()
+
+        client.deployment = deployment_override
+        client.pod = pod_override
+
+        # Reading an override must not resolve the feature flag as a side effect.
+        with unittest.mock.patch.object(
+            APIClient,
+            "_resolve_new_deployment_api",
+            side_effect=AssertionError("override unexpectedly resolved the flag"),
+        ):
+            self.assertIs(client.deployment, deployment_override)
+            self.assertIs(client.pod, pod_override)
+
+    def test_patch_object_restores_deployment_and_pod_dispatch(self):
+        for enabled in (False, True):
+            with self.subTest(enabled=enabled):
+                client = _client(token=f"dispatch-{enabled}")
+                expected_deployment = (
+                    client._endpoint_api if enabled else client._deployment_legacy
+                )
+                expected_pod = client._devpod_api if enabled else client._pod_legacy
+
+                with unittest.mock.patch.object(
+                    APIClient, "_resolve_new_deployment_api", return_value=enabled
+                ) as resolve:
+                    with unittest.mock.patch.object(
+                        client, "deployment", object()
+                    ) as fake:
+                        self.assertIs(client.deployment, fake)
+                    self.assertIs(client.deployment, expected_deployment)
+                    self.assertNotIn("deployment", client.__dict__)
+                    self.assertIs(
+                        client._deployment_override,
+                        client_module._API_RESOURCE_OVERRIDE_UNSET,
+                    )
+
+                    with unittest.mock.patch.object(client, "pod", object()) as fake:
+                        self.assertIs(client.pod, fake)
+                    self.assertIs(client.pod, expected_pod)
+                    self.assertNotIn("pod", client.__dict__)
+                    self.assertIs(
+                        client._pod_override,
+                        client_module._API_RESOURCE_OVERRIDE_UNSET,
+                    )
+
+                # The first patch lookup resolves the process memo. Restoration
+                # reuses that decision rather than leaving an override behind.
+                resolve.assert_called_once_with()
+
+    def test_nested_patch_object_restores_existing_public_overrides(self):
+        client = _client()
+
+        with unittest.mock.patch.object(
+            APIClient,
+            "_resolve_new_deployment_api",
+            side_effect=AssertionError("an explicit override resolved the flag"),
+        ):
+            for attribute in ("deployment", "pod"):
+                with self.subTest(attribute=attribute):
+                    outer = object()
+                    inner = object()
+                    setattr(client, attribute, outer)
+
+                    self.assertIs(client.__dict__[attribute], outer)
+                    with unittest.mock.patch.object(client, attribute, inner):
+                        self.assertIs(getattr(client, attribute), inner)
+                        self.assertIs(client.__dict__[attribute], inner)
+
+                    self.assertIs(getattr(client, attribute), outer)
+                    self.assertIs(client.__dict__[attribute], outer)
+
+                    delattr(client, attribute)
+                    self.assertNotIn(attribute, client.__dict__)
+
+    def test_endpoint_pod_creation_honors_public_pod_override(self):
+        client = _client()
+        pod_override = unittest.mock.Mock()
+        pod_override.create.side_effect = ["create-result", "create-pod-result"]
+        client.pod = pod_override
+        pod_spec = SimpleNamespace(spec=SimpleNamespace(is_pod=True))
+        create_pod_spec = SimpleNamespace(spec=SimpleNamespace(is_pod=False))
+
+        with (
+            unittest.mock.patch.object(
+                client._devpod_api,
+                "create",
+                side_effect=AssertionError("EndpointAPI bypassed client.pod"),
+            ),
+            unittest.mock.patch.object(
+                APIClient,
+                "_resolve_new_deployment_api",
+                side_effect=AssertionError("pod override unexpectedly resolved flag"),
+            ),
+        ):
+            self.assertEqual(client._endpoint_api.create(pod_spec), "create-result")
+            with self.assertWarns(DeprecationWarning):
+                self.assertEqual(
+                    client._endpoint_api.create_pod(create_pod_spec),
+                    "create-pod-result",
+                )
+
+        self.assertTrue(create_pod_spec.spec.is_pod)
+        self.assertEqual(
+            pod_override.create.call_args_list,
+            [unittest.mock.call(pod_spec), unittest.mock.call(create_pod_spec)],
+        )
+
+    def test_public_ip_helper_honors_new_pod_override(self):
+        client = _client(token="new-pod-override")
+        pod_override = unittest.mock.Mock()
+        pod_override.get.return_value = SimpleNamespace(
+            status=SimpleNamespace(public_ip="203.0.113.10")
+        )
+        client.pod = pod_override
+
+        with (
+            unittest.mock.patch.object(
+                APIClient, "_resolve_new_deployment_api", return_value=True
+            ),
+            unittest.mock.patch.object(
+                client._devpod_api,
+                "get",
+                side_effect=AssertionError("helper bypassed client.pod"),
+            ),
+        ):
+            self.assertEqual(
+                _get_only_replica_public_ip("pod-name", client), "203.0.113.10"
+            )
+
+        pod_override.get.assert_called_once_with("pod-name")
+
+    def test_public_ip_helper_honors_legacy_deployment_override(self):
+        client = _client(token="legacy-deployment-override")
+        deployment_override = unittest.mock.Mock()
+        deployment_override.get_replicas.return_value = [
+            SimpleNamespace(status=SimpleNamespace(public_ip="203.0.113.11"))
+        ]
+        client.deployment = deployment_override
+
+        with (
+            unittest.mock.patch.object(
+                APIClient, "_resolve_new_deployment_api", return_value=False
+            ),
+            unittest.mock.patch.object(
+                client._deployment_legacy,
+                "get_replicas",
+                side_effect=AssertionError(
+                    "helper bypassed the legacy deployment override accessor"
+                ),
+            ),
+        ):
+            self.assertEqual(
+                _get_only_replica_public_ip("pod-name", client), "203.0.113.11"
+            )
+
+        deployment_override.get_replicas.assert_called_once_with("pod-name")
+
+    def test_legacy_pod_delegation_honors_explicit_deployment_wrapper(self):
+        client = _client()
+        deployment = unittest.mock.Mock()
+        replica = object()
+        deployment.get.return_value = "get-result"
+        deployment.delete.return_value = "delete-result"
+        deployment.stop.return_value = "stop-result"
+        deployment.restart.return_value = "restart-result"
+        deployment.get_readiness.return_value = "readiness-result"
+        deployment.get_termination.return_value = "termination-result"
+        deployment.get_replicas.return_value = [replica]
+        deployment.get_log.return_value = iter(["log-result"])
+        client.deployment = deployment
+
+        pod = client._pod_legacy
+        self.assertEqual(pod.get("pod"), "get-result")
+        self.assertEqual(pod.delete("pod"), "delete-result")
+        self.assertEqual(pod.stop("pod"), "stop-result")
+        self.assertEqual(pod.restart("pod"), "restart-result")
+        self.assertEqual(pod.get_readiness("pod"), "readiness-result")
+        self.assertEqual(pod.get_termination("pod"), "termination-result")
+        self.assertEqual(list(pod.get_log("pod", timeout=7)), ["log-result"])
+
+        deployment.get.assert_called_once_with("pod")
+        deployment.delete.assert_called_once_with("pod")
+        deployment.stop.assert_called_once_with("pod")
+        deployment.restart.assert_called_once_with("pod")
+        deployment.get_readiness.assert_called_once_with("pod")
+        deployment.get_termination.assert_called_once_with("pod")
+        deployment.get_replicas.assert_called_once_with("pod")
+        deployment.get_log.assert_called_once_with("pod", replica, 7)
+
+    def test_legacy_pod_delegation_stays_legacy_without_override(self):
+        client = _client()
+
+        with (
+            unittest.mock.patch.object(
+                client._deployment_legacy, "get", return_value="legacy-result"
+            ) as legacy_get,
+            unittest.mock.patch.object(
+                client._endpoint_api,
+                "get",
+                side_effect=AssertionError("legacy PodAPI dispatched to EndpointAPI"),
+            ),
+            unittest.mock.patch.object(
+                APIClient,
+                "_resolve_new_deployment_api",
+                side_effect=AssertionError("legacy PodAPI resolved the feature flag"),
+            ),
+        ):
+            self.assertEqual(client._pod_legacy.get("pod"), "legacy-result")
+
+        legacy_get.assert_called_once_with("pod")
+
+
+class TestWorkspaceFlagSchema(unittest.TestCase):
+    def test_flag_accepts_only_strict_boolean_values(self):
+        self.assertTrue(
+            WorkspaceFeatures(enable_new_deployment_api=True).enable_new_deployment_api
+        )
+        self.assertFalse(
+            WorkspaceFeatures(enable_new_deployment_api=False).enable_new_deployment_api
+        )
+        self.assertIsNone(WorkspaceFeatures().enable_new_deployment_api)
+
+        for invalid in ("true", "false", 1, 0):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValidationError):
+                    WorkspaceFeatures(enable_new_deployment_api=invalid)
+
+    def test_reset_hook_is_exported_from_public_api(self):
+        self.assertIs(
+            api_v2.reset_new_deployment_api_flag_cache,
+            client_module.reset_new_deployment_api_flag_cache,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/api/v2/tests/test_new_api_translation_regressions.py
+++ b/leptonai/api/v2/tests/test_new_api_translation_regressions.py
@@ -1,0 +1,553 @@
+"""Regression tests for compatibility gaps found during the max-effort review."""
+
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+from requests import Response
+
+from leptonai.api.v2 import translation
+from leptonai.api.v2.devpod import DevPodAPI, NewDevPodAPIUnsupported
+from leptonai.api.v2.endpoint import EndpointAPI, NewEndpointAPIUnsupported
+from leptonai.api.v2.types.common import Metadata
+from leptonai.api.v2.types.deployment import (
+    LeptonContainer,
+    LeptonDeployment,
+    LeptonDeploymentUserSpec,
+    ResourceRequirement,
+)
+from leptonai.cli.storage import _get_rsync_host_port
+
+
+def _response(payload, status=200):
+    response = Response()
+    response.status_code = status
+    response._content = json.dumps(payload).encode()
+    response.headers["Content-Type"] = "application/json"
+    return response
+
+
+def _resource_client(get_response=None):
+    return SimpleNamespace(
+        _get=lambda *args, **kwargs: get_response,
+        _post=lambda *args, **kwargs: None,
+        _put=lambda *args, **kwargs: None,
+        _patch=lambda *args, **kwargs: None,
+        _delete=lambda *args, **kwargs: None,
+        _head=lambda *args, **kwargs: None,
+    )
+
+
+class TestEndpointTranslationRegressions(unittest.TestCase):
+    def test_disabled_ingress_survives_get_export_and_create(self):
+        raw = {
+            "metadata": {"name": "private-endpoint"},
+            "spec": {
+                "ingress_enabled": False,
+                "components": [{"name": "default", "image": "nginx"}],
+            },
+            "status": {"state": "Ready"},
+        }
+        posts = []
+        fake = _resource_client(_response(raw))
+        fake._post = lambda path, **kwargs: (
+            posts.append((path, kwargs["json"])) or _response({})
+        )
+        api = EndpointAPI(fake)
+
+        model = api.get("private-endpoint")
+        self.assertIs(model.spec.ingress_enabled, False)
+
+        # This is the exact spec-only representation written by `lep endpoint
+        # get --path`. Loading it into a fresh model must retain explicit false.
+        exported = json.loads(model.spec.model_dump_json(by_alias=True))
+        self.assertIs(exported["ingress_enabled"], False)
+        recreated = LeptonDeployment(
+            metadata=Metadata(name="private-endpoint-copy"),
+            spec=LeptonDeploymentUserSpec(**exported),
+        )
+
+        self.assertTrue(api.create(recreated))
+        self.assertEqual(posts[0][0], "/endpoints")
+        self.assertIs(posts[0][1]["spec"]["ingress_enabled"], False)
+
+    def test_create_without_ports_injects_legacy_default(self):
+        wire = translation.legacy_to_http_endpoint({
+            "metadata": {"name": "ep"},
+            "spec": {
+                "container": {"image": "nginx"},
+                "resource_requirement": {"resource_shape": "cpu.small"},
+            },
+        })
+        self.assertEqual(
+            wire["spec"]["components"][0]["ports"],
+            [{"container_port": 40000}],
+        )
+
+    def test_destructive_endpoint_patches_reject_ambiguous_snapshots(self):
+        invalid_snapshots = {
+            "missing spec": {},
+            "null spec": {"spec": None},
+            "missing components": {"spec": {}},
+            "null components": {"spec": {"components": None}},
+            "empty components": {"spec": {"components": []}},
+            "non-list components": {"spec": {"components": {}}},
+            "non-dict component": {"spec": {"components": [None]}},
+            "missing component name": {"spec": {"components": [{"image": "nginx"}]}},
+            "duplicate component names": {
+                "spec": {
+                    "components": [
+                        {"name": "duplicate", "frontend": True},
+                        {"name": "duplicate"},
+                    ]
+                }
+            },
+            "multi-component without frontend": {
+                "spec": {"components": [{"name": "api"}, {"name": "worker"}]}
+            },
+            "multi-component with two frontends": {
+                "spec": {
+                    "components": [
+                        {"name": "api", "frontend": True},
+                        {"name": "worker", "frontend": True},
+                    ]
+                }
+            },
+        }
+        legacy_update = {
+            "metadata": {},
+            "spec": {"container": {"image": "nginx:updated"}},
+        }
+        builders = {
+            "update": lambda raw: translation.legacy_to_http_endpoint_patch(
+                raw, legacy_update
+            ),
+            "stop": translation.build_endpoint_stop_patch,
+        }
+
+        for snapshot_name, raw in invalid_snapshots.items():
+            for builder_name, builder in builders.items():
+                with self.subTest(snapshot=snapshot_name, builder=builder_name):
+                    with self.assertRaises(ValueError):
+                        builder(raw)
+
+    def test_destructive_endpoint_patches_accept_valid_snapshots(self):
+        legacy_update = {
+            "metadata": {},
+            "spec": {"container": {"image": "nginx:updated"}},
+        }
+        valid_snapshots = {
+            "single": {
+                "spec": {"components": [{"name": "only", "image": "nginx:old"}]}
+            },
+            "multi": {
+                "spec": {
+                    "components": [
+                        {"name": "worker", "image": "worker:old"},
+                        {"name": "api", "image": "api:old", "frontend": True},
+                    ]
+                }
+            },
+        }
+
+        for snapshot_name, raw in valid_snapshots.items():
+            with self.subTest(snapshot=snapshot_name):
+                update = translation.legacy_to_http_endpoint_patch(raw, legacy_update)
+                update_components = update["spec"]["components"]
+                self.assertEqual(
+                    [component["name"] for component in update_components],
+                    [component["name"] for component in raw["spec"]["components"]],
+                )
+                expected_frontend_index = 0 if snapshot_name == "single" else 1
+                self.assertEqual(
+                    update_components[expected_frontend_index]["image"],
+                    "nginx:updated",
+                )
+                if snapshot_name == "multi":
+                    self.assertEqual(update_components[0], raw["spec"]["components"][0])
+
+                stop = translation.build_endpoint_stop_patch(raw)
+                self.assertEqual(
+                    [component["name"] for component in stop["spec"]["components"]],
+                    [component["name"] for component in raw["spec"]["components"]],
+                )
+                self.assertTrue(
+                    all(
+                        component["min_replicas"] == 0
+                        for component in stop["spec"]["components"]
+                    )
+                )
+
+    def test_stop_disables_active_gpu_and_qpm_targets(self):
+        raw = {
+            "spec": {
+                "components": [
+                    {
+                        "name": "gpu",
+                        "frontend": True,
+                        "min_replicas": 1,
+                        "autoscaling": {
+                            "target_gpu_utilization_percentage": 50,
+                            "scale_down": {"no_traffic_timeout": 600},
+                        },
+                    },
+                    {
+                        "name": "qpm",
+                        "min_replicas": 1,
+                        "autoscaling": {
+                            "target_throughput": {
+                                "qpm": 10,
+                                "paths": ["/predict"],
+                                "methods": ["POST"],
+                            }
+                        },
+                    },
+                    {
+                        "name": "scale-down-only",
+                        "min_replicas": 1,
+                        "autoscaling": {"scale_down": {"no_traffic_timeout": 300}},
+                    },
+                ]
+            }
+        }
+
+        patch = translation.build_endpoint_stop_patch(raw)
+        gpu, qpm, scale_down_only = patch["spec"]["components"]
+        self.assertEqual(gpu["min_replicas"], 0)
+        self.assertEqual(gpu["autoscaling"]["target_gpu_utilization_percentage"], 0)
+        self.assertEqual(gpu["autoscaling"]["scale_down"]["no_traffic_timeout"], 0)
+        self.assertEqual(qpm["autoscaling"]["target_throughput"]["qpm"], 0)
+        self.assertEqual(qpm["autoscaling"]["target_throughput"]["paths"], [])
+        self.assertEqual(qpm["autoscaling"]["target_throughput"]["methods"], [])
+        self.assertEqual(
+            scale_down_only["autoscaling"]["scale_down"]["no_traffic_timeout"],
+            300,
+        )
+        # Translation never mutates the server response supplied by the caller.
+        self.assertEqual(
+            raw["spec"]["components"][0]["autoscaling"][
+                "target_gpu_utilization_percentage"
+            ],
+            50,
+        )
+
+    def test_metadata_id_and_owner_survive_create_and_update(self):
+        legacy = {
+            "metadata": {"id": "ep", "owner": "new-owner"},
+            "spec": {"container": {"image": "nginx"}},
+        }
+        create = translation.legacy_to_http_endpoint(legacy)
+        self.assertEqual(create["metadata"]["name"], "ep")
+        self.assertEqual(create["metadata"]["lepton_metadata"]["owner"], "new-owner")
+
+        raw = {"spec": {"components": [{"name": "default", "image": "nginx"}]}}
+        update = translation.legacy_to_http_endpoint_patch(raw, legacy)
+        self.assertEqual(update["metadata"]["lepton_metadata"]["owner"], "new-owner")
+
+    def test_unsupported_legacy_port_exposure_is_rejected(self):
+        legacy = {
+            "metadata": {"name": "ep"},
+            "spec": {
+                "container": {
+                    "image": "nginx",
+                    "ports": [{"container_port": 8080, "host_port": 41000}],
+                }
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "cannot represent"):
+            translation.legacy_to_http_endpoint(legacy)
+
+    def test_unsupported_direct_resource_fields_are_rejected(self):
+        legacy = {
+            "metadata": {"name": "ep"},
+            "spec": {
+                "container": {"image": "nginx"},
+                "resource_requirement": {"cpu": 2.0, "memory": 4096},
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "resource_shape"):
+            translation.legacy_to_http_endpoint(legacy)
+
+    def test_endpoint_labels_are_rejected_instead_of_dropped(self):
+        legacy = {
+            "metadata": {"name": "ep", "labels": {"team": "inference"}},
+            "spec": {"container": {"image": "nginx"}},
+        }
+        with self.assertRaisesRegex(ValueError, "metadata labels"):
+            translation.legacy_to_http_endpoint(legacy)
+
+    def test_endpoint_empty_labels_are_accepted_as_noop(self):
+        wire = translation.legacy_to_http_endpoint({
+            "metadata": {"name": "ep", "labels": {}},
+            "spec": {"container": {"image": "nginx"}},
+        })
+        self.assertEqual(wire["metadata"]["name"], "ep")
+        self.assertNotIn("labels", wire["metadata"])
+
+
+class TestPodCompatibilityRegressions(unittest.TestCase):
+    def _pod_spec(self):
+        return LeptonDeployment(
+            metadata=Metadata(name="pod"),
+            spec=LeptonDeploymentUserSpec(
+                is_pod=True,
+                container=LeptonContainer(image="ubuntu"),
+                resource_requirement=ResourceRequirement(resource_shape="cpu.small"),
+            ),
+        )
+
+    def test_deployment_create_with_pod_spec_delegates_to_devpod(self):
+        fake = _resource_client()
+        calls = []
+        fake.pod = SimpleNamespace(create=lambda spec: calls.append(spec) or True)
+        api = EndpointAPI(fake)
+
+        spec = self._pod_spec()
+        self.assertTrue(api.create(spec))
+        self.assertEqual(calls, [spec])
+
+    def test_deprecated_create_pod_delegates_to_devpod(self):
+        fake = _resource_client()
+        calls = []
+        fake.pod = SimpleNamespace(create=lambda spec: calls.append(spec) or True)
+        api = EndpointAPI(fake)
+
+        spec = self._pod_spec()
+        with self.assertWarns(DeprecationWarning):
+            self.assertTrue(api.create_pod(spec))
+        self.assertEqual(calls, [spec])
+
+    def test_pod_objects_never_dispatch_to_endpoint_routes(self):
+        pod = self._pod_spec()
+        pod.metadata.id_ = "pod"
+
+        endpoint_transport = Mock(
+            side_effect=AssertionError("pod object reached an /endpoints transport")
+        )
+        fake = SimpleNamespace(
+            _get=endpoint_transport,
+            _post=endpoint_transport,
+            _put=endpoint_transport,
+            _patch=endpoint_transport,
+            _delete=endpoint_transport,
+            _head=endpoint_transport,
+        )
+        fake.pod = SimpleNamespace(
+            get=Mock(return_value="pod-get"),
+            update=Mock(side_effect=RuntimeError("pod updates are unsupported")),
+            stop=Mock(return_value="pod-stop"),
+            delete=Mock(return_value=True),
+            restart=Mock(return_value="pod-restart"),
+            get_readiness=Mock(
+                side_effect=NewDevPodAPIUnsupported("pod readiness is unsupported")
+            ),
+            get_termination=Mock(
+                side_effect=NewDevPodAPIUnsupported("pod termination is unsupported")
+            ),
+            get_log=Mock(
+                side_effect=NewDevPodAPIUnsupported("pod live logs are unsupported")
+            ),
+        )
+        api = EndpointAPI(fake)
+
+        self.assertEqual(api.get(pod), "pod-get")
+        self.assertEqual(api.stop(pod), "pod-stop")
+        self.assertTrue(api.delete(pod))
+        self.assertEqual(api.restart(pod), "pod-restart")
+        with self.assertRaisesRegex(RuntimeError, "pod updates"):
+            api.update(pod, pod)
+        with self.assertRaises(NewDevPodAPIUnsupported):
+            api.get_readiness(pod)
+        with self.assertRaises(NewDevPodAPIUnsupported):
+            api.get_termination(pod)
+        with self.assertRaises(NewEndpointAPIUnsupported):
+            api.get_replicas(pod)
+        with self.assertRaises(NewDevPodAPIUnsupported):
+            list(api.get_log(pod, replica="unused", timeout=7))
+        with self.assertRaises(NewEndpointAPIUnsupported):
+            api.get_events(pod)
+
+        fake.pod.get.assert_called_once_with(pod)
+        fake.pod.update.assert_called_once_with(pod, pod)
+        fake.pod.stop.assert_called_once_with(pod)
+        fake.pod.delete.assert_called_once_with(pod)
+        fake.pod.restart.assert_called_once_with(pod)
+        fake.pod.get_readiness.assert_called_once_with(pod)
+        fake.pod.get_termination.assert_called_once_with(pod)
+        fake.pod.get_log.assert_called_once_with(pod, timeout=7)
+        endpoint_transport.assert_not_called()
+
+    def test_devpod_direct_resources_are_rejected_instead_of_dropped(self):
+        legacy = self._pod_spec().model_dump(by_alias=True, exclude_none=True)
+        legacy["spec"]["resource_requirement"].update({"cpu": 2, "memory": 4096})
+        with self.assertRaisesRegex(ValueError, "DevPod API accepts resource_shape"):
+            translation.legacy_to_http_devpod(legacy)
+
+    def test_devpod_labels_are_rejected_instead_of_dropped(self):
+        legacy = self._pod_spec().model_dump(by_alias=True, exclude_none=True)
+        legacy["metadata"]["labels"] = {"team": "inference"}
+        with self.assertRaisesRegex(ValueError, "metadata labels"):
+            translation.legacy_to_http_devpod(legacy)
+
+    def test_devpod_empty_labels_are_accepted_as_noop(self):
+        legacy = self._pod_spec().model_dump(by_alias=True, exclude_none=True)
+        legacy["metadata"]["labels"] = {}
+        wire = translation.legacy_to_http_devpod(legacy)
+        self.assertEqual(wire["metadata"]["name"], "pod")
+        self.assertNotIn("labels", wire["metadata"])
+
+    def test_devpod_metadata_id_fallback_and_owner_reach_wire(self):
+        legacy = self._pod_spec().model_dump(by_alias=True, exclude_none=True)
+        legacy["metadata"] = {"id": "pod-from-id", "owner": "pod-owner"}
+        wire = translation.legacy_to_http_devpod(legacy)
+        self.assertEqual(
+            wire["metadata"],
+            {"name": "pod-from-id", "owner": "pod-owner"},
+        )
+
+    def test_devpod_rejects_unsupported_effective_legacy_fields(self):
+        unsupported_values = {
+            "health": {"readiness": {}},
+            "scheduling_policy": {"replica_spread": "Required"},
+            "routing_policy": {"enable_header_based_replica_routing": True},
+            "auth_config": {"ip_allowlist": ["192.0.2.0/24"]},
+            "load_balance_config": {"least_request": {"choice_count": 2}},
+        }
+        for field, value in unsupported_values.items():
+            with self.subTest(field=field):
+                legacy = self._pod_spec().model_dump(by_alias=True, exclude_none=True)
+                legacy["spec"][field] = value
+                with self.assertRaisesRegex(ValueError, field):
+                    translation.legacy_to_http_devpod(legacy)
+
+    def test_devpod_status_pairs_only_host_mapped_duplicate_ports(self):
+        raw = {
+            "metadata": {"name": "pod"},
+            "spec": {
+                "container": {
+                    "image": "ubuntu",
+                    "ports": [
+                        {
+                            "name": "admin",
+                            "container_port": 8080,
+                            "protocol": "TCP",
+                            "expose_strategies": ["HostPortMapping"],
+                        },
+                        {
+                            "name": "web",
+                            "container_port": 8080,
+                            "protocol": "TCP",
+                            "expose_strategies": ["IngressProxy"],
+                        },
+                        {
+                            "name": "dns",
+                            "container_port": 8080,
+                            "protocol": "UDP",
+                            "expose_strategies": ["HostPortMapping"],
+                        },
+                    ],
+                }
+            },
+            "status": {
+                "state": "Ready",
+                "port_statuses": [
+                    {"container_port": 8080, "host_port": 41000},
+                    {"container_port": 8080, "host_port": 41001},
+                ],
+            },
+        }
+        legacy = translation.http_devpod_to_legacy(raw)
+        statuses = legacy["status"]["container_port_status"]
+        self.assertEqual(
+            [(p["name"], p["protocol"], p["host_port"]) for p in statuses],
+            [("admin", "TCP", 41000), ("dns", "UDP", 41001)],
+        )
+
+    def test_missing_devpod_host_port_stays_unknown(self):
+        raw = {
+            "metadata": {"name": "pod"},
+            "spec": {
+                "container": {
+                    "ports": [{
+                        "container_port": 8080,
+                        "protocol": "TCP",
+                        "expose_strategies": ["HostPortMapping"],
+                    }]
+                }
+            },
+            "status": {
+                "state": "Starting",
+                "port_statuses": [{"container_port": 8080}],
+            },
+        }
+        legacy = translation.http_devpod_to_legacy(raw)
+        self.assertNotIn("host_port", legacy["status"]["container_port_status"][0])
+
+
+class TestObservableCompatibilityRegressions(unittest.TestCase):
+    def test_storage_rsync_prefers_allocated_status_port(self):
+        pod = SimpleNamespace(
+            status=SimpleNamespace(
+                container_port_status=[
+                    SimpleNamespace(container_port=873, host_port=41234)
+                ]
+            ),
+            spec=SimpleNamespace(
+                container=SimpleNamespace(
+                    ports=[SimpleNamespace(container_port=873, host_port=None)]
+                )
+            ),
+        )
+        self.assertEqual(_get_rsync_host_port(pod), 41234)
+
+    def test_translated_lists_skip_only_malformed_items(self):
+        valid_endpoint = {
+            "metadata": {"name": "good"},
+            "spec": {"components": [{"name": "default", "image": "nginx"}]},
+            "status": {"state": "Ready"},
+        }
+        invalid_endpoint = {
+            "metadata": {"name": "bad"},
+            "spec": {
+                "components": [{"name": "default", "ports": [{"container_port": 0}]}]
+            },
+            "status": {"state": "Ready"},
+        }
+        # Put the null first so the test proves a bad entry does not terminate
+        # traversal before later valid entries.
+        api = EndpointAPI(
+            _resource_client(_response([None, invalid_endpoint, valid_endpoint]))
+        )
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            result = api.list_all()
+        self.assertEqual([item.metadata.name for item in result], ["good"])
+        self.assertIn("Skipped 2 invalid endpoint", stderr.getvalue())
+
+        valid_pod = {
+            "metadata": {"name": "good-pod"},
+            "spec": {"container": {"image": "ubuntu"}},
+            "status": {"state": "Ready"},
+        }
+        invalid_pod = {
+            "metadata": {"name": "bad-pod"},
+            "spec": {"container": {"ports": [{"container_port": 0}]}},
+            "status": {"state": "Ready"},
+        }
+        api = DevPodAPI(_resource_client(_response([None, invalid_pod, valid_pod])))
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            result = api.list_all()
+        self.assertEqual([item.metadata.name for item in result], ["good-pod"])
+        self.assertIn("Skipped 2 invalid devpod", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/api/v2/translation.py
+++ b/leptonai/api/v2/translation.py
@@ -1,0 +1,532 @@
+"""Translation between the legacy LeptonDeployment schema and the new
+/endpoints (HTTPEndpoint) and /devpods (HTTPDevPod) wire schemas.
+
+The new deployment API (LEP-5664 / LEP-5665) does NOT mirror the legacy
+LeptonDeployment schema. Endpoints use a multi-component model
+(``spec.components[]``) and devpods use a flattened pod model
+(``spec.container`` + ``spec.resource_shape`` + ``spec.stopped``). To keep the
+CLI commands and SDK callers working against a single ``LeptonDeployment`` view
+model regardless of which routes are live, these functions translate:
+
+- outbound: a ``LeptonDeployment`` create/update spec -> the new wire payload
+- inbound:  a new HTTPEndpoint / HTTPDevPod response -> a ``LeptonDeployment``
+
+The mappings are ports of the dashboard's battle-tested TypeScript translators,
+which solve the identical problem in production:
+
+- endpoints: ``interaction-specs/apps/dashboard/src/endpoint-api.ts``
+  (``legacyToHTTPEndpoint``, ``normalizeHTTPEndpoint``,
+  ``toHTTPEndpointPatchFromRaw``, ``buildEndpointComponentsPatch``)
+- devpods: ``interaction-specs/apps/dashboard/src/devpod-api.ts``
+  (``normalizeHTTPDevPod``, ``toHTTPDevPodCreatePayload``, ``podStopPatch``)
+
+Where the TypeScript and the Go wire types disagree, the Go types win
+(``api-server/httpapi/endpoint/types.go``, ``api-server/httpapi/devpod/types.go``).
+
+All functions operate on plain dicts (already alias-serialized via
+``APIResourse.safe_json``) so they compose directly with the request/response
+JSON boundary, and never mutate their inputs.
+"""
+
+from typing import Any, Dict, List, Optional
+
+# The legacy deployment spec collapses into a single endpoint component. The
+# frontend flag is unnecessary for a single component; the api-server treats the
+# sole component as the frontend. Matches CANONICAL_COMPONENT_NAME in the TS.
+CANONICAL_COMPONENT_NAME = "default"
+
+
+def _get(d: Optional[Dict[str, Any]], key: str, default: Any = None) -> Any:
+    if not isinstance(d, dict):
+        return default
+    val = d.get(key, default)
+    return default if val is None else val
+
+
+def _prune_none(d: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop keys whose value is None. Mirrors ``exclude_none`` on the wire and
+    keeps merge-patch bodies from clearing untouched fields via explicit null.
+    """
+    return {k: v for k, v in d.items() if v is not None}
+
+
+# ---------------------------------------------------------------------------
+# Endpoints: legacy LeptonDeployment  <->  HTTPEndpoint
+# ---------------------------------------------------------------------------
+
+
+def _legacy_ports_to_component(
+    container: Dict[str, Any]
+) -> Optional[List[Dict[str, Any]]]:
+    ports = _get(container, "ports")
+    if not ports:
+        return None
+    # HTTPComponentSpec ports carry only container_port + protocol
+    # (api-server/httpapi/endpoint/types.go EndpointContainerPort projection).
+    return [
+        _prune_none({
+            "container_port": _get(p, "container_port", 0),
+            "protocol": _get(p, "protocol"),
+        })
+        for p in ports
+    ]
+
+
+def _legacy_spec_to_component(spec: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a single HTTPComponentSpec dict from a legacy deployment spec.
+
+    Ported from ``legacyToHTTPEndpoint`` in endpoint-api.ts: container/resource
+    fields fold into the component; endpoint-level fields are lifted out (see
+    :func:`legacy_to_http_endpoint`).
+    """
+    rr = _get(spec, "resource_requirement", {})
+    container = _get(spec, "container", {})
+    component: Dict[str, Any] = {
+        "name": CANONICAL_COMPONENT_NAME,
+        "image": _get(container, "image"),
+        "command": _get(container, "command"),
+        "ports": _legacy_ports_to_component(container),
+        "envs": _get(spec, "envs"),
+        "mounts": _get(spec, "mounts"),
+        "resource_shape": _get(rr, "resource_shape"),
+        "min_replicas": _get(rr, "min_replicas", 1),
+        "max_replicas": _get(rr, "max_replicas"),
+        "shared_memory_size": _get(rr, "shared_memory_size"),
+        "autoscaling": _get(spec, "auto_scaler"),
+        "affinity": _get(rr, "affinity"),
+        "host_network": _get(spec, "host_network"),
+        "scheduling_policy": _get(spec, "scheduling_policy"),
+        "queue_config": _get(spec, "queue_config"),
+        "reservation_config": _get(spec, "reservation_config"),
+        "health": _get(spec, "health"),
+        "user_security_context": _get(spec, "user_security_context"),
+    }
+    return _prune_none(component)
+
+
+def _legacy_endpoint_level_spec(spec: Dict[str, Any]) -> Dict[str, Any]:
+    """Endpoint-level (non-component) HTTPEndpointSpec fields lifted from the
+    legacy spec. Ported from ``legacyToHTTPEndpoint``.
+
+    Note the key rename: legacy ``auth_config`` -> new ``access_config`` and
+    legacy ``load_balance_config`` -> new ``load_balancing``
+    (api-server/httpapi/endpoint/types.go).
+    """
+    return _prune_none({
+        "ingress_timeout_seconds": _get(spec, "ingress_timeout_seconds"),
+        "access_config": _get(spec, "auth_config"),
+        "api_tokens": _get(spec, "api_tokens"),
+        "routing_policy": _get(spec, "routing_policy"),
+        "load_balancing": _get(spec, "load_balance_config"),
+        "log": _get(spec, "log"),
+        "metrics": _get(spec, "metrics"),
+        "image_pull_secrets": _get(spec, "image_pull_secrets"),
+    })
+
+
+def _legacy_metadata_to_endpoint(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    md: Dict[str, Any] = {}
+    if _get(metadata, "name"):
+        md["name"] = _get(metadata, "name")
+    if _get(metadata, "visibility"):
+        md["lepton_metadata"] = {"visibility": _get(metadata, "visibility")}
+    return md
+
+
+def legacy_to_http_endpoint(legacy: Dict[str, Any]) -> Dict[str, Any]:
+    """Legacy deployment create payload -> HTTPEndpoint create body.
+
+    Ported from ``toHTTPEndpointCreatePayload`` / ``legacyToHTTPEndpoint`` in
+    endpoint-api.ts. The spec collapses into a single "default" component; the
+    endpoint-level fields are lifted out of the component.
+    """
+    spec = _get(legacy, "spec", {})
+    metadata = _get(legacy, "metadata", {})
+    endpoint_spec = {"components": [_legacy_spec_to_component(spec)]}
+    endpoint_spec.update(_legacy_endpoint_level_spec(spec))
+    return {
+        "metadata": _legacy_metadata_to_endpoint(metadata),
+        "spec": endpoint_spec,
+    }
+
+
+def _merge_rfc7386(base: Dict[str, Any], patch: Dict[str, Any]) -> Dict[str, Any]:
+    """RFC7386 (JSON Merge Patch) deep merge of ``patch`` onto ``base``.
+
+    Ported from ``mergeRFC7386`` in endpoint-api.ts: ``None`` deletes a key,
+    plain dicts merge recursively, everything else replaces. (Here ``None`` is
+    used only for explicit deletes; absent keys are simply not present.)
+    """
+    result = dict(base)
+    for key, value in patch.items():
+        if value is None:
+            result.pop(key, None)
+        elif isinstance(value, dict):
+            current = result.get(key)
+            result[key] = _merge_rfc7386(
+                current if isinstance(current, dict) else {}, value
+            )
+        else:
+            result[key] = value
+    return result
+
+
+def _frontend_index(components: List[Dict[str, Any]]) -> int:
+    for i, c in enumerate(components):
+        if c.get("frontend") is True:
+            return i
+    return 0
+
+
+def legacy_to_http_endpoint_patch(
+    raw: Dict[str, Any], legacy: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Legacy update payload -> HTTPEndpoint PATCH (RFC7386 merge) body.
+
+    Ported from ``toHTTPEndpointPatchFromRaw`` in endpoint-api.ts. The new API
+    replaces ``spec.components`` wholesale, so the patch resends the WHOLE
+    component array built from the live endpoint (``raw``): the form's fields
+    are overlaid onto the frontend component in place, preserving its real name
+    and every field the form does not carry; sibling components pass through
+    untouched. ``raw`` is the un-normalized HTTPEndpoint fetched immediately
+    before the update.
+    """
+    spec = _get(legacy, "spec", {})
+    rr = _get(spec, "resource_requirement", {})
+    container = _get(spec, "container", {})
+
+    # Component-level fields the form carries. Fields left as None are pruned so
+    # the merge preserves the live component's value (no accidental clearing).
+    component_changes = _prune_none({
+        "image": _get(container, "image"),
+        "command": _get(container, "command"),
+        "ports": _legacy_ports_to_component(container),
+        "envs": _get(spec, "envs"),
+        "mounts": _get(spec, "mounts"),
+        "resource_shape": _get(rr, "resource_shape"),
+        "min_replicas": _get(rr, "min_replicas"),
+        "max_replicas": _get(rr, "max_replicas"),
+        "shared_memory_size": _get(rr, "shared_memory_size"),
+        "autoscaling": _get(spec, "auto_scaler"),
+        "affinity": _get(rr, "affinity"),
+        "host_network": _get(spec, "host_network"),
+        "scheduling_policy": _get(spec, "scheduling_policy"),
+        "queue_config": _get(spec, "queue_config"),
+        "reservation_config": _get(spec, "reservation_config"),
+        "health": _get(spec, "health"),
+        "user_security_context": _get(spec, "user_security_context"),
+    })
+
+    components = _get(_get(raw, "spec", {}), "components", [])
+    if components:
+        fi = _frontend_index(components)
+        next_components = [
+            _merge_rfc7386(c, component_changes) if i == fi else c
+            for i, c in enumerate(components)
+        ]
+    else:
+        next_components = [
+            _merge_rfc7386({"name": CANONICAL_COMPONENT_NAME}, component_changes)
+        ]
+
+    endpoint_spec = {"components": next_components}
+    endpoint_spec.update(_legacy_endpoint_level_spec(spec))
+
+    metadata: Dict[str, Any] = {}
+    if _get(_get(legacy, "metadata", {}), "visibility"):
+        metadata["lepton_metadata"] = {
+            "visibility": _get(_get(legacy, "metadata", {}), "visibility")
+        }
+    return {"metadata": metadata, "spec": endpoint_spec}
+
+
+def build_endpoint_stop_patch(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """HTTPEndpoint PATCH that scales the endpoint to zero replicas.
+
+    Ported from ``buildEndpointComponentsPatch`` in endpoint-api.ts with
+    ``minReplicas: 0`` (the "terminate" case): ``min_replicas: 0`` must
+    propagate to EVERY component. Resends the full component array (RFC7386
+    replaces it) built from the live endpoint ``raw``.
+    """
+    components = _get(_get(raw, "spec", {}), "components", [])
+    source = components if components else [{"name": CANONICAL_COMPONENT_NAME}]
+    next_components = []
+    for c in source:
+        updated = dict(c)
+        updated["min_replicas"] = 0
+        next_components.append(updated)
+    return {"metadata": {}, "spec": {"components": next_components}}
+
+
+def _endpoint_primary_component(ep: Dict[str, Any]) -> Dict[str, Any]:
+    components = _get(_get(ep, "spec", {}), "components", [])
+    for c in components:
+        if c.get("frontend") is True:
+            return c
+    return components[0] if components else {}
+
+
+# Map the new EndpointState -> the legacy LeptonDeploymentState phase strings.
+# Ported from mapEndpointStateToLegacyPhase in endpoint-api.ts. Unknown states
+# pass through so the CLI's LeptonDeploymentState enum can classify them.
+_ENDPOINT_STATE_TO_LEGACY_PHASE = {
+    "Ready": "Ready",
+    "NotReady": "Not Ready",
+    "Starting": "Starting",
+    "Updating": "Updating",
+    "Scaling": "Scaling",
+    "Stopping": "Stopping",
+    "Stopped": "Stopped",
+    "Deleting": "Deleting",
+    "Error": "Error",
+}
+
+
+def _map_endpoint_state_to_legacy_phase(state: Optional[str]) -> str:
+    if not state:
+        return ""
+    return _ENDPOINT_STATE_TO_LEGACY_PHASE.get(state, state)
+
+
+def http_endpoint_to_legacy(ep: Dict[str, Any]) -> Dict[str, Any]:
+    """HTTPEndpoint response -> legacy LeptonDeployment dict.
+
+    Ported from ``normalizeHTTPEndpoint`` in endpoint-api.ts. The frontend
+    component's fields are unfolded back into ``spec.container`` /
+    ``spec.resource_requirement`` and the endpoint-level fields are placed at
+    ``spec`` top level. Deleting is signalled by ``deleted_at`` -> "Deleting".
+    """
+    md = _get(ep, "metadata", {})
+    lm = _get(md, "lepton_metadata", {})
+    component = _endpoint_primary_component(ep)
+    status = _get(ep, "status", {})
+    name = _get(md, "name") or _get(md, "id") or ""
+
+    if _get(md, "deleted_at"):
+        phase = "Deleting"
+    else:
+        phase = _map_endpoint_state_to_legacy_phase(_get(status, "state"))
+    # The legacy api-server folds Stopping/Stopped down to "Not Ready" in the
+    # deprecated status.state field (phase keeps the real state). Reproduce it.
+    if _get(md, "deleted_at"):
+        state = "Deleting"
+    elif phase in ("Stopping", "Stopped"):
+        state = "Not Ready"
+    else:
+        state = phase
+
+    ports = _get(component, "ports")
+    container = _prune_none({
+        "image": _get(component, "image"),
+        "command": _get(component, "command"),
+        "ports": (
+            [
+                _prune_none({
+                    "container_port": _get(p, "container_port"),
+                    "protocol": _get(p, "protocol"),
+                })
+                for p in ports
+            ]
+            if ports
+            else None
+        ),
+    })
+
+    resource_requirement = _prune_none({
+        "resource_shape": _get(component, "resource_shape"),
+        "min_replicas": _get(component, "min_replicas"),
+        "max_replicas": _get(component, "max_replicas"),
+        "shared_memory_size": _get(component, "shared_memory_size"),
+        "affinity": _get(component, "affinity"),
+    })
+
+    spec = _prune_none({
+        "resource_requirement": resource_requirement or None,
+        "container": container or None,
+        "envs": _get(component, "envs"),
+        "mounts": _get(component, "mounts"),
+        "api_tokens": _get(_get(ep, "spec", {}), "api_tokens"),
+        "image_pull_secrets": _get(_get(ep, "spec", {}), "image_pull_secrets"),
+        "queue_config": _get(component, "queue_config"),
+        "auto_scaler": _get(component, "autoscaling"),
+        "auth_config": _get(_get(ep, "spec", {}), "access_config"),
+        "reservation_config": _get(component, "reservation_config"),
+        "load_balance_config": _get(_get(ep, "spec", {}), "load_balancing"),
+        "health": _get(component, "health"),
+        "log": _get(_get(ep, "spec", {}), "log"),
+        "metrics": _get(_get(ep, "spec", {}), "metrics"),
+        "ingress_timeout_seconds": _get(
+            _get(ep, "spec", {}), "ingress_timeout_seconds"
+        ),
+        "scheduling_policy": _get(component, "scheduling_policy"),
+        "routing_policy": _get(_get(ep, "spec", {}), "routing_policy"),
+        "host_network": _get(component, "host_network"),
+        "user_security_context": _get(component, "user_security_context"),
+    })
+
+    external_url = _get(status, "external_url")
+    metadata = _prune_none({
+        "id": name,
+        "name": name,
+        "created_at": _get(md, "created_at"),
+        "created_by": _get(lm, "created_by"),
+        "owner": _get(lm, "owner"),
+        "last_modified_at": _get(lm, "last_modified_at"),
+        "last_modified_by": _get(lm, "last_modified_by"),
+        "visibility": _get(lm, "visibility"),
+        "version": _get(md, "version"),
+        "semantic_version": _get(md, "semantic_version"),
+        "resource_version": _get(md, "resource_version"),
+    })
+    legacy_status = {
+        "state": state,
+        # The legacy LeptonDeploymentStatus.endpoint is a required object with an
+        # external_endpoint field; always provide it so the pydantic model that
+        # marks endpoint required does not reject the response.
+        "endpoint": {
+            "internal_endpoint": "",
+            "external_endpoint": external_url or "",
+        },
+        "autoscaler_status": _get(status, "auto_scaler_status"),
+    }
+    return {
+        "metadata": metadata,
+        "spec": spec,
+        "status": _prune_none(legacy_status),
+    }
+
+
+# ---------------------------------------------------------------------------
+# DevPods: legacy LeptonDeployment (pod)  <->  HTTPDevPod
+# ---------------------------------------------------------------------------
+
+
+def legacy_to_http_devpod(legacy: Dict[str, Any]) -> Dict[str, Any]:
+    """Legacy pod create payload -> HTTPDevPod create body.
+
+    Ported from ``toHTTPDevPodCreatePayload`` in devpod-api.ts. The legacy pod
+    spec's ``resource_requirement.resource_shape`` becomes a spec-level
+    ``resource_shape`` string; ``is_pod`` / ``min_replicas`` / ``auto_scaler`` /
+    ``api_tokens`` have no place in the devpod spec and are dropped. Rejects
+    non-TCP/UDP ports, matching the new DevPod API.
+    """
+    spec = _get(legacy, "spec", {})
+    rr = _get(spec, "resource_requirement", {})
+    container = _get(spec, "container", {})
+    for port in _get(container, "ports", []) or []:
+        proto = _get(port, "protocol")
+        if proto and proto not in ("TCP", "UDP"):
+            raise ValueError(
+                f"The new DevPod API does not support {proto} ports. Use TCP or UDP."
+            )
+    devpod_spec = _prune_none({
+        "container": _get(spec, "container"),
+        "resource_shape": _get(rr, "resource_shape"),
+        "shared_memory_size": _get(rr, "shared_memory_size"),
+        "affinity": _get(rr, "affinity"),
+        "envs": _get(spec, "envs"),
+        "mounts": _get(spec, "mounts"),
+        "storage_attachments": _get(spec, "storage_attachments"),
+        "image_pull_secrets": _get(spec, "image_pull_secrets"),
+        "queue_config": _get(spec, "queue_config"),
+        "reservation_config": _get(spec, "reservation_config"),
+        "user_security_context": _get(spec, "user_security_context"),
+        "host_network": _get(spec, "host_network"),
+        "log": _get(spec, "log"),
+        "metrics": _get(spec, "metrics"),
+        "ingress_timeout_seconds": _get(spec, "ingress_timeout_seconds"),
+    })
+    metadata = {}
+    if _get(_get(legacy, "metadata", {}), "name"):
+        metadata["name"] = _get(_get(legacy, "metadata", {}), "name")
+    return {"metadata": metadata, "spec": devpod_spec}
+
+
+def _running_replica_count(stopped: Optional[bool]) -> int:
+    return 0 if stopped is True else 1
+
+
+def http_devpod_to_legacy(dp: Dict[str, Any]) -> Dict[str, Any]:
+    """HTTPDevPod response -> legacy LeptonDeployment (pod) dict.
+
+    Ported from ``normalizeHTTPDevPod`` in devpod-api.ts. ``spec.resource_shape``
+    folds into ``resource_requirement``; ``spec.stopped`` projects to
+    ``min_replicas`` (0 when stopped, else 1); ``is_pod`` is forced True.
+    """
+    md = _get(dp, "metadata", {})
+    spec = _get(dp, "spec", {})
+    status = _get(dp, "status", {})
+    name = _get(md, "name") or ""
+    state = _get(status, "state", "")
+    container = _get(spec, "container", {})
+    ports = _get(container, "ports", []) or []
+
+    resource_requirement = _prune_none({
+        "resource_shape": _get(spec, "resource_shape"),
+        "min_replicas": _running_replica_count(_get(spec, "stopped")),
+        "shared_memory_size": _get(spec, "shared_memory_size"),
+        "affinity": _get(spec, "affinity"),
+    })
+
+    legacy_spec = _prune_none({
+        "is_pod": True,
+        "container": _get(spec, "container"),
+        "resource_requirement": resource_requirement or None,
+        "envs": _get(spec, "envs"),
+        "mounts": _get(spec, "mounts"),
+        "image_pull_secrets": _get(spec, "image_pull_secrets"),
+        "queue_config": _get(spec, "queue_config"),
+        "reservation_config": _get(spec, "reservation_config"),
+        "user_security_context": _get(spec, "user_security_context"),
+        "host_network": _get(spec, "host_network"),
+        "log": _get(spec, "log"),
+        "metrics": _get(spec, "metrics"),
+        "ingress_timeout_seconds": _get(spec, "ingress_timeout_seconds"),
+    })
+
+    external_url = _get(status, "external_url")
+    container_port_status = None
+    port_statuses = _get(status, "port_statuses")
+    if port_statuses:
+        container_port_status = []
+        for ps in port_statuses:
+            matched = next(
+                (
+                    p
+                    for p in ports
+                    if _get(p, "container_port") == _get(ps, "container_port")
+                ),
+                {},
+            )
+            container_port_status.append(
+                _prune_none({
+                    "container_port": _get(ps, "container_port"),
+                    "protocol": _get(matched, "protocol", "TCP"),
+                    "host_port": _get(ps, "host_port", 0),
+                    "external_endpoint": _get(ps, "external_url"),
+                    "name": _get(matched, "name"),
+                })
+            )
+
+    legacy_status = _prune_none({
+        "state": state or "UNK",
+        "endpoint": {
+            "internal_endpoint": "",
+            "external_endpoint": external_url or "",
+        },
+        "container_port_status": container_port_status,
+    })
+
+    metadata = _prune_none({
+        "id": name,
+        "name": name,
+        "created_at": _get(md, "created_at"),
+        "version": _get(md, "version"),
+        "resource_version": _get(md, "resource_version"),
+        "created_by": _get(md, "created_by"),
+        "owner": _get(md, "owner"),
+        "last_modified_by": _get(md, "last_modified_by"),
+        "last_modified_at": _get(md, "last_modified_at"),
+        "visibility": _get(md, "visibility"),
+    })
+    return {"metadata": metadata, "spec": legacy_spec, "status": legacy_status}

--- a/leptonai/api/v2/translation.py
+++ b/leptonai/api/v2/translation.py
@@ -396,6 +396,10 @@ def http_endpoint_to_legacy(ep: Dict[str, Any]) -> Dict[str, Any]:
             "external_endpoint": external_url or "",
         },
         "autoscaler_status": _get(status, "auto_scaler_status"),
+        # Carry the endpoint's ready_replicas so the CLI list can report running
+        # replicas for static endpoints (no autoscaler_status). HTTPEndpointStatus
+        # omits the field when zero, so absence reads as 0.
+        "ready_replicas": _get(status, "ready_replicas"),
     }
     return {
         "metadata": metadata,

--- a/leptonai/api/v2/translation.py
+++ b/leptonai/api/v2/translation.py
@@ -94,7 +94,9 @@ def _legacy_spec_to_component(spec: Dict[str, Any]) -> Dict[str, Any]:
         "shared_memory_size": _get(rr, "shared_memory_size"),
         "autoscaling": _get(spec, "auto_scaler"),
         "affinity": _get(rr, "affinity"),
-        "host_network": _get(spec, "host_network"),
+        # Legacy stores host_network under resource_requirement; the new component
+        # spec carries it at the component level.
+        "host_network": _get(rr, "host_network"),
         "scheduling_policy": _get(spec, "scheduling_policy"),
         "queue_config": _get(spec, "queue_config"),
         "reservation_config": _get(spec, "reservation_config"),
@@ -209,7 +211,7 @@ def legacy_to_http_endpoint_patch(
         "shared_memory_size": _get(rr, "shared_memory_size"),
         "autoscaling": _get(spec, "auto_scaler"),
         "affinity": _get(rr, "affinity"),
-        "host_network": _get(spec, "host_network"),
+        "host_network": _get(rr, "host_network"),
         "scheduling_policy": _get(spec, "scheduling_policy"),
         "queue_config": _get(spec, "queue_config"),
         "reservation_config": _get(spec, "reservation_config"),
@@ -338,6 +340,9 @@ def http_endpoint_to_legacy(ep: Dict[str, Any]) -> Dict[str, Any]:
         "max_replicas": _get(component, "max_replicas"),
         "shared_memory_size": _get(component, "shared_memory_size"),
         "affinity": _get(component, "affinity"),
+        # Legacy carries host_network under resource_requirement (there is no
+        # spec-level field); fold the component's value back in there.
+        "host_network": _get(component, "host_network"),
     })
 
     spec = _prune_none({
@@ -360,7 +365,6 @@ def http_endpoint_to_legacy(ep: Dict[str, Any]) -> Dict[str, Any]:
         ),
         "scheduling_policy": _get(component, "scheduling_policy"),
         "routing_policy": _get(_get(ep, "spec", {}), "routing_policy"),
-        "host_network": _get(component, "host_network"),
         "user_security_context": _get(component, "user_security_context"),
     })
 
@@ -431,7 +435,9 @@ def legacy_to_http_devpod(legacy: Dict[str, Any]) -> Dict[str, Any]:
         "queue_config": _get(spec, "queue_config"),
         "reservation_config": _get(spec, "reservation_config"),
         "user_security_context": _get(spec, "user_security_context"),
-        "host_network": _get(spec, "host_network"),
+        # Legacy stores host_network under resource_requirement; the devpod spec
+        # carries it at the top level.
+        "host_network": _get(rr, "host_network"),
         "log": _get(spec, "log"),
         "metrics": _get(spec, "metrics"),
         "ingress_timeout_seconds": _get(spec, "ingress_timeout_seconds"),
@@ -466,6 +472,9 @@ def http_devpod_to_legacy(dp: Dict[str, Any]) -> Dict[str, Any]:
         "min_replicas": _running_replica_count(_get(spec, "stopped")),
         "shared_memory_size": _get(spec, "shared_memory_size"),
         "affinity": _get(spec, "affinity"),
+        # Legacy carries host_network under resource_requirement (there is no
+        # spec-level field); fold the devpod spec's value back in there.
+        "host_network": _get(spec, "host_network"),
     })
 
     legacy_spec = _prune_none({
@@ -478,7 +487,6 @@ def http_devpod_to_legacy(dp: Dict[str, Any]) -> Dict[str, Any]:
         "queue_config": _get(spec, "queue_config"),
         "reservation_config": _get(spec, "reservation_config"),
         "user_security_context": _get(spec, "user_security_context"),
-        "host_network": _get(spec, "host_network"),
         "log": _get(spec, "log"),
         "metrics": _get(spec, "metrics"),
         "ingress_timeout_seconds": _get(spec, "ingress_timeout_seconds"),
@@ -515,6 +523,9 @@ def http_devpod_to_legacy(dp: Dict[str, Any]) -> Dict[str, Any]:
             "external_endpoint": external_url or "",
         },
         "container_port_status": container_port_status,
+        # The devpod status exposes the pod's bare public IP directly; carry it
+        # through so the CLI need not (mis)parse it out of a port's external URL.
+        "public_ip": _get(status, "public_ip"),
     })
 
     metadata = _prune_none({

--- a/leptonai/api/v2/translation.py
+++ b/leptonai/api/v2/translation.py
@@ -446,9 +446,15 @@ def legacy_to_http_devpod(legacy: Dict[str, Any]) -> Dict[str, Any]:
         "metrics": _get(spec, "metrics"),
         "ingress_timeout_seconds": _get(spec, "ingress_timeout_seconds"),
     })
-    metadata = {}
-    if _get(_get(legacy, "metadata", {}), "name"):
-        metadata["name"] = _get(_get(legacy, "metadata", {}), "name")
+    legacy_metadata = _get(legacy, "metadata", {})
+    metadata: Dict[str, Any] = {}
+    if _get(legacy_metadata, "name"):
+        metadata["name"] = _get(legacy_metadata, "name")
+    # HTTPDevPodMetadata inlines LeptonMetadata, so visibility sits directly on
+    # metadata (unlike the endpoint's nested lepton_metadata). Carry it through
+    # or a create with visibility=private is silently made public server-side.
+    if _get(legacy_metadata, "visibility"):
+        metadata["visibility"] = _get(legacy_metadata, "visibility")
     return {"metadata": metadata, "spec": devpod_spec}
 
 

--- a/leptonai/api/v2/translation.py
+++ b/leptonai/api/v2/translation.py
@@ -61,12 +61,15 @@ def _legacy_ports_to_component(
     ports = _get(container, "ports")
     if not ports:
         return None
-    # HTTPComponentSpec ports carry only container_port + protocol
+    # HTTPComponentSpec ports carry container_port + protocol + app_protocol
     # (api-server/httpapi/endpoint/types.go EndpointContainerPort projection).
+    # app_protocol ("http"/"grpc") selects ingress routing and must survive the
+    # round-trip so an image-only update does not silently clear it.
     return [
         _prune_none({
             "container_port": _get(p, "container_port", 0),
             "protocol": _get(p, "protocol"),
+            "app_protocol": _get(p, "app_protocol"),
         })
         for p in ports
     ]
@@ -326,6 +329,7 @@ def http_endpoint_to_legacy(ep: Dict[str, Any]) -> Dict[str, Any]:
                 _prune_none({
                     "container_port": _get(p, "container_port"),
                     "protocol": _get(p, "protocol"),
+                    "app_protocol": _get(p, "app_protocol"),
                 })
                 for p in ports
             ]
@@ -452,6 +456,19 @@ def _running_replica_count(stopped: Optional[bool]) -> int:
     return 0 if stopped is True else 1
 
 
+# The devpod DevPodState enum spells NotReady without a space, but the CLI's
+# LeptonDeploymentState enum expects "Not Ready"; without this remap the state
+# collapses to "UNK". Every other DevPodState value matches the CLI enum, so
+# unknown states pass through for the enum's own _missing_ handling.
+_DEVPOD_STATE_TO_LEGACY = {"NotReady": "Not Ready"}
+
+
+def _map_devpod_state_to_legacy(state: Optional[str]) -> str:
+    if not state:
+        return ""
+    return _DEVPOD_STATE_TO_LEGACY.get(state, state)
+
+
 def http_devpod_to_legacy(dp: Dict[str, Any]) -> Dict[str, Any]:
     """HTTPDevPod response -> legacy LeptonDeployment (pod) dict.
 
@@ -463,7 +480,7 @@ def http_devpod_to_legacy(dp: Dict[str, Any]) -> Dict[str, Any]:
     spec = _get(dp, "spec", {})
     status = _get(dp, "status", {})
     name = _get(md, "name") or ""
-    state = _get(status, "state", "")
+    state = _map_devpod_state_to_legacy(_get(status, "state", ""))
     container = _get(spec, "container", {})
     ports = _get(container, "ports", []) or []
 

--- a/leptonai/api/v2/translation.py
+++ b/leptonai/api/v2/translation.py
@@ -58,8 +58,14 @@ def _prune_none(d: Dict[str, Any]) -> Dict[str, Any]:
 def _legacy_ports_to_component(
     container: Dict[str, Any]
 ) -> Optional[List[Dict[str, Any]]]:
-    ports = _get(container, "ports")
-    if not ports:
+    # Distinguish "ports not specified" (absent -> None -> pruned so a patch
+    # preserves the live ports) from an explicit empty list (clear all ports).
+    # Under RFC7386 the backend replaces the whole ports array, so an explicit
+    # `[]` must reach the wire to clear ports, matching the legacy /deployments
+    # update which sends `ports: []` verbatim. Collapsing both to None would
+    # silently retain ports on an intended clear.
+    ports = container.get("ports") if isinstance(container, dict) else None
+    if ports is None:
         return None
     # HTTPComponentSpec ports carry container_port + protocol + app_protocol
     # (api-server/httpapi/endpoint/types.go EndpointContainerPort projection).

--- a/leptonai/api/v2/translation.py
+++ b/leptonai/api/v2/translation.py
@@ -35,6 +35,12 @@ from typing import Any, Dict, List, Optional
 # sole component as the frontend. Matches CANONICAL_COMPONENT_NAME in the TS.
 CANONICAL_COMPONENT_NAME = "default"
 
+# The legacy /deployments handler injects this service port for every non-pod
+# container whose port list is absent or empty.  The new endpoint controller
+# does not inject a port and creates no frontend Service when the component has
+# none, so the compatibility translator must reproduce the legacy default.
+LEGACY_DEFAULT_ENDPOINT_PORT = 40000
+
 
 def _get(d: Optional[Dict[str, Any]], key: str, default: Any = None) -> Any:
     if not isinstance(d, dict):
@@ -56,17 +62,39 @@ def _prune_none(d: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _legacy_ports_to_component(
-    container: Dict[str, Any]
+    container: Dict[str, Any], *, for_create: bool = False
 ) -> Optional[List[Dict[str, Any]]]:
-    # Distinguish "ports not specified" (absent -> None -> pruned so a patch
-    # preserves the live ports) from an explicit empty list (clear all ports).
-    # Under RFC7386 the backend replaces the whole ports array, so an explicit
-    # `[]` must reach the wire to clear ports, matching the legacy /deployments
-    # update which sends `ports: []` verbatim. Collapsing both to None would
-    # silently retain ports on an intended clear.
+    # Reproduce the legacy backend's 40000 default on create. On update,
+    # distinguish an omitted field (preserve live ports) from an explicit empty
+    # list (clear ports), which is part of this compatibility layer's contract.
     ports = container.get("ports") if isinstance(container, dict) else None
     if ports is None:
-        return None
+        if not for_create:
+            return None
+        ports = []
+    if not ports:
+        return [{"container_port": LEGACY_DEFAULT_ENDPOINT_PORT}] if for_create else []
+
+    # Several legacy exposure controls have no equivalent on
+    # EndpointContainerPort.  Dropping them can turn a host-only port into an
+    # ingress-exposed port, so fail explicitly instead of changing reachability.
+    unsupported_fields = (
+        "name",
+        "expose_strategies",
+        "host_port",
+        "enable_load_balancer",
+    )
+    for index, port in enumerate(ports):
+        unsupported = [
+            field
+            for field in unsupported_fields
+            if field in port and port[field] is not None
+        ]
+        if unsupported:
+            raise ValueError(
+                "The new Endpoint API cannot represent legacy container port"
+                f" field(s) {', '.join(unsupported)} on port index {index}."
+            )
     # HTTPComponentSpec ports carry container_port + protocol + app_protocol
     # (api-server/httpapi/endpoint/types.go EndpointContainerPort projection).
     # app_protocol ("http"/"grpc") selects ingress routing and must survive the
@@ -81,6 +109,26 @@ def _legacy_ports_to_component(
     ]
 
 
+def _reject_unrepresentable_direct_resources(
+    rr: Dict[str, Any], resource_kind: str
+) -> None:
+    unsupported_fields = (
+        "cpu",
+        "memory",
+        "ephemeral_storage_in_gb",
+        "accelerator_type",
+        "accelerator_num",
+        "resourse_affinity",
+    )
+    unsupported = [field for field in unsupported_fields if _get(rr, field) is not None]
+    if unsupported:
+        raise ValueError(
+            f"The new {resource_kind} API accepts resource_shape rather than legacy"
+            " direct"
+            f" resource field(s): {', '.join(unsupported)}."
+        )
+
+
 def _legacy_spec_to_component(spec: Dict[str, Any]) -> Dict[str, Any]:
     """Build a single HTTPComponentSpec dict from a legacy deployment spec.
 
@@ -89,12 +137,13 @@ def _legacy_spec_to_component(spec: Dict[str, Any]) -> Dict[str, Any]:
     :func:`legacy_to_http_endpoint`).
     """
     rr = _get(spec, "resource_requirement", {})
+    _reject_unrepresentable_direct_resources(rr, "Endpoint")
     container = _get(spec, "container", {})
     component: Dict[str, Any] = {
         "name": CANONICAL_COMPONENT_NAME,
         "image": _get(container, "image"),
         "command": _get(container, "command"),
-        "ports": _legacy_ports_to_component(container),
+        "ports": _legacy_ports_to_component(container, for_create=True),
         "envs": _get(spec, "envs"),
         "mounts": _get(spec, "mounts"),
         "resource_shape": _get(rr, "resource_shape"),
@@ -124,6 +173,7 @@ def _legacy_endpoint_level_spec(spec: Dict[str, Any]) -> Dict[str, Any]:
     (api-server/httpapi/endpoint/types.go).
     """
     return _prune_none({
+        "ingress_enabled": _get(spec, "ingress_enabled"),
         "ingress_timeout_seconds": _get(spec, "ingress_timeout_seconds"),
         "access_config": _get(spec, "auth_config"),
         "api_tokens": _get(spec, "api_tokens"),
@@ -136,12 +186,30 @@ def _legacy_endpoint_level_spec(spec: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _legacy_metadata_to_endpoint(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    _reject_unrepresentable_labels(metadata, "Endpoint")
     md: Dict[str, Any] = {}
-    if _get(metadata, "name"):
-        md["name"] = _get(metadata, "name")
-    if _get(metadata, "visibility"):
-        md["lepton_metadata"] = {"visibility": _get(metadata, "visibility")}
+    name = _get(metadata, "name") or _get(metadata, "id")
+    if name:
+        md["name"] = name
+    lepton_metadata = _prune_none({
+        "owner": _get(metadata, "owner"),
+        "visibility": _get(metadata, "visibility"),
+    })
+    if lepton_metadata:
+        md["lepton_metadata"] = lepton_metadata
     return md
+
+
+def _reject_unrepresentable_labels(
+    metadata: Dict[str, Any], resource_kind: str
+) -> None:
+    # An empty mapping has no effect and is equivalent to omission. Only reject
+    # labels whose loss would change the caller's requested metadata.
+    if isinstance(metadata, dict) and metadata.get("labels"):
+        raise ValueError(
+            f"The new {resource_kind} API does not expose metadata labels; remove"
+            " metadata.labels before creating or updating this resource."
+        )
 
 
 def legacy_to_http_endpoint(legacy: Dict[str, Any]) -> Dict[str, Any]:
@@ -153,6 +221,10 @@ def legacy_to_http_endpoint(legacy: Dict[str, Any]) -> Dict[str, Any]:
     """
     spec = _get(legacy, "spec", {})
     metadata = _get(legacy, "metadata", {})
+    if _get(spec, "is_pod") is True:
+        raise ValueError(
+            "A pod-flavoured deployment must be created through the DevPod API."
+        )
     endpoint_spec = {"components": [_legacy_spec_to_component(spec)]}
     endpoint_spec.update(_legacy_endpoint_level_spec(spec))
     return {
@@ -189,6 +261,55 @@ def _frontend_index(components: List[Dict[str, Any]]) -> int:
     return 0
 
 
+def _require_endpoint_component_snapshot(
+    raw: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    """Return a safe live component snapshot for a destructive merge patch.
+
+    Endpoint PATCH replaces the complete component array. A missing or malformed
+    GET snapshot must therefore fail closed; fabricating a fallback component
+    could delete every live component. The checks mirror the structural
+    invariants guaranteed by the Endpoint backend for a valid response.
+    """
+    if not isinstance(raw, dict):
+        raise ValueError("Endpoint preflight response must be an object.")
+    raw_spec = raw.get("spec")
+    if not isinstance(raw_spec, dict):
+        raise ValueError("Endpoint preflight response is missing spec.components.")
+    components = raw_spec.get("components")
+    if not isinstance(components, list) or not components:
+        raise ValueError(
+            "Endpoint preflight response spec.components must be a non-empty list."
+        )
+
+    names = set()
+    frontend_count = 0
+    for index, component in enumerate(components):
+        if not isinstance(component, dict):
+            raise ValueError(
+                f"Endpoint preflight component at index {index} must be an object."
+            )
+        name = component.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(
+                f"Endpoint preflight component at index {index} is missing name."
+            )
+        if name in names:
+            raise ValueError(
+                f"Endpoint preflight response contains duplicate component {name!r}."
+            )
+        names.add(name)
+        if component.get("frontend") is True:
+            frontend_count += 1
+
+    if len(components) > 1 and frontend_count != 1:
+        raise ValueError(
+            "Endpoint preflight response must contain exactly one frontend component"
+            " when multiple components are present."
+        )
+    return components
+
+
 def legacy_to_http_endpoint_patch(
     raw: Dict[str, Any], legacy: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -204,6 +325,7 @@ def legacy_to_http_endpoint_patch(
     """
     spec = _get(legacy, "spec", {})
     rr = _get(spec, "resource_requirement", {})
+    _reject_unrepresentable_direct_resources(rr, "Endpoint")
     container = _get(spec, "container", {})
 
     # Component-level fields the form carries. Fields left as None are pruned so
@@ -228,26 +350,25 @@ def legacy_to_http_endpoint_patch(
         "user_security_context": _get(spec, "user_security_context"),
     })
 
-    components = _get(_get(raw, "spec", {}), "components", [])
-    if components:
-        fi = _frontend_index(components)
-        next_components = [
-            _merge_rfc7386(c, component_changes) if i == fi else c
-            for i, c in enumerate(components)
-        ]
-    else:
-        next_components = [
-            _merge_rfc7386({"name": CANONICAL_COMPONENT_NAME}, component_changes)
-        ]
+    components = _require_endpoint_component_snapshot(raw)
+    fi = _frontend_index(components)
+    next_components = [
+        _merge_rfc7386(c, component_changes) if i == fi else c
+        for i, c in enumerate(components)
+    ]
 
     endpoint_spec = {"components": next_components}
     endpoint_spec.update(_legacy_endpoint_level_spec(spec))
 
+    legacy_metadata = _get(legacy, "metadata", {})
+    _reject_unrepresentable_labels(legacy_metadata, "Endpoint")
+    lepton_metadata = _prune_none({
+        "owner": _get(legacy_metadata, "owner"),
+        "visibility": _get(legacy_metadata, "visibility"),
+    })
     metadata: Dict[str, Any] = {}
-    if _get(_get(legacy, "metadata", {}), "visibility"):
-        metadata["lepton_metadata"] = {
-            "visibility": _get(_get(legacy, "metadata", {}), "visibility")
-        }
+    if lepton_metadata:
+        metadata["lepton_metadata"] = lepton_metadata
     return {"metadata": metadata, "spec": endpoint_spec}
 
 
@@ -259,12 +380,38 @@ def build_endpoint_stop_patch(raw: Dict[str, Any]) -> Dict[str, Any]:
     propagate to EVERY component. Resends the full component array (RFC7386
     replaces it) built from the live endpoint ``raw``.
     """
-    components = _get(_get(raw, "spec", {}), "components", [])
-    source = components if components else [{"name": CANONICAL_COMPONENT_NAME}]
+    source = _require_endpoint_component_snapshot(raw)
     next_components = []
     for c in source:
         updated = dict(c)
         updated["min_replicas"] = 0
+
+        # Endpoint validation requires min_replicas >= 1 while either the GPU
+        # or throughput target is active.  Match the dashboard's terminate path
+        # by disabling those targets before scaling to zero.  Scale-down-only
+        # autoscaling remains valid and is left unchanged.
+        autoscaling = c.get("autoscaling")
+        if isinstance(autoscaling, dict):
+            throughput = autoscaling.get("target_throughput")
+            qpm = throughput.get("qpm") if isinstance(throughput, dict) else None
+            gpu_target = autoscaling.get("target_gpu_utilization_percentage")
+            if gpu_target not in (None, 0) or qpm not in (None, 0):
+                next_autoscaling = dict(autoscaling)
+                next_autoscaling["target_gpu_utilization_percentage"] = 0
+
+                next_throughput = (
+                    dict(throughput) if isinstance(throughput, dict) else {}
+                )
+                next_throughput.update({"qpm": 0, "paths": [], "methods": []})
+                next_autoscaling["target_throughput"] = next_throughput
+
+                scale_down = autoscaling.get("scale_down")
+                next_scale_down = (
+                    dict(scale_down) if isinstance(scale_down, dict) else {}
+                )
+                next_scale_down["no_traffic_timeout"] = 0
+                next_autoscaling["scale_down"] = next_scale_down
+                updated["autoscaling"] = next_autoscaling
         next_components.append(updated)
     return {"metadata": {}, "spec": {"components": next_components}}
 
@@ -370,6 +517,7 @@ def http_endpoint_to_legacy(ep: Dict[str, Any]) -> Dict[str, Any]:
         "health": _get(component, "health"),
         "log": _get(_get(ep, "spec", {}), "log"),
         "metrics": _get(_get(ep, "spec", {}), "metrics"),
+        "ingress_enabled": _get(_get(ep, "spec", {}), "ingress_enabled"),
         "ingress_timeout_seconds": _get(
             _get(ep, "spec", {}), "ingress_timeout_seconds"
         ),
@@ -394,6 +542,7 @@ def http_endpoint_to_legacy(ep: Dict[str, Any]) -> Dict[str, Any]:
     })
     legacy_status = {
         "state": state,
+        "phase": phase,
         # The legacy LeptonDeploymentStatus.endpoint is a required object with an
         # external_endpoint field; always provide it so the pydantic model that
         # marks endpoint required does not reject the response.
@@ -419,6 +568,33 @@ def http_endpoint_to_legacy(ep: Dict[str, Any]) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _reject_unrepresentable_devpod_fields(spec: Dict[str, Any]) -> None:
+    """Reject effective legacy pod settings absent from the DevPod wire.
+
+    Health and replica spread fail validation on the legacy pod backend. The
+    remaining fields affect legacy pod ingress/Envoy behavior. Silently dropping
+    any of them would therefore make flag-on behavior materially different.
+    """
+    unsupported = []
+    if "health" in spec and spec["health"] is not None:
+        unsupported.append("health")
+
+    scheduling = spec.get("scheduling_policy")
+    if isinstance(scheduling, dict) and scheduling.get("replica_spread") is not None:
+        unsupported.append("scheduling_policy")
+
+    for field in ("routing_policy", "auth_config", "load_balance_config"):
+        if spec.get(field):
+            unsupported.append(field)
+
+    if unsupported:
+        raise ValueError(
+            "The new DevPod API cannot represent legacy pod field(s): "
+            + ", ".join(unsupported)
+            + ". Remove them before creating this DevPod."
+        )
+
+
 def legacy_to_http_devpod(legacy: Dict[str, Any]) -> Dict[str, Any]:
     """Legacy pod create payload -> HTTPDevPod create body.
 
@@ -429,7 +605,9 @@ def legacy_to_http_devpod(legacy: Dict[str, Any]) -> Dict[str, Any]:
     non-TCP/UDP ports, matching the new DevPod API.
     """
     spec = _get(legacy, "spec", {})
+    _reject_unrepresentable_devpod_fields(spec)
     rr = _get(spec, "resource_requirement", {})
+    _reject_unrepresentable_direct_resources(rr, "DevPod")
     container = _get(spec, "container", {})
     for port in _get(container, "ports", []) or []:
         proto = _get(port, "protocol")
@@ -457,14 +635,18 @@ def legacy_to_http_devpod(legacy: Dict[str, Any]) -> Dict[str, Any]:
         "ingress_timeout_seconds": _get(spec, "ingress_timeout_seconds"),
     })
     legacy_metadata = _get(legacy, "metadata", {})
+    _reject_unrepresentable_labels(legacy_metadata, "DevPod")
     metadata: Dict[str, Any] = {}
-    if _get(legacy_metadata, "name"):
-        metadata["name"] = _get(legacy_metadata, "name")
+    name = _get(legacy_metadata, "name") or _get(legacy_metadata, "id")
+    if name:
+        metadata["name"] = name
     # HTTPDevPodMetadata inlines LeptonMetadata, so visibility sits directly on
     # metadata (unlike the endpoint's nested lepton_metadata). Carry it through
     # or a create with visibility=private is silently made public server-side.
     if _get(legacy_metadata, "visibility"):
         metadata["visibility"] = _get(legacy_metadata, "visibility")
+    if _get(legacy_metadata, "owner"):
+        metadata["owner"] = _get(legacy_metadata, "owner")
     return {"metadata": metadata, "spec": devpod_spec}
 
 
@@ -529,21 +711,26 @@ def http_devpod_to_legacy(dp: Dict[str, Any]) -> Dict[str, Any]:
     container_port_status = None
     port_statuses = _get(status, "port_statuses")
     if port_statuses:
+        # Port status omits protocol/name and the controller emits entries only
+        # for HostPortMapping ports. Pair those eligible spec ports by number
+        # and occurrence; including an IngressProxy port with the same number
+        # would attach the allocated host port to the wrong protocol/name.
+        ports_by_number: Dict[Any, List[Dict[str, Any]]] = {}
+        for port in ports:
+            strategies = _get(port, "expose_strategies", []) or []
+            if "HostPortMapping" in strategies:
+                ports_by_number.setdefault(_get(port, "container_port"), []).append(
+                    port
+                )
         container_port_status = []
         for ps in port_statuses:
-            matched = next(
-                (
-                    p
-                    for p in ports
-                    if _get(p, "container_port") == _get(ps, "container_port")
-                ),
-                {},
-            )
+            candidates = ports_by_number.get(_get(ps, "container_port"), [])
+            matched = candidates.pop(0) if candidates else {}
             container_port_status.append(
                 _prune_none({
                     "container_port": _get(ps, "container_port"),
                     "protocol": _get(matched, "protocol", "TCP"),
-                    "host_port": _get(ps, "host_port", 0),
+                    "host_port": _get(ps, "host_port"),
                     "external_endpoint": _get(ps, "external_url"),
                     "name": _get(matched, "name"),
                 })
@@ -551,6 +738,7 @@ def http_devpod_to_legacy(dp: Dict[str, Any]) -> Dict[str, Any]:
 
     legacy_status = _prune_none({
         "state": state or "UNK",
+        "phase": state or "UNK",
         "endpoint": {
             "internal_endpoint": "",
             "external_endpoint": external_url or "",

--- a/leptonai/api/v2/types/deployment.py
+++ b/leptonai/api/v2/types/deployment.py
@@ -355,6 +355,10 @@ class LeptonDeploymentStatus(BaseModel):
     endpoint: DeploymentEndpoint
     container_port_status: Optional[List[ContainerPortStatus]] = None
     autoscaler_status: Optional[AutoScalerStatus] = None
+    # Bare public IP of the (single) pod, surfaced from the new devpod API's
+    # status.public_ip. Legacy /deployments responses do not carry this field
+    # (the CLI reads the per-replica public_ip there instead), so it stays None.
+    public_ip: Optional[str] = None
     is_system: Optional[bool] = None
 
 

--- a/leptonai/api/v2/types/deployment.py
+++ b/leptonai/api/v2/types/deployment.py
@@ -364,6 +364,11 @@ class LeptonDeploymentStatus(BaseModel):
     # status.public_ip. Legacy /deployments responses do not carry this field
     # (the CLI reads the per-replica public_ip there instead), so it stays None.
     public_ip: Optional[str] = None
+    # Ready-replica count surfaced from the new endpoint API's
+    # status.ready_replicas. Static (non-autoscaled) endpoints carry no
+    # autoscaler_status, so the CLI list falls back to this to avoid reporting 0
+    # running replicas. Legacy /deployments responses do not set it -> None.
+    ready_replicas: Optional[int] = None
     is_system: Optional[bool] = None
 
 

--- a/leptonai/api/v2/types/deployment.py
+++ b/leptonai/api/v2/types/deployment.py
@@ -54,6 +54,11 @@ class ContainerPort(BaseModel):
     container_port: int
     expose_strategies: Optional[List[ContainerPortExposeStrategy]] = None
     protocol: Optional[str] = None
+    # Ingress routing hint on the new endpoint component ports ("http" or "grpc";
+    # EndpointContainerPort.app_protocol). Carried through translation so an
+    # image-only endpoint update does not drop the live value. Unused by the
+    # legacy /deployments path.
+    app_protocol: Optional[str] = None
     host_port: Optional[int] = None
     enable_load_balancer: Optional[bool] = None
 

--- a/leptonai/api/v2/types/deployment.py
+++ b/leptonai/api/v2/types/deployment.py
@@ -299,6 +299,10 @@ class LeptonDeploymentUserSpec(BaseModel):
     queue_config: Optional[QueueConfig] = None
     scheduling_policy: Optional[DeploymentSchedulingPolicy] = None
     auth_config: Optional[AuthConfig] = None
+    # Endpoint-level ingress switch on the new API. Preserve an explicit false
+    # value in the legacy-shaped compatibility model: omission defaults to true
+    # on create and would otherwise make an exported private endpoint reachable.
+    ingress_enabled: Optional[bool] = None
     ingress_timeout_seconds: Optional[int] = None
     load_balance_config: Optional[Union[LoadBalanceConfig, Dict[str, Any]]] = None
 
@@ -357,6 +361,11 @@ class AutoScalerStatus(BaseModel):
 
 class LeptonDeploymentStatus(BaseModel):
     state: LeptonDeploymentState
+    # The legacy backend preserves the real lifecycle state in `phase` while
+    # collapsing Stopping/Stopped to state="Not Ready" for old clients. New API
+    # translators populate the same distinction so callers can tell an
+    # unhealthy running workload from one that is already stopped.
+    phase: Optional[LeptonDeploymentState] = None
     endpoint: DeploymentEndpoint
     container_port_status: Optional[List[ContainerPortStatus]] = None
     autoscaler_status: Optional[AutoScalerStatus] = None

--- a/leptonai/api/v2/types/workspace.py
+++ b/leptonai/api/v2/types/workspace.py
@@ -42,6 +42,19 @@ class ResourceQuota(BaseModel):
     used: TotalResource
 
 
+class WorkspaceFeatures(BaseModel):
+    """Workspace feature flags.
+
+    Mirrors the backend ``go-pkg/workspace-features`` ``WorkspaceFeatures``
+    struct. Only the flags the CLI acts on are enumerated; any additional
+    flags the backend adds are ignored here. ``enable_new_deployment_api``
+    switches the endpoint/devpod command paths from the legacy
+    ``/deployments`` routes to the new ``/endpoints`` and ``/devpods`` routes.
+    """
+
+    enable_new_deployment_api: Optional[bool] = None
+
+
 class WorkspaceInfo(BaseModel):
     # Implementation note: inlined version.Info in the go backend.
     build_time: str
@@ -57,3 +70,8 @@ class WorkspaceInfo(BaseModel):
     workloads: Workloads
     resource_quota: ResourceQuota
     dedicated_node_group_only: Optional[bool] = None
+
+    # The backend nests all workspace feature flags under a "features" object in
+    # the /workspace (and /info) response (api-server/httpapi/info/handler.go
+    # WorkspaceInfo.Features). Absent on older backends -> None -> legacy mode.
+    features: Optional[WorkspaceFeatures] = None

--- a/leptonai/api/v2/types/workspace.py
+++ b/leptonai/api/v2/types/workspace.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from pydantic import BaseModel
+from pydantic import BaseModel, StrictBool
 from typing import Dict, Optional
 
 from loguru import logger
@@ -52,7 +52,7 @@ class WorkspaceFeatures(BaseModel):
     ``/deployments`` routes to the new ``/endpoints`` and ``/devpods`` routes.
     """
 
-    enable_new_deployment_api: Optional[bool] = None
+    enable_new_deployment_api: Optional[StrictBool] = None
 
 
 class WorkspaceInfo(BaseModel):

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -83,6 +83,7 @@ from leptonai.config import (
 )
 from ..api.v2.client import APIClient
 from ..api.v2.api_resource import ClientError
+from ..api.v2.endpoint import NewEndpointAPIUnsupported
 from ..api.v2.deployment import make_token_vars_from_config
 from ..api.v2.spec_utils import make_mounts_from_strings, make_env_vars_from_strings
 from ..api.v2.workspace_record import WorkspaceRecord
@@ -1431,31 +1432,43 @@ def status(name, show_tokens, detail):
 
     console.print("Replicas List:")
 
-    reading_issue_root = client.deployment.get_readiness(name).root
-    # Print a table of readiness information.
-    table = Table(show_lines=False)
-    table.add_column("replica id")
-    table.add_column("status")
-    table.add_column("message")
-    ready_count = 0
-    for id, value in reading_issue_root.items():
-        reason = value[0].reason
-        message = value[0].message
-        # Do we need to display red?
-        if reason == "Ready":
-            reason = f"[green]{reason}[/]"
-            ready_count += 1
-        else:
-            reason = f"[yellow]{reason}[/]"
-        if message == "":
-            message = "(empty)"
-        table.add_row(id, reason, message)
-    console.print(table)
-    console.print(
-        f"[green]{ready_count}[/] out of {len(reading_issue_root)} replicas ready."
-    )
+    # The new /endpoints API folds readiness/termination into per-replica status
+    # and exposes no standalone readiness/termination route, so in new-API mode
+    # these degrade to a clear note rather than a 404. Legacy mode is unchanged.
+    try:
+        reading_issue_root = client.deployment.get_readiness(name).root
+    except NewEndpointAPIUnsupported as e:
+        reading_issue_root = None
+        console.print(f"[yellow]Readiness summary unavailable: {e}[/]")
 
-    deployment_terminations_root = client.deployment.get_termination(name).root
+    if reading_issue_root is not None:
+        # Print a table of readiness information.
+        table = Table(show_lines=False)
+        table.add_column("replica id")
+        table.add_column("status")
+        table.add_column("message")
+        ready_count = 0
+        for id, value in reading_issue_root.items():
+            reason = value[0].reason
+            message = value[0].message
+            # Do we need to display red?
+            if reason == "Ready":
+                reason = f"[green]{reason}[/]"
+                ready_count += 1
+            else:
+                reason = f"[yellow]{reason}[/]"
+            if message == "":
+                message = "(empty)"
+            table.add_row(id, reason, message)
+        console.print(table)
+        console.print(
+            f"[green]{ready_count}[/] out of {len(reading_issue_root)} replicas ready."
+        )
+
+    try:
+        deployment_terminations_root = client.deployment.get_termination(name).root
+    except NewEndpointAPIUnsupported:
+        deployment_terminations_root = {}
 
     if len(deployment_terminations_root):
         console.print("There are earlier terminations. Detailed Info:")

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -118,7 +118,10 @@ def _same_major_version(version_str_list: List[str]) -> bool:
         return True
 
     def validate(v: str) -> bool:
-        return bool(re.match(r"^\d+\.\d+$", v))
+        # Replicas from the new /endpoints API do not carry a semantic_version
+        # (only legacy /deployments replicas do), so treat a missing/None value
+        # as "not a comparable version" rather than letting re.match raise.
+        return bool(v) and bool(re.match(r"^\d+\.\d+$", v))
 
     if not all(validate(version_str) for version_str in version_str_list):
         return False
@@ -1424,6 +1427,12 @@ def status(name, show_tokens, detail):
     if show_tokens and dep_info.spec.api_tokens:
 
         def stringfy_token(x):
+            # The new /endpoints API redacts literal token values to "***" on
+            # read (secret references via value_from are returned intact). Make
+            # the redaction explicit rather than printing a bare "***" that looks
+            # like a usable token.
+            if x.value == "***":
+                return "*** (literal value hidden by server; not retrievable)"
             return x.value or f"[{x.value_from.token_name_ref}]"
 
         console.print(f"Tokens:     {stringfy_token(dep_info.spec.api_tokens[0])}")

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -965,14 +965,23 @@ def create(
     else:
         spec = LeptonDeploymentUserSpec()
 
-    existing_deployments = client.deployment.list_all()
+    # Bind the deployment dispatcher once for the whole create operation. The
+    # `client.deployment` property re-resolves the new-deployment-API flag on
+    # every access, and a transient /workspace failure is not cached
+    # (client.py). Reading it separately for the preflight list, the --rerun
+    # delete, and the create could therefore split across APIs: e.g. a legacy
+    # list that misses an existing new endpoint, then an endpoint create that
+    # 409s on the duplicate instead of rerunning it. One binding keeps the
+    # whole operation on a single API.
+    dep_api = client.deployment
+    existing_deployments = dep_api.list_all()
     if name in [d.metadata.name for d in existing_deployments]:
         if rerun:
             console.print(
                 f"Endpoint [green]{name}[/] already exists. Shutting down the"
                 " existing endpoint and rerunning."
             )
-            client.deployment.delete(name)
+            dep_api.delete(name)
         else:
             console.print(
                 f"Endpoint [green]{name}[/] already exists. Use `lep endpoint"
@@ -1284,7 +1293,7 @@ def create(
         spec=spec,
     )
     logger.trace(json.dumps(lepton_deployment.model_dump(), indent=2))
-    client.deployment.create(lepton_deployment)
+    dep_api.create(lepton_deployment)
     console.print(
         "🎉 [green]Endpoint Created Successfully![/]\n"
         f"Name: [blue]{name}[/]\n"

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -965,14 +965,11 @@ def create(
     else:
         spec = LeptonDeploymentUserSpec()
 
-    # Bind the deployment dispatcher once for the whole create operation. The
-    # `client.deployment` property re-resolves the new-deployment-API flag on
-    # every access, and a transient /workspace failure is not cached
-    # (client.py). Reading it separately for the preflight list, the --rerun
-    # delete, and the create could therefore split across APIs: e.g. a legacy
-    # list that misses an existing new endpoint, then an endpoint create that
-    # 409s on the duplicate instead of rerunning it. One binding keeps the
-    # whole operation on a single API.
+    # Bind the deployment dispatcher once for the whole create operation
+    # (preflight list -> optional --rerun delete -> create). The dispatch flag
+    # is now committed process-wide on first resolution (client.py), so repeated
+    # `client.deployment` reads already agree; binding once is belt-and-braces
+    # that also makes the single-API intent explicit at the call site.
     dep_api = client.deployment
     existing_deployments = dep_api.list_all()
     if name in [d.metadata.name for d in existing_deployments]:

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -415,6 +415,11 @@ def _print_deployments_table(
             and d.status.autoscaler_status.desired_replicas is not None
             else None
         )
+        # Static endpoints (new API) carry no autoscaler_status; fall back to the
+        # ready_replicas count so the list does not report 0 for a running
+        # endpoint. Legacy /deployments responses leave ready_replicas None.
+        if desired is None and d.status and d.status.ready_replicas is not None:
+            desired = d.status.ready_replicas
         desired_disp = str(desired if desired is not None else 0)
 
         shape = rr.resource_shape if rr and rr.resource_shape else "-"
@@ -1983,11 +1988,24 @@ def update(
 
             replicas = client.deployment.get_replicas(lepton_deployment)
 
-            version_str_list = [lepton_deployment.metadata.semantic_version] + [
-                replica.metadata.semantic_version for replica in replicas
+            # "Update in progress" is inferred from a replica whose major version
+            # differs from the deployment's. New /endpoints replicas carry no
+            # semantic_version (only ID + created_at), so a missing value is
+            # "unknown", not evidence of an overlap — otherwise every disruptive
+            # endpoint update would falsely warn. Only compare replicas that
+            # actually report a version.
+            replica_versions = [
+                replica.metadata.semantic_version
+                for replica in replicas
+                if replica.metadata.semantic_version
             ]
-
-            updating_ongoing = not _same_major_version(version_str_list)
+            if replica_versions:
+                version_str_list = [
+                    lepton_deployment.metadata.semantic_version
+                ] + replica_versions
+                updating_ongoing = not _same_major_version(version_str_list)
+            else:
+                updating_ongoing = False
 
             confirmation_prompt = (
                 "Warning: another update is currently in progress for this"

--- a/leptonai/cli/deployment.py
+++ b/leptonai/cli/deployment.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 import re
 import sys
+import time
 from typing import List, Optional
 
 import click
@@ -40,6 +41,33 @@ def _exit_if_no_changes_to_update(e, name):
         )
         sys.exit(0)
     raise e
+
+
+def _create_after_new_api_rerun(
+    dep_api, spec, name: str, timeout_seconds: float = 60.0
+):
+    """Retry a new workload create while asynchronous deletion finishes.
+
+    Endpoint and DevPod deletion return after initiating CR deletion. An
+    immediate create can therefore receive 409 from the old CR or dependent
+    resources. Only a ``--rerun`` invocation that actually deleted the old
+    workload may safely retry this conflict; ordinary duplicates fail at once.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    announced_wait = False
+    while True:
+        try:
+            return dep_api.create(spec)
+        except ClientError as e:
+            if e.response.status_code != 409 or time.monotonic() >= deadline:
+                raise
+            if not announced_wait:
+                console.print(
+                    f"Waiting for the previous workload [green]{name}[/] deletion"
+                    " to finish."
+                )
+                announced_wait = True
+            time.sleep(0.5)
 
 
 def _parse_container_port(container_port: Optional[str]) -> Optional["ContainerPort"]:
@@ -83,7 +111,8 @@ from leptonai.config import (
 )
 from ..api.v2.client import APIClient
 from ..api.v2.api_resource import ClientError
-from ..api.v2.endpoint import NewEndpointAPIUnsupported
+from ..api.v2.devpod import DevPodAPI
+from ..api.v2.endpoint import EndpointAPI, NewEndpointAPIUnsupported
 from ..api.v2.deployment import make_token_vars_from_config
 from ..api.v2.spec_utils import make_mounts_from_strings, make_env_vars_from_strings
 from ..api.v2.workspace_record import WorkspaceRecord
@@ -415,9 +444,12 @@ def _print_deployments_table(
             and d.status.autoscaler_status.desired_replicas is not None
             else None
         )
-        # Static endpoints (new API) carry no autoscaler_status; fall back to the
-        # ready_replicas count so the list does not report 0 for a running
-        # endpoint. Legacy /deployments responses leave ready_replicas None.
+        # For a static endpoint the configured minimum is its desired capacity;
+        # ready_replicas is only current observed readiness and may be lower
+        # during startup or degradation. Use readiness only when the response
+        # lacks the configured target entirely.
+        if desired is None and rr and rr.min_replicas is not None:
+            desired = rr.min_replicas
         if desired is None and d.status and d.status.ready_replicas is not None:
             desired = d.status.ready_replicas
         desired_disp = str(desired if desired is not None else 0)
@@ -965,27 +997,26 @@ def create(
     else:
         spec = LeptonDeploymentUserSpec()
 
-    # Bind the deployment dispatcher once for the whole create operation
-    # (preflight list -> optional --rerun delete -> create). The dispatch flag
-    # is now committed process-wide on first resolution (client.py), so repeated
-    # `client.deployment` reads already agree; binding once is belt-and-braces
-    # that also makes the single-API intent explicit at the call site.
-    dep_api = client.deployment
-    existing_deployments = dep_api.list_all()
-    if name in [d.metadata.name for d in existing_deployments]:
-        if rerun:
-            console.print(
-                f"Endpoint [green]{name}[/] already exists. Shutting down the"
-                " existing endpoint and rerunning."
-            )
-            dep_api.delete(name)
-        else:
-            console.print(
-                f"Endpoint [green]{name}[/] already exists. Use `lep endpoint"
-                f" update -n {name}` to update the endpoint, or add `--rerun` to"
-                " shutdown the existing endpoint and rerun it."
-            )
-            sys.exit(1)
+    # Bind one resource family for the whole operation (preflight list ->
+    # optional --rerun delete -> create). Deprecated endpoint-create spec files
+    # may still carry is_pod=True; those must use the pod dispatcher throughout
+    # so a same-named endpoint is never deleted before creating a DevPod.
+    dep_api = client.pod if spec.is_pod else client.deployment
+    deleted_for_rerun = False
+    already_exists = False
+    if not rerun:
+        existing_deployments = dep_api.list_all()
+        already_exists = name in [d.metadata.name for d in existing_deployments]
+    if already_exists:
+        # Preserve the legacy command's early duplicate short-circuit. In
+        # particular, do not create workspace-token secrets or prompt for a
+        # replacement that will never be submitted.
+        console.print(
+            f"Endpoint [green]{name}[/] already exists. Use `lep endpoint"
+            f" update -n {name}` to update the endpoint, or add `--rerun` to"
+            " shutdown the existing endpoint and rerun it."
+        )
+        sys.exit(1)
 
     # Determine the container details for the deployment.
     if container_image is not None or container_command is not None:
@@ -1290,7 +1321,29 @@ def create(
         spec=spec,
     )
     logger.trace(json.dumps(lepton_deployment.model_dump(), indent=2))
-    dep_api.create(lepton_deployment)
+
+    # Validate the fully assembled replacement before deleting anything. New
+    # API translation is stricter than the legacy wire; without this preflight,
+    # ``--rerun`` could delete a healthy workload and then fail locally.
+    validate_create = getattr(dep_api, "validate_create", None)
+    if validate_create is not None:
+        validate_create(lepton_deployment)
+
+    if rerun:
+        existing_deployments = dep_api.list_all()
+        already_exists = name in [d.metadata.name for d in existing_deployments]
+    if already_exists:
+        console.print(
+            f"Endpoint [green]{name}[/] already exists. Shutting down the"
+            " existing endpoint and rerunning."
+        )
+        dep_api.delete(name)
+        deleted_for_rerun = True
+
+    if deleted_for_rerun and isinstance(dep_api, (EndpointAPI, DevPodAPI)):
+        _create_after_new_api_rerun(dep_api, lepton_deployment, name)
+    else:
+        dep_api.create(lepton_deployment)
     console.print(
         "🎉 [green]Endpoint Created Successfully![/]\n"
         f"Name: [blue]{name}[/]\n"
@@ -2130,14 +2183,20 @@ def stop(name):
     """
     client = APIClient()
     endpoint = client.deployment.get(name)
-    if endpoint.status.state in [
+    phase = endpoint.status.phase
+    terminal_state = phase or endpoint.status.state
+    already_stopped = terminal_state in [
         LeptonDeploymentState.Stopped,
         LeptonDeploymentState.Stopping,
         LeptonDeploymentState.Deleting,
-        LeptonDeploymentState.NotReady,
-    ]:
+    ]
+    # Older servers may omit phase and expose a stopped deployment only through
+    # the historical state="Not Ready" compatibility collapse.
+    if phase is None and terminal_state == LeptonDeploymentState.NotReady:
+        already_stopped = True
+    if already_stopped:
         console.print(
-            f"[yellow]⚠ Endpoint [green]{name}[/] is {endpoint.status.state}. No"
+            f"[yellow]⚠ Endpoint [green]{name}[/] is {terminal_state}. No"
             " action taken.[/]"
         )
         sys.exit(0)

--- a/leptonai/cli/pod.py
+++ b/leptonai/cli/pod.py
@@ -537,7 +537,7 @@ def list_command(pattern, detail):
     pod_ips = [None] * pods_count
     for index, pod in enumerate(pods):
         if pod.status.state in ("Running", "Ready"):
-            public_ip = _get_only_replica_public_ip(pod.metadata.name)
+            public_ip = _get_only_replica_public_ip(pod.metadata.name, client)
             pod_ips[index] = public_ip
     logger.trace(f"Pod IPs:\n{pod_ips}")
 
@@ -721,7 +721,7 @@ def ssh(name):
         " command"
     )
 
-    public_ip = _get_only_replica_public_ip(pod.metadata.name)
+    public_ip = _get_only_replica_public_ip(pod.metadata.name, client)
 
     if not public_ip:
         dashboard_base_url = client.get_dashboard_base_url()

--- a/leptonai/cli/pod.py
+++ b/leptonai/cli/pod.py
@@ -459,12 +459,12 @@ def get(name, path):
 
     client = APIClient()
 
-    dep = client.deployment.get(name)
+    dep = client.pod.get(name)
     if not dep.spec.is_pod:
         console.print(f"[red]{name} is not a pod.[/]")
         sys.exit(1)
 
-    console.print(json.dumps(client.deployment.safe_json(dep), indent=2))
+    console.print(json.dumps(client.pod.safe_json(dep), indent=2))
 
     if path:
         spec_json = dep.spec.model_dump_json(indent=2, by_alias=True)
@@ -503,7 +503,7 @@ def list_command(pattern, detail):
     """
     client = APIClient()
 
-    deployments = client.deployment.list_all()
+    deployments = client.pod.list_all()
 
     logger.trace(f"Deployments:\n{[d for d in deployments if d.spec.is_pod]}")
     pods = [
@@ -697,7 +697,7 @@ def remove(name):
 
     client = APIClient()
 
-    client.deployment.delete(name)
+    client.pod.delete(name)
     console.log(f"Pod [green]{name}[/] removed.")
 
     return 0
@@ -709,7 +709,7 @@ def ssh(name):
     """SSH into a running pod."""
     client = APIClient()
 
-    pod = client.deployment.get(name)
+    pod = client.pod.get(name)
     logger.trace(json.dumps(pod.model_dump(), indent=2))
     ports = pod.status.container_port_status
     if pod.status.state not in ("Running", "Ready"):
@@ -786,7 +786,7 @@ def stop(name):
     Stops a pod by its name.
     """
     client = APIClient()
-    endpoint = client.deployment.get(name)
+    endpoint = client.pod.get(name)
     if endpoint.status.state in [
         LeptonDeploymentState.Stopped,
         LeptonDeploymentState.Stopping,
@@ -798,7 +798,7 @@ def stop(name):
             " action taken.[/]"
         )
         sys.exit(0)
-    client.deployment.stop(name)
+    client.pod.stop(name)
     console.print(f"Pod [green]{name}[/] stopped successfully.")
 
 

--- a/leptonai/cli/pod.py
+++ b/leptonai/cli/pod.py
@@ -524,7 +524,12 @@ def list_command(pattern, detail):
         if not ports:
             continue
 
-        port_pairs = [(p.container_port, p.host_port) for p in ports]
+        # A requested container port is present before the platform allocates a
+        # host port. Do not render commands containing the literal string
+        # ``None`` while that allocation is still pending.
+        port_pairs = [
+            (p.container_port, p.host_port) for p in ports if p.host_port is not None
+        ]
 
         for port_pair in port_pairs:
             if port_pair[0] == SSH_PORT:
@@ -711,10 +716,10 @@ def ssh(name):
 
     pod = client.pod.get(name)
     logger.trace(json.dumps(pod.model_dump(), indent=2))
-    ports = pod.status.container_port_status
-    if pod.status.state not in ("Running", "Ready"):
+    if pod.status is None or pod.status.state not in ("Running", "Ready"):
         console.print("This pod is not running or is not ready.")
         sys.exit(1)
+    ports = pod.status.container_port_status or []
 
     notice_msg = (
         "[yellow]Notice[/]: lep pod output may only work for default image and default"
@@ -738,7 +743,7 @@ def ssh(name):
 
     ssh_flag = False
     for port in ports:
-        if port.container_port == SSH_PORT:
+        if port.container_port == SSH_PORT and port.host_port:
             ssh_flag = True
             try:
                 logger.trace(f"ssh -p {port.host_port} root@{public_ip}")
@@ -787,15 +792,18 @@ def stop(name):
     """
     client = APIClient()
     endpoint = client.pod.get(name)
-    if endpoint.status.state in [
+    phase = endpoint.status.phase
+    terminal_state = phase or endpoint.status.state
+    already_stopped = terminal_state in [
         LeptonDeploymentState.Stopped,
         LeptonDeploymentState.Stopping,
         LeptonDeploymentState.Deleting,
-        LeptonDeploymentState.NotReady,
-    ]:
+    ]
+    if phase is None and terminal_state == LeptonDeploymentState.NotReady:
+        already_stopped = True
+    if already_stopped:
         console.print(
-            f"[yellow]⚠ Pod [green]{name}[/] is {endpoint.status.state}. No"
-            " action taken.[/]"
+            f"[yellow]⚠ Pod [green]{name}[/] is {terminal_state}. No action taken.[/]"
         )
         sys.exit(0)
     client.pod.stop(name)

--- a/leptonai/cli/storage.py
+++ b/leptonai/cli/storage.py
@@ -308,7 +308,10 @@ def upload(
 
         name = "storage-rsync-by-lepton"
 
-        lepton_deployment = client.deployment.get(name)
+        # storage-rsync-by-lepton is a pod (devpod under the new API). Read it via
+        # the pod dispatcher, not client.deployment: in a flag-on workspace the
+        # latter routes to GET /endpoints/<name>, which 404s for a devpod.
+        lepton_deployment = client.pod.get(name)
         port = lepton_deployment.spec.container.ports[0].host_port
         ip = _get_only_replica_public_ip(name)
 

--- a/leptonai/cli/storage.py
+++ b/leptonai/cli/storage.py
@@ -313,7 +313,7 @@ def upload(
         # latter routes to GET /endpoints/<name>, which 404s for a devpod.
         lepton_deployment = client.pod.get(name)
         port = lepton_deployment.spec.container.ports[0].host_port
-        ip = _get_only_replica_public_ip(name)
+        ip = _get_only_replica_public_ip(name, client)
 
         workspace_id = client.get_workspace_id()
 

--- a/leptonai/cli/storage.py
+++ b/leptonai/cli/storage.py
@@ -25,6 +25,31 @@ custom_theme = Theme({
 console = Console(highlight=False, theme=custom_theme)
 
 
+def _get_rsync_host_port(lepton_deployment) -> int:
+    """Return the allocated host port for the storage helper pod.
+
+    New DevPods report allocations in status.container_port_status; their spec
+    intentionally retains only the requested container port. Legacy pods may
+    still expose the host port on the spec, so keep that as a compatibility
+    fallback.
+    """
+    status = getattr(lepton_deployment, "status", None)
+    for port in getattr(status, "container_port_status", None) or []:
+        if port.host_port:
+            return port.host_port
+
+    spec = getattr(lepton_deployment, "spec", None)
+    container = getattr(spec, "container", None)
+    for port in getattr(container, "ports", None) or []:
+        if port.host_port:
+            return port.host_port
+
+    raise ValueError(
+        "The storage rsync helper pod has no allocated host port yet. Wait for"
+        " the pod to become ready and retry."
+    )
+
+
 def print_dir_contents(dir_path, dir_infos):
     """
     Format the contents of a directory for printing.
@@ -312,7 +337,7 @@ def upload(
         # the pod dispatcher, not client.deployment: in a flag-on workspace the
         # latter routes to GET /endpoints/<name>, which 404s for a devpod.
         lepton_deployment = client.pod.get(name)
-        port = lepton_deployment.spec.container.ports[0].host_port
+        port = _get_rsync_host_port(lepton_deployment)
         ip = _get_only_replica_public_ip(name, client)
 
         workspace_id = client.get_workspace_id()

--- a/leptonai/cli/tests/test_new_api_cli_regressions.py
+++ b/leptonai/cli/tests/test_new_api_cli_regressions.py
@@ -1,0 +1,514 @@
+"""CLI regressions for the endpoint/devpod API compatibility dispatcher."""
+
+import io
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+from click.testing import CliRunner
+from requests import Response
+
+from leptonai.api.v2.api_resource import ClientError
+from leptonai.api.v2.devpod import DevPodAPI
+from leptonai.api.v2.endpoint import EndpointAPI
+from leptonai.api.v2.types.common import Metadata
+from leptonai.api.v2.types.deployment import (
+    ContainerPort,
+    LeptonContainer,
+    LeptonDeployment,
+    LeptonDeploymentStatus,
+    LeptonDeploymentUserSpec,
+    ResourceRequirement,
+)
+from leptonai.cli.deployment import (
+    _create_after_new_api_rerun,
+    _print_deployments_table,
+    deployment,
+)
+from leptonai.cli.pod import pod
+
+
+def _pod(name="pod"):
+    return LeptonDeployment(
+        metadata=Metadata(id=name, name=name, created_at=1000),
+        spec=LeptonDeploymentUserSpec(
+            is_pod=True,
+            container=LeptonContainer(image="ubuntu"),
+            resource_requirement=ResourceRequirement(
+                resource_shape="cpu.small", min_replicas=1
+            ),
+        ),
+        status=LeptonDeploymentStatus(
+            state="Ready",
+            endpoint={"internal_endpoint": "", "external_endpoint": ""},
+            container_port_status=None,
+            public_ip="203.0.113.7",
+        ),
+    )
+
+
+class TestPodSSHMissingPort(unittest.TestCase):
+    def test_ready_pod_without_port_status_exits_cleanly(self):
+        fake_client = SimpleNamespace(
+            pod=SimpleNamespace(get=lambda _name: _pod()),
+            get_dashboard_base_url=lambda: None,
+        )
+
+        runner = CliRunner()
+        with (
+            patch("leptonai.cli.pod.APIClient", return_value=fake_client),
+            patch(
+                "leptonai.cli.pod._get_only_replica_public_ip",
+                return_value="203.0.113.7",
+            ),
+            patch("leptonai.cli.pod.subprocess.run") as run,
+        ):
+            result = runner.invoke(pod, ["ssh", "--name", "pod"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("SSH port not found", result.output)
+        run.assert_not_called()
+
+    def test_list_detail_does_not_render_unallocated_host_port(self):
+        pod_model = _pod()
+        pod_model.status.container_port_status = [
+            ContainerPort(container_port=22, host_port=None)
+        ]
+        fake_client = SimpleNamespace(
+            pod=SimpleNamespace(list_all=lambda: [pod_model]),
+            get_dashboard_base_url=lambda: None,
+        )
+
+        runner = CliRunner()
+        with (
+            patch("leptonai.cli.pod.APIClient", return_value=fake_client),
+            patch(
+                "leptonai.cli.pod._get_only_replica_public_ip",
+                return_value="203.0.113.7",
+            ),
+        ):
+            result = runner.invoke(pod, ["list", "--detail"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("None", result.output)
+        self.assertNotIn("ssh -p", result.output)
+
+
+class TestEndpointListCapacity(unittest.TestCase):
+    def test_static_endpoint_uses_configured_target_not_current_readiness(self):
+        endpoint_model = LeptonDeployment(
+            metadata=Metadata(id="ep", name="ep", created_at=1000),
+            spec=LeptonDeploymentUserSpec(
+                container=LeptonContainer(image="nginx"),
+                resource_requirement=ResourceRequirement(
+                    resource_shape="cpu.small", min_replicas=4
+                ),
+            ),
+            status=LeptonDeploymentStatus(
+                state="Starting",
+                endpoint={"internal_endpoint": "", "external_endpoint": ""},
+                ready_replicas=1,
+            ),
+        )
+        tables = []
+
+        class RecordingTable:
+            def __init__(self, *args, **kwargs):
+                self.rows = []
+                tables.append(self)
+
+            def add_column(self, *args, **kwargs):
+                pass
+
+            def add_row(self, *values):
+                self.rows.append(values)
+
+        with (
+            patch("leptonai.cli.deployment.Table", RecordingTable),
+            patch("leptonai.cli.deployment.console") as console,
+        ):
+            _print_deployments_table([endpoint_model])
+
+        self.assertEqual(tables[0].rows[0][5], "4")
+        console.print.assert_any_call("  [bright_black]cpu.small[/] : [bold cyan]4[/]")
+
+
+class TestNotReadyStopBehavior(unittest.TestCase):
+    def _workload(self, *, is_pod, state, phase):
+        workload = _pod("workload")
+        workload.spec.is_pod = is_pod
+        workload.status.state = state
+        workload.status.phase = phase
+        return workload
+
+    def test_endpoint_not_ready_phase_can_still_be_stopped(self):
+        workload = self._workload(
+            is_pod=False,
+            state="Not Ready",
+            phase="Not Ready",
+        )
+        deployment_api = Mock()
+        deployment_api.get.return_value = workload
+        fake_client = SimpleNamespace(deployment=deployment_api)
+
+        runner = CliRunner()
+        with patch("leptonai.cli.deployment.APIClient", return_value=fake_client):
+            result = runner.invoke(deployment, ["stop", "--name", "workload"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        deployment_api.stop.assert_called_once_with("workload")
+
+    def test_pod_not_ready_phase_can_still_be_stopped(self):
+        workload = self._workload(
+            is_pod=True,
+            state="Not Ready",
+            phase="Not Ready",
+        )
+        pod_api = Mock()
+        pod_api.get.return_value = workload
+        fake_client = SimpleNamespace(pod=pod_api)
+
+        runner = CliRunner()
+        with patch("leptonai.cli.pod.APIClient", return_value=fake_client):
+            result = runner.invoke(pod, ["stop", "--name", "workload"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        pod_api.stop.assert_called_once_with("workload")
+
+    def test_phase_absent_not_ready_keeps_legacy_noop(self):
+        workload = self._workload(
+            is_pod=False,
+            state="Not Ready",
+            phase=None,
+        )
+        deployment_api = Mock()
+        deployment_api.get.return_value = workload
+        fake_client = SimpleNamespace(deployment=deployment_api)
+
+        runner = CliRunner()
+        with patch("leptonai.cli.deployment.APIClient", return_value=fake_client):
+            result = runner.invoke(deployment, ["stop", "--name", "workload"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        deployment_api.stop.assert_not_called()
+
+
+class TestPodFlavouredEndpointCreate(unittest.TestCase):
+    def test_rerun_uses_pod_api_and_retries_async_deletion_conflict(self):
+        calls = []
+        existing = SimpleNamespace(metadata=Metadata(name="pod"))
+        conflict_response = Response()
+        conflict_response.status_code = 409
+        conflict_response._content = b'{"message":"devpod is still deleting"}'
+        conflicts = [ClientError(conflict_response)]
+
+        def create_pod(spec):
+            calls.append(("pod-create", spec.spec.is_pod))
+            if conflicts:
+                raise conflicts.pop()
+            return True
+
+        def validate_pod(spec):
+            calls.append((
+                "pod-validate",
+                spec.metadata.name,
+                spec.spec.container.image,
+                spec.spec.container.ports[0].container_port,
+                [(env.name, env.value) for env in spec.spec.envs],
+            ))
+
+        pod_api = Mock(spec=DevPodAPI)
+        pod_api.validate_create.side_effect = validate_pod
+        pod_api.list_all.side_effect = lambda: calls.append("pod-list") or [existing]
+        pod_api.delete.side_effect = lambda name: calls.append(("pod-delete", name))
+        pod_api.create.side_effect = create_pod
+        deployment_api = SimpleNamespace(
+            list_all=lambda: calls.append("endpoint-list") or [],
+            delete=lambda name: calls.append(("endpoint-delete", name)),
+            create=lambda spec: calls.append(("endpoint-create", spec.spec.is_pod)),
+        )
+        fake_client = SimpleNamespace(pod=pod_api, deployment=deployment_api)
+
+        spec = LeptonDeploymentUserSpec(
+            is_pod=True,
+            container=LeptonContainer(image="ubuntu"),
+            resource_requirement=ResourceRequirement(resource_shape="cpu.small"),
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("pod.json", "w") as spec_file:
+                spec_file.write(spec.model_dump_json())
+            with (
+                patch("leptonai.cli.deployment.APIClient", return_value=fake_client),
+                patch("leptonai.cli.deployment.time.monotonic", return_value=0),
+                patch("leptonai.cli.deployment.time.sleep") as sleep,
+            ):
+                result = runner.invoke(
+                    deployment,
+                    [
+                        "create",
+                        "--name",
+                        "pod",
+                        "--file",
+                        "pod.json",
+                        "--container-image",
+                        "ubuntu:24.04",
+                        "--container-port",
+                        "2222",
+                        "--env",
+                        "MODE=pod-rerun",
+                        "--rerun",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            calls,
+            [
+                (
+                    "pod-validate",
+                    "pod",
+                    "ubuntu:24.04",
+                    2222,
+                    [("MODE", "pod-rerun")],
+                ),
+                "pod-list",
+                ("pod-delete", "pod"),
+                ("pod-create", True),
+                ("pod-create", True),
+            ],
+        )
+        sleep.assert_called_once_with(0.5)
+
+
+class TestNewEndpointRerun(unittest.TestCase):
+    def test_non_rerun_duplicate_exits_before_mutation_or_validation(self):
+        existing = SimpleNamespace(metadata=Metadata(name="ep"))
+        endpoint_api = Mock(spec=EndpointAPI)
+        endpoint_api.list_all.return_value = [existing]
+        fake_client = SimpleNamespace(
+            deployment=endpoint_api,
+            pod=SimpleNamespace(),
+        )
+
+        class TTYInput(io.BytesIO):
+            def isatty(self):
+                return True
+
+        runner = CliRunner()
+        with (
+            patch("leptonai.cli.deployment.APIClient", return_value=fake_client),
+            patch(
+                "leptonai.cli.deployment._create_workspace_token_secret_var_if_not_existing"
+            ) as create_workspace_token_secret,
+            patch(
+                "leptonai.cli.deployment.click.confirm", return_value=True
+            ) as confirm,
+        ):
+            result = runner.invoke(
+                deployment,
+                [
+                    "create",
+                    "--name",
+                    "ep",
+                    "--container-image",
+                    "nginx:1.27",
+                    "--include-workspace-token",
+                ],
+                input=TTYInput(),
+            )
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertIn("already exists", result.output)
+        endpoint_api.list_all.assert_called_once_with()
+        create_workspace_token_secret.assert_not_called()
+        confirm.assert_not_called()
+        endpoint_api.validate_create.assert_not_called()
+        endpoint_api.delete.assert_not_called()
+        endpoint_api.create.assert_not_called()
+
+    def test_rerun_validates_fully_assembled_spec_before_list_and_delete(self):
+        calls = []
+        existing = SimpleNamespace(metadata=Metadata(name="ep"))
+
+        def validate_endpoint(spec):
+            calls.append((
+                "endpoint-validate",
+                spec.metadata.name,
+                spec.spec.container.image,
+                spec.spec.container.ports[0].container_port,
+                [(env.name, env.value) for env in spec.spec.envs],
+            ))
+
+        endpoint_api = Mock(spec=EndpointAPI)
+        endpoint_api.validate_create.side_effect = validate_endpoint
+        endpoint_api.list_all.side_effect = lambda: calls.append("endpoint-list") or [
+            existing
+        ]
+        endpoint_api.delete.side_effect = lambda name: calls.append(
+            ("endpoint-delete", name)
+        )
+        endpoint_api.create.side_effect = lambda spec: calls.append(
+            ("endpoint-create", spec.spec.is_pod)
+        )
+        fake_client = SimpleNamespace(
+            deployment=endpoint_api,
+            pod=SimpleNamespace(),
+        )
+        spec = LeptonDeploymentUserSpec(
+            is_pod=False,
+            container=LeptonContainer(image="nginx:old"),
+            resource_requirement=ResourceRequirement(resource_shape="cpu.small"),
+        )
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open("endpoint.json", "w") as spec_file:
+                spec_file.write(spec.model_dump_json())
+            with patch("leptonai.cli.deployment.APIClient", return_value=fake_client):
+                result = runner.invoke(
+                    deployment,
+                    [
+                        "create",
+                        "--name",
+                        "ep",
+                        "--file",
+                        "endpoint.json",
+                        "--container-image",
+                        "nginx:1.27",
+                        "--container-port",
+                        "8080:tcp",
+                        "--env",
+                        "MODE=endpoint-rerun",
+                        "--rerun",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            calls,
+            [
+                (
+                    "endpoint-validate",
+                    "ep",
+                    "nginx:1.27",
+                    8080,
+                    [("MODE", "endpoint-rerun")],
+                ),
+                "endpoint-list",
+                ("endpoint-delete", "ep"),
+                ("endpoint-create", False),
+            ],
+        )
+
+    def test_validation_failure_does_not_list_delete_or_create(self):
+        cases = [
+            ("endpoint", False, EndpointAPI),
+            ("pod", True, DevPodAPI),
+        ]
+
+        for name, is_pod, api_class in cases:
+            with self.subTest(name=name):
+                calls = []
+
+                def reject(spec):
+                    calls.append((
+                        "validate",
+                        spec.metadata.name,
+                        spec.spec.container.image,
+                        spec.spec.container.ports[0].container_port,
+                        [(env.name, env.value) for env in spec.spec.envs],
+                    ))
+                    raise ValueError("replacement cannot be translated")
+
+                selected_api = Mock(spec=api_class)
+                selected_api.validate_create.side_effect = reject
+                fake_client = SimpleNamespace(
+                    deployment=selected_api if not is_pod else SimpleNamespace(),
+                    pod=selected_api if is_pod else SimpleNamespace(),
+                )
+                spec = LeptonDeploymentUserSpec(
+                    is_pod=is_pod,
+                    container=LeptonContainer(image="original:image"),
+                    resource_requirement=ResourceRequirement(
+                        resource_shape="cpu.small"
+                    ),
+                )
+
+                runner = CliRunner()
+                with runner.isolated_filesystem():
+                    with open("spec.json", "w") as spec_file:
+                        spec_file.write(spec.model_dump_json())
+                    with patch(
+                        "leptonai.cli.deployment.APIClient",
+                        return_value=fake_client,
+                    ):
+                        result = runner.invoke(
+                            deployment,
+                            [
+                                "create",
+                                "--name",
+                                name,
+                                "--file",
+                                "spec.json",
+                                "--container-image",
+                                "assembled:image",
+                                "--container-port",
+                                "4242",
+                                "--env",
+                                "MODE=preflight",
+                                "--rerun",
+                            ],
+                        )
+
+                self.assertEqual(result.exit_code, 1, result.output)
+                self.assertEqual(
+                    calls,
+                    [(
+                        "validate",
+                        name,
+                        "assembled:image",
+                        4242,
+                        [("MODE", "preflight")],
+                    )],
+                )
+                selected_api.list_all.assert_not_called()
+                selected_api.delete.assert_not_called()
+                selected_api.create.assert_not_called()
+
+    def test_create_retries_conflict_until_async_delete_finishes(self):
+        conflicts = []
+        for _ in range(2):
+            response = Response()
+            response.status_code = 409
+            response._content = b'{"message":"endpoint is still deleting"}'
+            conflicts.append(ClientError(response))
+
+        attempts = []
+
+        def create(spec):
+            attempts.append(spec)
+            if conflicts:
+                raise conflicts.pop(0)
+            return True
+
+        spec = object()
+        with (
+            patch("leptonai.cli.deployment.time.monotonic", return_value=0),
+            patch("leptonai.cli.deployment.time.sleep") as sleep,
+        ):
+            result = _create_after_new_api_rerun(
+                SimpleNamespace(create=create), spec, "ep"
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(attempts, [spec, spec, spec])
+        self.assertEqual(sleep.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/cli/util.py
+++ b/leptonai/cli/util.py
@@ -317,26 +317,17 @@ def sizeof_fmt(num, suffix="B"):
 
 
 def _get_only_replica_public_ip(name: str, client: Optional[APIClient] = None):
-    # Reuse the caller's client so this helper shares the caller's already
-    # resolved dispatch decision. The callers (pod list/ssh, storage upload)
-    # each construct their own APIClient() and successfully route the pod
-    # through client.pod before calling here; falling back to the get_client()
-    # singleton would resolve the new-deployment-API flag a SECOND time on a
-    # DIFFERENT client, and since a transient /workspace failure is no longer
-    # cached (client.py), that second resolution could disagree and route this
-    # devpod to the legacy /deployments/<name>/replicas route (404 for a
-    # devpod). Sharing the caller's client keeps the whole operation on one API.
+    # Reuse the caller's client when provided so this helper shares the caller's
+    # dispatch decision. The dispatch flag is committed process-wide on first
+    # resolution (client.py), so even the get_client() fallback below now agrees
+    # with the caller; passing the caller's client remains the clearer contract.
     if client is None:
         client = get_client()
     # The new devpod API exposes no /replicas route; the single pod's public IP
     # is surfaced directly on the devpod status as a bare IP (status.public_ip),
     # carried through by the response translation. In legacy mode, read it from
-    # the single replica as before.
-    #
-    # Snapshot the flag once and call the matching backing implementation
-    # directly: reading the flag twice within one operation could disagree and
-    # route this pod to the mismatched API (e.g. GET /endpoints/<pod>/replicas,
-    # which does not exist for a devpod). Resolving once keeps this on one API.
+    # the single replica as before. The dispatch flag is stable process-wide, so
+    # this branch cannot disagree with the caller's pod routing.
     if client.new_deployment_api_enabled:
         pod = client._devpod_api.get(name)
         status = pod.status

--- a/leptonai/cli/util.py
+++ b/leptonai/cli/util.py
@@ -316,19 +316,27 @@ def sizeof_fmt(num, suffix="B"):
     return f"{num:.1f}Yi{suffix}"
 
 
-def _get_only_replica_public_ip(name: str):
-    client = get_client()
+def _get_only_replica_public_ip(name: str, client: Optional[APIClient] = None):
+    # Reuse the caller's client so this helper shares the caller's already
+    # resolved dispatch decision. The callers (pod list/ssh, storage upload)
+    # each construct their own APIClient() and successfully route the pod
+    # through client.pod before calling here; falling back to the get_client()
+    # singleton would resolve the new-deployment-API flag a SECOND time on a
+    # DIFFERENT client, and since a transient /workspace failure is no longer
+    # cached (client.py), that second resolution could disagree and route this
+    # devpod to the legacy /deployments/<name>/replicas route (404 for a
+    # devpod). Sharing the caller's client keeps the whole operation on one API.
+    if client is None:
+        client = get_client()
     # The new devpod API exposes no /replicas route; the single pod's public IP
     # is surfaced directly on the devpod status as a bare IP (status.public_ip),
     # carried through by the response translation. In legacy mode, read it from
     # the single replica as before.
     #
     # Snapshot the flag once and call the matching backing implementation
-    # directly: a transient /workspace failure is no longer cached (client.py),
-    # so reading the flag twice within one operation could disagree and route
-    # this pod to the mismatched API (e.g. GET /endpoints/<pod>/replicas, which
-    # does not exist for a devpod). Resolving once keeps the whole operation on
-    # one API.
+    # directly: reading the flag twice within one operation could disagree and
+    # route this pod to the mismatched API (e.g. GET /endpoints/<pod>/replicas,
+    # which does not exist for a devpod). Resolving once keeps this on one API.
     if client.new_deployment_api_enabled:
         pod = client._devpod_api.get(name)
         status = pod.status

--- a/leptonai/cli/util.py
+++ b/leptonai/cli/util.py
@@ -319,20 +319,13 @@ def sizeof_fmt(num, suffix="B"):
 def _get_only_replica_public_ip(name: str):
     client = get_client()
     # The new devpod API exposes no /replicas route; the single pod's public IP
-    # is surfaced directly on the devpod status (mapped into the replica's
-    # status.public_ip by the response translation). In legacy mode, read it
-    # from the single replica as before.
+    # is surfaced directly on the devpod status as a bare IP (status.public_ip),
+    # carried through by the response translation. In legacy mode, read it from
+    # the single replica as before.
     if client.new_deployment_api_enabled:
         pod = client.pod.get(name)
         status = pod.status
-        cps = status.container_port_status if status else None
-        if cps:
-            for port_status in cps:
-                if port_status.external_endpoint:
-                    # external_endpoint is host:port; keep only the host part to
-                    # match the legacy replica public_ip semantics.
-                    return port_status.external_endpoint.split(":", 1)[0]
-        return None
+        return status.public_ip if status else None
     replicas = client.deployment.get_replicas(name)
     logger.trace(f"Replicas for {name}:\n{replicas}")
 

--- a/leptonai/cli/util.py
+++ b/leptonai/cli/util.py
@@ -322,11 +322,18 @@ def _get_only_replica_public_ip(name: str):
     # is surfaced directly on the devpod status as a bare IP (status.public_ip),
     # carried through by the response translation. In legacy mode, read it from
     # the single replica as before.
+    #
+    # Snapshot the flag once and call the matching backing implementation
+    # directly: a transient /workspace failure is no longer cached (client.py),
+    # so reading the flag twice within one operation could disagree and route
+    # this pod to the mismatched API (e.g. GET /endpoints/<pod>/replicas, which
+    # does not exist for a devpod). Resolving once keeps the whole operation on
+    # one API.
     if client.new_deployment_api_enabled:
-        pod = client.pod.get(name)
+        pod = client._devpod_api.get(name)
         status = pod.status
         return status.public_ip if status else None
-    replicas = client.deployment.get_replicas(name)
+    replicas = client._deployment_legacy.get_replicas(name)
     logger.trace(f"Replicas for {name}:\n{replicas}")
 
     if len(replicas) != 1:

--- a/leptonai/cli/util.py
+++ b/leptonai/cli/util.py
@@ -318,6 +318,21 @@ def sizeof_fmt(num, suffix="B"):
 
 def _get_only_replica_public_ip(name: str):
     client = get_client()
+    # The new devpod API exposes no /replicas route; the single pod's public IP
+    # is surfaced directly on the devpod status (mapped into the replica's
+    # status.public_ip by the response translation). In legacy mode, read it
+    # from the single replica as before.
+    if client.new_deployment_api_enabled:
+        pod = client.pod.get(name)
+        status = pod.status
+        cps = status.container_port_status if status else None
+        if cps:
+            for port_status in cps:
+                if port_status.external_endpoint:
+                    # external_endpoint is host:port; keep only the host part to
+                    # match the legacy replica public_ip semantics.
+                    return port_status.external_endpoint.split(":", 1)[0]
+        return None
     replicas = client.deployment.get_replicas(name)
     logger.trace(f"Replicas for {name}:\n{replicas}")
 

--- a/leptonai/cli/util.py
+++ b/leptonai/cli/util.py
@@ -329,10 +329,10 @@ def _get_only_replica_public_ip(name: str, client: Optional[APIClient] = None):
     # the single replica as before. The dispatch flag is stable process-wide, so
     # this branch cannot disagree with the caller's pod routing.
     if client.new_deployment_api_enabled:
-        pod = client._devpod_api.get(name)
+        pod = client.pod.get(name)
         status = pod.status
         return status.public_ip if status else None
-    replicas = client._deployment_legacy.get_replicas(name)
+    replicas = client._deployment_api_for_legacy_pod().get_replicas(name)
     logger.trace(f"Replicas for {name}:\n{replicas}")
 
     if len(replicas) != 1:


### PR DESCRIPTION
## Summary

Transparent mode-switch: the same `lep endpoint` / `lep pod` commands, new `/endpoints` + `/devpods` routes when the workspace feature flag `enable_new_deployment_api` is on. New `EndpointAPI`/`DevPodAPI` resource classes translate the CLI's legacy `LeptonDeployment` view to/from the redesigned `HTTPEndpoint` (components[]) and `HTTPDevPod` (flattened) wire schemas — ported field-by-field from the dashboard's production TypeScript translators, with the api-server Go types as source of truth.

## Flag semantics

`features.enable_new_deployment_api` from `/workspace`, resolved once per client and memoized; **explicit `true` only** — false/absent/missing-features/fetch-error all fail safe to legacy. Flag-off behavior is byte-identical (legacy `PodAPI` is flag-immune via `_deployment_legacy`).

## Route table (new mode)

| Command | Endpoint route | Devpod route |
|---|---|---|
| list / create / get / update / delete | `/endpoints[/:id]` | `/devpods[/:id]` |
| restart | `PUT /endpoints/:id/restart` | `PUT /devpods/:id/restart` |
| stop | `PATCH` components `min_replicas: 0` | `PATCH spec.stopped: true` |
| replicas / log | `/endpoints/:id/replicas[/:rid/log]` | — (no route yet) |
| events | `/endpoints/:id/events` | — (no route yet) |
| readiness / termination | — degrades (per-replica only server-side) | — degrades |

Commands whose sub-operations have no new-mode route emit a clear "not yet supported by the new API" note instead of an opaque 404. The server-side 403 gate message ("the new … API is not enabled for this workspace") surfaces cleanly through the existing error handler.

## Tests

24 new `responses`-mocked tests: flag detection/caching/fail-safe, off-mode and on-mode routing for both families, the pod-create path, degradations, and 403 surfacing. Full package suite: 66 passed (one pre-existing environmental failure in `test_s3cache` — missing optional `boto3`, file untouched).

Tickets: LEP-5664, LEP-5665

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Adversarial review (converged, 6 rounds)

This PR was run through a max-effort adversarial review loop (Codex `xhigh` audit → independent verification against the backend Go types → fix → re-review) before being marked ready. **15 findings fixed, 7 refuted-with-evidence or documented as legacy-parity limitations**, across 6 `fix(review):` commits. Highlights fixed: devpod `metadata.visibility` dropped in translation (private pods created public via SDK), `semantic_version: None` crash on disruptive updates, `app_protocol` erased on round-trip (gRPC routing), endpoint log queries misrouted under `deployment=`, transient flag-resolution failures poisoning the mode cache, explicit `ports: []` not clearing ports under RFC 7386 merge.

**Residual notes for reviewers:**
- The endpoint-flavored legacy-create backstop depends on the server-side gate (monorepo MR \!7865) landing
- Legacy-parity limitations (unchanged from the `/deployments` path): `storage_attachments` not representable in the legacy SDK model; rsync `PASSWORD` redaction; devpod container `appProtocol` casing
- Multi-component endpoints are collapsed to the frontend component by design (the legacy CLI view can only express the single-component subset)
- Tests are route/payload mocks verified field-by-field against the Go types; a flag-ON e2e smoke post-merge is recommended
