### PR TITLE
feat(cli): add filters to node list-nodes

### DIFF
--- a/leptonai/api/v2/dedicated_node_groups.py
+++ b/leptonai/api/v2/dedicated_node_groups.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 
 from .api_resource import APIResourse
 
-from .types.dedicated_node_group import DedicatedNodeGroup, Node, Volume
+from .types.dedicated_node_group import DedicatedNodeGroup, Machine, Node, Volume
 from .types.node_reservation import NodeReservation
 from .types.storage_data_source import StorageDataSource, StorageDataSourceSpec
 from .types.storage_permission import StoragePermission
@@ -30,6 +30,14 @@ class DedicatedNodeGroupAPI(APIResourse):
             f"/dedicated-node-groups/{self._to_name(name_or_ng)}/nodes"
         )
         return self.ensure_list(response, Node)
+
+    def list_machines(
+        self, name_or_ng: Union[str, DedicatedNodeGroup]
+    ) -> List[Machine]:
+        response = self._get(
+            f"/dedicated-node-groups/{self._to_name(name_or_ng)}/machines"
+        )
+        return self.ensure_list(response, Machine)
 
     def list_idle_nodes(self, name_or_ng: Union[str, DedicatedNodeGroup]) -> List[Node]:
         response = self._get(

--- a/leptonai/api/v2/types/dedicated_node_group.py
+++ b/leptonai/api/v2/types/dedicated_node_group.py
@@ -157,17 +157,45 @@ class NodeResource(BaseModel):
     system: Optional[NodeResourceSystem] = None
 
 
+class MachineStatus(BaseModel):
+    machine_id: Optional[str] = None
+    node_name: Optional[str] = None
+    capacity_type: Optional[str] = None
+    provider: Optional[str] = None
+    provider_region: Optional[str] = None
+    status: Optional[str] = None
+    resource: Optional[NodeResource] = None
+    public_ip: Optional[str] = None
+    private_ip: Optional[str] = None
+    hostname: Optional[str] = None
+
+
+class Machine(BaseModel):
+    metadata: Metadata
+    status: MachineStatus
+
+
 class NodeSpec(BaseModel):
     dedicated_node_group: Optional[str] = None
+    machine_id: Optional[str] = None
+    capacity_type: Optional[str] = None
+    hostname: Optional[str] = None
+    public_ip: Optional[str] = None
+    local_ip: Optional[str] = None
+    # Kept for compatibility with callers that used the old misspelled field.
     public_op: Optional[str] = None
     provider: Optional[str] = None
     provider_region: Optional[str] = None
     resource: Optional[NodeResource] = None
     unschedulable: bool
+    gpu_clique_id: Optional[str] = None
 
 
 class NodeStatus(BaseModel):
     status: Optional[List[str]] = None
+    machine_stage: Optional[str] = None
+    machine_status: Optional[str] = None
+    hostname: Optional[str] = None
     workloads: Optional[List[NodeResourceWorkload]] = None
 
 

--- a/leptonai/cli/node.py
+++ b/leptonai/cli/node.py
@@ -578,7 +578,7 @@ def _filter_nodes(
     cpu_types=(),
     unschedulable=False,
 ):
-    """Apply the same node-filtering semantics as the node-group WebUI."""
+    """Apply node filters, with CLI prefix matching for providers and labels."""
     normalized_keyword = keyword.strip().lower() if keyword else ""
     wanted_statuses = set(statuses)
     wanted_stages = set(stages)
@@ -629,16 +629,20 @@ def _filter_nodes(
                 getattr(metadata, "labels", None) if metadata else None
             ) or {}
             for label_filter in labels:
-                key, separator, value = label_filter.partition(":")
-                if separator:
-                    if node_labels.get(key) != value:
-                        return False
-                elif key not in node_labels:
+                key_prefix, separator, value_prefix = label_filter.partition(":")
+                if not key_prefix or not any(
+                    label_key.startswith(key_prefix)
+                    and (not separator or str(label_value).startswith(value_prefix))
+                    for label_key, label_value in node_labels.items()
+                ):
                     return False
 
         if wanted_providers:
-            provider = getattr(spec, "provider", None) if spec else None
-            if provider not in wanted_providers:
+            provider = (getattr(spec, "provider", None) if spec else None) or ""
+            if not any(
+                provider.lower().startswith(prefix.lower())
+                for prefix in wanted_providers
+            ):
                 return False
 
         if wanted_gpu_types:
@@ -680,7 +684,10 @@ def _filter_nodes(
     "labels",
     type=str,
     multiple=True,
-    help="Filter by label KEY (exists) or KEY:VALUE (exact match). Repeat for AND.",
+    help=(
+        "Filter by case-sensitive label KEY_PREFIX or KEY_PREFIX:VALUE_PREFIX."
+        " Repeat for AND."
+    ),
 )
 @click.option(
     "--status",
@@ -701,7 +708,7 @@ def _filter_nodes(
     "providers",
     type=str,
     multiple=True,
-    help="Filter by exact provider. Repeat for OR.",
+    help="Filter by case-insensitive provider prefix. Repeat for OR.",
 )
 @click.option(
     "--gpu-type",

--- a/leptonai/cli/node.py
+++ b/leptonai/cli/node.py
@@ -1,4 +1,5 @@
 import re
+from copy import deepcopy
 
 import click
 
@@ -14,6 +15,9 @@ from .util import (
 )
 from ..api.v2.client import APIClient
 from ..api.v2.types.dedicated_node_group import (
+    Node,
+    NodeSpec,
+    NodeStatus,
     Volume,
     VolumeCreationMode,
     VolumeFrom,
@@ -25,6 +29,46 @@ from ..api.v2.types.storage_data_source import (
     StorageDataSourceSpec,
 )
 from ..api.v2.types.storage_permission import StoragePermission
+
+
+NODE_STATUS_FILTER_VALUES = (
+    "Healthy",
+    "Unhealthy",
+    "Degraded",
+    "Rebooting",
+    "Registered",
+    "CheckingIn",
+    "Bootstrapping",
+    "Initializing",
+    "Launching",
+    "Booting",
+    "Draining",
+    "Leaving",
+    "Terminating",
+    "Offline",
+    "Failed",
+    "WaitForDraining",
+    "Verifying",
+    "Rejected",
+    "Terminated",
+    "RemoveFromNodeGroup",
+)
+
+NODE_STAGE_FILTER_VALUES = (
+    "production",
+    "ready-to-repair",
+    "repairing",
+    "recalled",
+    "verifying",
+)
+
+LEAVING_NODE_STATUS_VALUES = {
+    "Draining",
+    "Leaving",
+    "Terminating",
+    "Terminated",
+    "RemoveFromNodeGroup",
+}
 
 
 @click_group()
@@ -373,15 +417,332 @@ def _format_disk_cell(disk):
     return f"{used} / {total}"
 
 
+def _format_labels_cell(labels):
+    if not labels:
+        return "[dim]-[/dim]"
+    return "\n".join(
+        f"{key}={value}" if value else key for key, value in sorted(labels.items())
+    )
+
+
+def _format_node_status_cell(status):
+    if not status:
+        return "-"
+    values = []
+    for value in [status.machine_status, *(status.status or [])]:
+        if value and value not in values:
+            values.append(value)
+    return ", ".join(_colorize_status(value) for value in values) or "-"
+
+
+def _format_node_cell(metadata):
+    node_name = getattr(metadata, "name", None)
+    node_id = getattr(metadata, "id_", None)
+    value = make_name_id_cell(
+        node_name or node_id,
+        node_id if node_id and node_id != node_name else None,
+    )
+    labels = getattr(metadata, "labels", None)
+    if labels:
+        value += f"\n[dim]{_format_labels_cell(labels)}[/dim]"
+    return value
+
+
+def _format_provider_cell(spec):
+    provider = (getattr(spec, "provider", None) if spec else None) or "-"
+    region = (getattr(spec, "provider_region", None) if spec else None) or "-"
+    value = f"{provider} / {region}"
+    gpu_clique_id = getattr(spec, "gpu_clique_id", None) if spec else None
+    if gpu_clique_id:
+        value += f"\n[dim]clique: {gpu_clique_id}[/dim]"
+    return value
+
+
+def _format_state_cell(node):
+    value = _format_node_status_cell(node.status)
+    stage = (
+        getattr(node.status, "machine_stage", None) if node.status else None
+    ) or "-"
+    scheduling = (
+        "[yellow]unschedulable[/yellow]"
+        if node.spec and getattr(node.spec, "unschedulable", False)
+        else "[dim]schedulable[/dim]"
+    )
+    return f"{value}\n[dim]stage: {stage}[/dim]\n{scheduling}"
+
+
+def _format_network_cell(node):
+    spec = node.spec
+    hostname = (
+        (getattr(spec, "hostname", None) if spec else None)
+        or (getattr(node.status, "hostname", None) if node.status else None)
+        or "-"
+    )
+    public_ip = (getattr(spec, "public_ip", None) if spec else None) or "-"
+    local_ip = (getattr(spec, "local_ip", None) if spec else None) or "-"
+    return f"{hostname}\n[dim]public: {public_ip}[/dim]\n[dim]local: {local_ip}[/dim]"
+
+
+def _merge_nodes_with_machines(nodes, machines):
+    """Merge node and machine responses using the WebUI's machine_id rules."""
+    machines_by_id = {
+        machine.status.machine_id: machine
+        for machine in machines
+        if machine.status and machine.status.machine_id
+    }
+    matched_machine_ids = set()
+    merged = []
+
+    for original in nodes:
+        node = deepcopy(original)
+        spec = node.spec
+        machine_id = getattr(spec, "machine_id", None) if spec else None
+        machine = machines_by_id.get(machine_id)
+        if not machine:
+            merged.append(node)
+            continue
+
+        matched_machine_ids.add(machine_id)
+        machine_status = machine.status
+        if spec:
+            spec.hostname = machine_status.hostname or spec.hostname
+            spec.provider = spec.provider or machine_status.provider
+            spec.provider_region = (
+                spec.provider_region or machine_status.provider_region
+            )
+            spec.public_ip = spec.public_ip or machine_status.public_ip
+            spec.local_ip = spec.local_ip or machine_status.private_ip
+
+        status = node.status
+        if status and not status.hostname:
+            status.hostname = machine_status.hostname
+        if (
+            status
+            and machine_status.status == "Failed"
+            and status.machine_status not in LEAVING_NODE_STATUS_VALUES
+        ):
+            old_status = status.machine_status
+            status.machine_status = "Failed"
+            status.status = [
+                value for value in (status.status or []) if value != old_status
+            ]
+            if "Failed" not in status.status:
+                status.status.append("Failed")
+
+        merged.append(node)
+
+    for machine in machines:
+        machine_status = machine.status
+        machine_id = machine_status.machine_id
+        if machine_id and machine_id in matched_machine_ids:
+            continue
+
+        metadata = deepcopy(machine.metadata)
+        metadata.id_ = metadata.name or metadata.id_
+        metadata.name = machine_status.node_name or metadata.name or metadata.id_
+        phase = machine_status.status
+        merged.append(
+            Node(
+                metadata=metadata,
+                spec=NodeSpec(
+                    machine_id=machine_id,
+                    capacity_type=machine_status.capacity_type,
+                    hostname=machine_status.hostname,
+                    public_ip=machine_status.public_ip,
+                    local_ip=machine_status.private_ip,
+                    provider=machine_status.provider,
+                    provider_region=machine_status.provider_region,
+                    resource=deepcopy(machine_status.resource),
+                    unschedulable=False,
+                ),
+                status=NodeStatus(
+                    status=[phase] if phase else [],
+                    machine_status=phase,
+                    hostname=machine_status.hostname,
+                ),
+            )
+        )
+
+    return merged
+
+
+def _filter_nodes(
+    nodes,
+    *,
+    keyword=None,
+    labels=(),
+    statuses=(),
+    stages=(),
+    providers=(),
+    gpu_types=(),
+    cpu_types=(),
+    unschedulable=False,
+):
+    """Apply the same node-filtering semantics as the node-group WebUI."""
+    normalized_keyword = keyword.strip().lower() if keyword else ""
+    wanted_statuses = set(statuses)
+    wanted_stages = set(stages)
+    wanted_providers = set(providers)
+    wanted_gpu_types = set(gpu_types)
+    wanted_cpu_types = set(cpu_types)
+
+    def matches(node):
+        metadata = getattr(node, "metadata", None)
+        spec = getattr(node, "spec", None)
+        status = getattr(node, "status", None)
+        resource = getattr(spec, "resource", None) if spec else None
+
+        if normalized_keyword:
+            keyword_fields = (
+                getattr(metadata, "name", None) if metadata else None,
+                getattr(status, "hostname", None) if status else None,
+                getattr(spec, "hostname", None) if spec else None,
+                getattr(spec, "public_ip", None) if spec else None,
+                getattr(spec, "local_ip", None) if spec else None,
+                getattr(spec, "gpu_clique_id", None) if spec else None,
+                getattr(spec, "provider", None) if spec else None,
+                getattr(spec, "provider_region", None) if spec else None,
+            )
+            if not any(
+                normalized_keyword in str(value).lower()
+                for value in keyword_fields
+                if value is not None
+            ):
+                return False
+
+        if wanted_statuses:
+            machine_status = getattr(status, "machine_status", None) if status else None
+            status_values = (getattr(status, "status", None) if status else None) or []
+            if (
+                machine_status not in wanted_statuses
+                and not wanted_statuses.intersection(status_values)
+            ):
+                return False
+
+        if wanted_stages:
+            machine_stage = getattr(status, "machine_stage", None) if status else None
+            if machine_stage not in wanted_stages:
+                return False
+
+        if labels:
+            node_labels = (
+                getattr(metadata, "labels", None) if metadata else None
+            ) or {}
+            for label_filter in labels:
+                key, separator, value = label_filter.partition(":")
+                if separator:
+                    if node_labels.get(key) != value:
+                        return False
+                elif key not in node_labels:
+                    return False
+
+        if wanted_providers:
+            provider = getattr(spec, "provider", None) if spec else None
+            if provider not in wanted_providers:
+                return False
+
+        if wanted_gpu_types:
+            gpu = getattr(resource, "gpu", None) if resource else None
+            if getattr(gpu, "product", None) not in wanted_gpu_types:
+                return False
+
+        if wanted_cpu_types:
+            cpu = getattr(resource, "cpu", None) if resource else None
+            if getattr(cpu, "type_", None) not in wanted_cpu_types:
+                return False
+
+        if unschedulable and (
+            not spec or getattr(spec, "unschedulable", None) is not True
+        ):
+            return False
+
+        return True
+
+    return [item for item in nodes if matches(item)]
+
+
 @node.command(name="list-nodes")
 @click.argument("name", type=str)
-def list_nodes_command(name):
+@click.option(
+    "--search",
+    "--keyword",
+    "-q",
+    "keyword",
+    type=str,
+    help=(
+        "Case-insensitive substring search across node name, hostnames, public/local"
+        " IPs, GPU clique ID, provider, and provider region."
+    ),
+)
+@click.option(
+    "--label",
+    "--labels",
+    "labels",
+    type=str,
+    multiple=True,
+    help="Filter by label KEY (exists) or KEY:VALUE (exact match). Repeat for AND.",
+)
+@click.option(
+    "--status",
+    "statuses",
+    type=click.Choice(NODE_STATUS_FILTER_VALUES),
+    multiple=True,
+    help="Filter by machine/node status. Repeat for OR.",
+)
+@click.option(
+    "--stage",
+    "stages",
+    type=click.Choice(NODE_STAGE_FILTER_VALUES),
+    multiple=True,
+    help="Filter by machine stage. Repeat for OR.",
+)
+@click.option(
+    "--provider",
+    "providers",
+    type=str,
+    multiple=True,
+    help="Filter by exact provider. Repeat for OR.",
+)
+@click.option(
+    "--gpu-type",
+    "gpu_types",
+    type=str,
+    multiple=True,
+    help="Filter by exact GPU product. Repeat for OR.",
+)
+@click.option(
+    "--cpu-type",
+    "cpu_types",
+    type=str,
+    multiple=True,
+    help="Filter by exact CPU type. Repeat for OR.",
+)
+@click.option(
+    "--unschedulable",
+    is_flag=True,
+    help="Show only nodes with unschedulable=true.",
+)
+def list_nodes_command(
+    name,
+    keyword=None,
+    labels=(),
+    statuses=(),
+    stages=(),
+    providers=(),
+    gpu_types=(),
+    cpu_types=(),
+    unschedulable=False,
+):
     """
     List the nodes under a node group with per-node resource detail.
 
     NAME is the node group name or ID (partial match supported, e.g. 'h100').
-    For each node it shows the node ID, provider/region, status, GPU
-    availability, and the used/total split for GPU, CPU, memory, and disk.
+    For each node it shows name/ID/labels, provider/region/GPU clique ID,
+    status/stage/scheduling state, resources, hostname, and public/local IPs.
+
+    Repeat values within status, stage, provider, GPU type, or CPU type to OR
+    them together. Different filter categories and repeated label filters are
+    combined with AND.
     """
     node_groups = resolve_node_groups([name], is_exact_match=False)
     if not node_groups:
@@ -401,14 +762,26 @@ def list_nodes_command(name):
             )
             continue
 
+        try:
+            machines = client.nodegroup.list_machines(node_group)
+        except Exception as e:
+            console.print(
+                "[dim]Warning:[/dim] Failed to fetch machine details for"
+                f" {ng_name} ({ng_id}); hostname and provisioning nodes may be"
+                f" unavailable: {e}"
+            )
+            machines = []
+        nodes = _merge_nodes_with_machines(nodes, machines)
+
         table = Table(title=f"Nodes in {ng_name} ({ng_id})", show_lines=True)
-        table.add_column("Node ID")
-        table.add_column("Provider / Region")
-        table.add_column("Status")
+        table.add_column("Node\n[dim](name / ID / labels)[/dim]")
+        table.add_column("Provider / Region\n[dim](GPU clique ID)[/dim]")
+        table.add_column("Status\n[dim](stage / scheduling)[/dim]")
         table.add_column("GPU\n[dim](avail · used/total)[/dim]")
         table.add_column("CPU\n[dim](used / total)[/dim]")
         table.add_column("Memory\n[dim](used / total)[/dim]")
         table.add_column("Disk\n[dim](used / total)[/dim]")
+        table.add_column("Network\n[dim](hostname / public / local)[/dim]")
 
         if not nodes:
             console.print(
@@ -416,18 +789,32 @@ def list_nodes_command(name):
             )
             continue
 
+        nodes = _filter_nodes(
+            nodes,
+            keyword=keyword,
+            labels=labels,
+            statuses=statuses,
+            stages=stages,
+            providers=providers,
+            gpu_types=gpu_types,
+            cpu_types=cpu_types,
+            unschedulable=unschedulable,
+        )
+        if not nodes:
+            console.print(
+                "[yellow]No nodes match the specified filters in node group"
+                f" {ng_name} ({ng_id}).[/yellow]"
+            )
+            continue
+
         for node in nodes:
             spec = node.spec
             resource = spec.resource if spec else None
-            provider = (getattr(spec, "provider", None) if spec else None) or "-"
-            region = (getattr(spec, "provider_region", None) if spec else None) or "-"
-            statuses = (node.status.status if node.status else None) or []
-            status_cell = ", ".join(_colorize_status(s) for s in statuses) or "-"
 
             table.add_row(
-                make_name_id_cell(node.metadata.id_, None),
-                f"{provider} / {region}",
-                status_cell,
+                _format_node_cell(node.metadata),
+                _format_provider_cell(spec),
+                _format_state_cell(node),
                 _format_gpu_cell(
                     resource.gpu if resource else None,
                     usable=_is_node_usable(node),
@@ -435,6 +822,7 @@ def list_nodes_command(name):
                 _format_cpu_cell(resource.cpu if resource else None),
                 _format_memory_cell(resource.memory if resource else None),
                 _format_disk_cell(resource.disk if resource else None),
+                _format_network_cell(node),
             )
 
         console.print(table)

--- a/leptonai/cli/tests/test_node_cli.py
+++ b/leptonai/cli/tests/test_node_cli.py
@@ -1227,16 +1227,28 @@ def test_filter_nodes_status_matches_machine_status_or_status_array(nodes):
     assert [item.metadata.id_ for item in secondary] == ["node-2"]
 
 
-def test_filter_nodes_requires_every_label_condition(nodes):
-    filtered = _filter_nodes(nodes, labels=("env:prod", "rack:r2", "paused"))
+def test_filter_nodes_requires_every_label_prefix_condition(nodes):
+    filtered = _filter_nodes(nodes, labels=("en:pro", "ra:r2", "pa"))
 
     assert [item.metadata.id_ for item in filtered] == ["node-2"]
 
 
-def test_filter_nodes_label_with_empty_value_is_an_exact_match(nodes):
-    filtered = _filter_nodes(nodes, labels=("paused:",))
+def test_filter_nodes_label_prefix_is_case_sensitive(nodes):
+    filtered = _filter_nodes(nodes, labels=("EN:pro",))
 
-    assert [item.metadata.id_ for item in filtered] == ["node-2"]
+    assert filtered == []
+
+
+def test_filter_nodes_label_with_empty_value_prefix_matches_any_value(nodes):
+    filtered = _filter_nodes(nodes, labels=("env:",))
+
+    assert [item.metadata.id_ for item in filtered] == ["node-1", "node-2", "node-3"]
+
+
+def test_filter_nodes_provider_prefix_is_case_insensitive(nodes):
+    filtered = _filter_nodes(nodes, providers=("AW",))
+
+    assert [item.metadata.id_ for item in filtered] == ["node-1"]
 
 
 def test_filter_nodes_unschedulable_only(nodes):
@@ -1347,9 +1359,9 @@ def test_list_nodes_command_applies_repeatable_filters(nodes):
                     "--status",
                     "Offline",
                     "--provider",
-                    "gcp",
+                    "gc",
                     "--label",
-                    "env:prod",
+                    "en:pro",
                     "--unschedulable",
                 ],
             )

--- a/leptonai/cli/tests/test_node_cli.py
+++ b/leptonai/cli/tests/test_node_cli.py
@@ -1,6 +1,8 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from leptonai.api.v2.dedicated_node_groups import DedicatedNodeGroupAPI
@@ -9,12 +11,26 @@ from leptonai.api.v2.types.dedicated_node_group import (
     DedicatedNodeGroup,
     DedicatedNodeGroupSpec,
     DedicatedNodeGroupStatus,
+    Machine,
+    MachineStatus,
     MountOptions,
+    Node,
+    NodeResource,
+    NodeResourceCPU,
+    NodeResourceGPU,
+    NodeSpec,
+    NodeStatus,
     Volume,
 )
 from leptonai.api.v2.types.storage_data_source import StorageDataSource
 from leptonai.api.v2.types.storage_permission import StoragePermission
 from leptonai.cli import lep as cli
+from leptonai.cli.node import (
+    _filter_nodes,
+    _merge_nodes_with_machines,
+    console as node_console,
+    node,
+)
 
 
 def _make_node_group():
@@ -1071,3 +1087,310 @@ def test_storage_permission_rejects_path_for_object_storage():
     assert result.exit_code != 0
     assert "bucket-wide" in result.output
     assert fake_client.nodegroup.updated_data_sources == []
+
+
+def _node(
+    id_,
+    *,
+    name=None,
+    labels=None,
+    hostname=None,
+    status_hostname=None,
+    public_ip=None,
+    local_ip=None,
+    gpu_clique_id=None,
+    provider=None,
+    provider_region=None,
+    gpu_type=None,
+    cpu_type=None,
+    machine_status=None,
+    statuses=None,
+    machine_stage=None,
+    unschedulable=False,
+):
+    return Node(
+        metadata=Metadata(id=id_, name=name or id_, labels=labels),
+        spec=NodeSpec(
+            hostname=hostname,
+            public_ip=public_ip,
+            local_ip=local_ip,
+            gpu_clique_id=gpu_clique_id,
+            provider=provider,
+            provider_region=provider_region,
+            resource=NodeResource(
+                gpu=NodeResourceGPU(product=gpu_type),
+                cpu=NodeResourceCPU(type=cpu_type),
+            ),
+            unschedulable=unschedulable,
+        ),
+        status=NodeStatus(
+            hostname=status_hostname,
+            machine_status=machine_status,
+            machine_stage=machine_stage,
+            status=statuses,
+        ),
+    )
+
+
+@pytest.fixture
+def nodes():
+    return [
+        _node(
+            "node-1",
+            name="Alpha-Node",
+            labels={"env": "prod", "rack": "r1"},
+            hostname="spec-host-1",
+            status_hostname="status-host-1",
+            public_ip="203.0.113.10",
+            local_ip="10.0.0.10",
+            gpu_clique_id="clique-blue",
+            provider="aws",
+            provider_region="us-west-2",
+            gpu_type="H100",
+            cpu_type="amd64",
+            machine_status="Healthy",
+            statuses=["Ready", "Healthy"],
+            machine_stage="production",
+        ),
+        _node(
+            "node-2",
+            name="Beta-Node",
+            labels={"env": "prod", "rack": "r2", "paused": ""},
+            hostname="spec-host-2",
+            status_hostname="status-host-2",
+            public_ip="198.51.100.20",
+            local_ip="10.0.0.20",
+            gpu_clique_id="clique-green",
+            provider="gcp",
+            provider_region="us-central1",
+            gpu_type="A100",
+            cpu_type="arm64",
+            machine_status="Draining",
+            statuses=["NotReady", "WaitForDraining"],
+            machine_stage="ready-to-repair",
+            unschedulable=True,
+        ),
+        _node(
+            "node-3",
+            name="Gamma-Node",
+            labels={"env": "dev", "rack": "r3"},
+            provider="azure",
+            provider_region="eastus",
+            gpu_type="H100",
+            cpu_type="amd64",
+            machine_status="Offline",
+            statuses=["NotReady", "Offline"],
+            machine_stage="repairing",
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("keyword", "expected"),
+    [
+        ("alpha", ["node-1"]),
+        ("STATUS-HOST-2", ["node-2"]),
+        ("spec-host-1", ["node-1"]),
+        ("113.10", ["node-1"]),
+        ("0.0.20", ["node-2"]),
+        ("CLIQUE-GREEN", ["node-2"]),
+        ("AZURE", ["node-3"]),
+        ("central1", ["node-2"]),
+    ],
+)
+def test_filter_nodes_keyword_matches_webui_fields_case_insensitively(
+    nodes, keyword, expected
+):
+    filtered = _filter_nodes(nodes, keyword=keyword)
+
+    assert [item.metadata.id_ for item in filtered] == expected
+
+
+def test_filter_nodes_combines_categories_with_and_and_values_with_or(nodes):
+    filtered = _filter_nodes(
+        nodes,
+        statuses=("Healthy", "Offline"),
+        stages=("production", "repairing"),
+        providers=("aws", "azure"),
+        gpu_types=("H100",),
+        cpu_types=("amd64",),
+    )
+
+    assert [item.metadata.id_ for item in filtered] == ["node-1", "node-3"]
+
+
+def test_filter_nodes_status_matches_machine_status_or_status_array(nodes):
+    primary = _filter_nodes(nodes, statuses=("Draining",))
+    secondary = _filter_nodes(nodes, statuses=("WaitForDraining",))
+
+    assert [item.metadata.id_ for item in primary] == ["node-2"]
+    assert [item.metadata.id_ for item in secondary] == ["node-2"]
+
+
+def test_filter_nodes_requires_every_label_condition(nodes):
+    filtered = _filter_nodes(nodes, labels=("env:prod", "rack:r2", "paused"))
+
+    assert [item.metadata.id_ for item in filtered] == ["node-2"]
+
+
+def test_filter_nodes_label_with_empty_value_is_an_exact_match(nodes):
+    filtered = _filter_nodes(nodes, labels=("paused:",))
+
+    assert [item.metadata.id_ for item in filtered] == ["node-2"]
+
+
+def test_filter_nodes_unschedulable_only(nodes):
+    filtered = _filter_nodes(nodes, unschedulable=True)
+
+    assert [item.metadata.id_ for item in filtered] == ["node-2"]
+
+
+def test_merge_nodes_with_machines_enriches_matching_node(nodes):
+    nodes[0].spec.machine_id = "machine-1"
+    nodes[0].spec.hostname = None
+    machine = Machine(
+        metadata=Metadata(name="machine-1"),
+        status=MachineStatus(
+            machine_id="machine-1",
+            hostname="machine-host-1",
+            provider="machine-provider",
+            public_ip="192.0.2.10",
+            private_ip="172.16.0.10",
+            status="Failed",
+        ),
+    )
+
+    merged = _merge_nodes_with_machines([nodes[0]], [machine])
+
+    assert len(merged) == 1
+    assert merged[0].spec.hostname == "machine-host-1"
+    assert merged[0].spec.provider == "aws"
+    assert merged[0].status.machine_status == "Failed"
+    assert merged[0].status.status == ["Ready", "Failed"]
+    assert nodes[0].spec.hostname is None
+    assert nodes[0].status.machine_status == "Healthy"
+
+
+def test_merge_nodes_with_machines_adds_provisioning_machine():
+    machine = Machine(
+        metadata=Metadata(id="record-id", name="machine-2"),
+        status=MachineStatus(
+            machine_id="provider-id-2",
+            node_name="pending-node",
+            hostname="pending-host",
+            provider="gcp",
+            provider_region="us-central1",
+            public_ip="198.51.100.30",
+            private_ip="10.0.0.30",
+            status="Launching",
+            resource=NodeResource(
+                gpu=NodeResourceGPU(product="H100"),
+                cpu=NodeResourceCPU(type="amd64"),
+            ),
+        ),
+    )
+
+    merged = _merge_nodes_with_machines([], [machine])
+
+    assert len(merged) == 1
+    assert merged[0].metadata.id_ == "machine-2"
+    assert merged[0].metadata.name == "pending-node"
+    assert merged[0].spec.local_ip == "10.0.0.30"
+    assert merged[0].status.status == ["Launching"]
+    assert _filter_nodes(merged, statuses=("Launching",)) == merged
+
+
+def test_list_machines_api_uses_node_group_machines_endpoint():
+    response = Mock(status_code=200)
+    response.json.return_value = [{
+        "metadata": {"name": "machine-1"},
+        "status": {
+            "machine_id": "provider-id-1",
+            "hostname": "machine-host-1",
+            "status": "Launching",
+        },
+    }]
+    http_client = SimpleNamespace(
+        _get=Mock(return_value=response),
+        _post=Mock(),
+        _put=Mock(),
+        _patch=Mock(),
+        _delete=Mock(),
+        _head=Mock(),
+    )
+    api = DedicatedNodeGroupAPI(http_client)
+
+    machines = api.list_machines("ng-1")
+
+    http_client._get.assert_called_once_with("/dedicated-node-groups/ng-1/machines")
+    assert machines[0].status.hostname == "machine-host-1"
+
+
+def test_list_nodes_command_applies_repeatable_filters(nodes):
+    node_group = SimpleNamespace(metadata=SimpleNamespace(name="gpu-group", id_="ng-1"))
+    client = SimpleNamespace(
+        nodegroup=SimpleNamespace(
+            list_nodes=Mock(return_value=nodes),
+            list_machines=Mock(return_value=[]),
+        )
+    )
+
+    with patch("leptonai.cli.node.resolve_node_groups", return_value=[node_group]):
+        with patch("leptonai.cli.node.get_client", return_value=client):
+            result = CliRunner().invoke(
+                node,
+                [
+                    "list-nodes",
+                    "gpu-group",
+                    "--status",
+                    "Draining",
+                    "--status",
+                    "Offline",
+                    "--provider",
+                    "gcp",
+                    "--label",
+                    "env:prod",
+                    "--unschedulable",
+                ],
+            )
+
+    assert result.exit_code == 0, result.output
+    assert "node-2" in result.output
+    assert "node-1" not in result.output
+    assert "node-3" not in result.output
+
+
+def test_list_nodes_command_displays_webui_inventory_fields(nodes, monkeypatch):
+    node_group = SimpleNamespace(metadata=SimpleNamespace(name="gpu-group", id_="ng-1"))
+    client = SimpleNamespace(
+        nodegroup=SimpleNamespace(
+            list_nodes=Mock(return_value=[nodes[0]]),
+            list_machines=Mock(return_value=[]),
+        )
+    )
+    monkeypatch.setattr(node_console, "width", 240)
+
+    with patch("leptonai.cli.node.resolve_node_groups", return_value=[node_group]):
+        with patch("leptonai.cli.node.get_client", return_value=client):
+            result = CliRunner().invoke(node, ["list-nodes", "gpu-group"])
+
+    assert result.exit_code == 0, result.output
+    for value in (
+        "Alpha-Node",
+        "clique-blue",
+        "env=prod",
+        "production",
+        "spec-host-1",
+        "203.0.113.10",
+        "10.0.0.10",
+    ):
+        assert value in result.output
+
+
+def test_list_nodes_command_rejects_unknown_status():
+    result = CliRunner().invoke(
+        node, ["list-nodes", "gpu-group", "--status", "Unknown"]
+    )
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--status'" in result.output


### PR DESCRIPTION
## Summary

- add keyword, label, status, stage, provider, GPU type, CPU type, and unschedulable filters to lep node list-nodes
- use OR within repeatable value filters, AND across categories, and AND across label predicates
- support case-insensitive prefix matching for providers and case-sensitive prefix matching for both label keys and values
- add the read-only node-group machines API and merge machine lifecycle data into nodes by machine_id
- include provisioning-only machines and backfill hostname, provider, region, and IP data with graceful fallback when the machines request fails
- expand the table with node labels, GPU clique ID, machine stage, scheduling state, hostname, public IP, and local IP

## Prefix examples

- --provider aw matches aws
- --label en matches label keys such as env
- --label en:pro matches env=prod and env=production

## Testing

- pytest -q leptonai/cli/tests --no-cov: 50 passed
- black --check and ruff check on changed files: passed
- previous full-suite run: 61 passed; the existing external S3 cache integration test failed because the public bucket returned HTTP 400