### PR TITLE
feat(cli): add --storage-attachment to job create

### DIFF
--- a/leptonai/api/v2/types/job.py
+++ b/leptonai/api/v2/types/job.py
@@ -13,6 +13,7 @@ from .deployment import (
     LeptonLog,
     QueueConfig,
     ReservationConfig,
+    StorageAttachment,
 )
 
 DefaultTTLSecondsAfterFinished: int = 600
@@ -53,6 +54,7 @@ class LeptonJobUserSpec(BaseModel):
     max_job_failure_retry: Optional[int] = None
     envs: Optional[List[EnvVar]] = []
     mounts: Optional[List[Mount]] = []
+    storage_attachments: Optional[List[StorageAttachment]] = None
     image_pull_secrets: Optional[List[str]] = []
     ttl_seconds_after_finished: Optional[int] = DefaultTTLSecondsAfterFinished
     intra_job_communication: Optional[bool] = None

--- a/leptonai/cli/job.py
+++ b/leptonai/cli/job.py
@@ -32,6 +32,7 @@ from .util import make_container_port_from_string  # noqa: F401
 from leptonai.api.v2.spec_utils import (
     make_mounts_from_strings,
     make_env_vars_from_strings,
+    make_storage_attachments_from_strings,
 )
 from leptonai.config import VALID_SHAPES
 from leptonai.config import JOB_BASE_IMAGE as BASE_IMAGE
@@ -412,6 +413,23 @@ def job():
     multiple=True,
 )
 @click.option(
+    "--storage-attachment",
+    help=(
+        "Attach an object storage data source to the job, as"
+        " `DATA_SOURCE_NAME:MODE[:ATTACH_WITH[:PROFILE_NAME]]` (split on the first"
+        " three colons). `DATA_SOURCE_NAME` is the name of a data source created"
+        " with `lep node storage add --type object`. `MODE` is `awsProfile` (AWS"
+        " credentials in ~/.aws/config format) or `mscProfile` (multi-cloud"
+        " credentials in YAML format). `ATTACH_WITH` is `object` or"
+        " `object.aistore` (defaults based on workspace configuration when"
+        " omitted). `PROFILE_NAME` defaults to the data source's bucket name."
+        " Repeat this flag to attach multiple data sources, or multiple modes of"
+        " the same data source. Example: `--storage-attachment"
+        " my-bucket:awsProfile`."
+    ),
+    multiple=True,
+)
+@click.option(
     "--image-pull-secrets",
     type=str,
     help="Secrets to use for pulling images.",
@@ -572,6 +590,7 @@ def create(
     env,
     secret,
     mount,
+    storage_attachment,
     image_pull_secrets,
     intra_job_communication,
     privileged,
@@ -719,6 +738,16 @@ def create(
             job_spec.mounts = make_mounts_from_strings(mount)  # type: ignore
         except ValueError as e:
             console.print(f"[red]Error parsing --mount[/]: {e}")
+            sys.exit(1)
+
+    # Configure storage attachments
+    if storage_attachment:
+        try:
+            job_spec.storage_attachments = make_storage_attachments_from_strings(
+                list(storage_attachment)
+            )
+        except ValueError as e:
+            console.print(f"[red]Error parsing --storage-attachment[/]: {e}")
             sys.exit(1)
 
     # Set image pull secrets

--- a/leptonai/cli/tests/test_job_cli.py
+++ b/leptonai/cli/tests/test_job_cli.py
@@ -1,0 +1,116 @@
+import os
+import tempfile
+
+# Set cache dir to a temp dir before importing anything from leptonai
+tmpdir = tempfile.mkdtemp()
+os.environ["LEPTON_CACHE_DIR"] = tmpdir
+
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+from loguru import logger
+
+from leptonai import config
+from leptonai.api.v2.types.common import Metadata
+from leptonai.api.v2.types.job import LeptonJob
+from leptonai.cli import lep as cli
+
+
+logger.info(f"Using cache dir: {config.CACHE_DIR}")
+
+
+class _FakeJobAPI:
+    def __init__(self):
+        self.created_job = None
+
+    def create(self, job):
+        self.created_job = job
+        return LeptonJob(metadata=Metadata(id="job-123"), spec=job.spec)
+
+
+class _FakeAPIClient:
+    last_instance = None
+
+    def __init__(self, *args, **kwargs):
+        self.job = _FakeJobAPI()
+        _FakeAPIClient.last_instance = self
+
+
+def _create_args(*extra):
+    return [
+        "job",
+        "create",
+        "--name",
+        "test-job",
+        "--container-image",
+        "nginx:latest",
+        "--command",
+        "echo done",
+        "--resource-shape",
+        config.DEFAULT_RESOURCE_SHAPE,
+        *extra,
+    ]
+
+
+class TestJobCliStorageAttachment(unittest.TestCase):
+    def test_job_create_builds_storage_attachments(self):
+        runner = CliRunner()
+        _FakeAPIClient.last_instance = None
+
+        with patch("leptonai.cli.job.APIClient", _FakeAPIClient):
+            result = runner.invoke(
+                cli,
+                _create_args(
+                    "--storage-attachment",
+                    "my-bucket:awsProfile",
+                    "--storage-attachment",
+                    "my-bucket:mscProfile:object.aistore:my-profile",
+                ),
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        created = _FakeAPIClient.last_instance.job.created_job
+        self.assertIsNotNone(created)
+        attachments = created.spec.storage_attachments
+        self.assertEqual(len(attachments), 1)
+        self.assertEqual(attachments[0].data_source_name, "my-bucket")
+        self.assertEqual(len(attachments[0].attachments), 2)
+        self.assertEqual(attachments[0].attachments[0].mode, "awsProfile")
+        self.assertIsNone(attachments[0].attachments[0].attach_with)
+        self.assertEqual(attachments[0].attachments[1].mode, "mscProfile")
+        self.assertEqual(attachments[0].attachments[1].attach_with, "object.aistore")
+        self.assertEqual(attachments[0].attachments[1].profile_name, "my-profile")
+
+    def test_job_create_without_storage_attachment_leaves_field_unset(self):
+        runner = CliRunner()
+        _FakeAPIClient.last_instance = None
+
+        with patch("leptonai.cli.job.APIClient", _FakeAPIClient):
+            result = runner.invoke(cli, _create_args())
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        created = _FakeAPIClient.last_instance.job.created_job
+        self.assertIsNotNone(created)
+        self.assertIsNone(created.spec.storage_attachments)
+
+    def test_job_create_rejects_invalid_storage_attachment_mode(self):
+        runner = CliRunner()
+        _FakeAPIClient.last_instance = None
+
+        with patch("leptonai.cli.job.APIClient", _FakeAPIClient):
+            result = runner.invoke(
+                cli,
+                _create_args("--storage-attachment", "my-bucket:not-a-mode"),
+            )
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        output = " ".join(((result.output or "") + (result.stderr or "")).split())
+        self.assertIn("Error parsing --storage-attachment", output)
+        self.assertIn("MODE must be one of", output)
+        self.assertIsNotNone(_FakeAPIClient.last_instance)
+        self.assertIsNone(_FakeAPIClient.last_instance.job.created_job)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Follow-up to #792, which added `--storage-attachment` to `lep endpoint create`/`update` and `lep pod create` and explicitly left `job` out of scope. This adds the same flag to `lep job create`.
- Add `storage_attachments` to `LeptonJobUserSpec` (`types/job.py`), mirroring the backend's job CRD field (`deployment-operator/api/v1alpha1/leptonjob_types.go`, `json:"storage_attachments,omitempty"`), which reuses the same shared `StorageAttachment` type as endpoints. Parsing reuses `make_storage_attachments_from_strings()` from `spec_utils.py`, so flag syntax, merging of repeated flags by data source name, and error messages are identical to endpoint/pod.
- No translation-layer change: jobs POST directly to `/jobs` (`api/v2/job.py`) and don't go through the `/endpoints` + `/devpods` translation. `job_validation.py` is per-field and needs no change; the backend additionally validates attachments server-side (requires exactly one dedicated node group, `api-server/service/job/create.go`).

## Test plan
- [x] New unit tests in `leptonai/cli/tests/test_job_cli.py`: repeated flags merge into one `StorageAttachment` with multiple modes, field stays unset (`None`, omitted by `exclude_none`) when the flag isn't passed, and invalid `MODE` exits 1 without issuing a create call
- [x] `pytest leptonai/cli/tests/ leptonai/tests/test_job_validation.py leptonai/api/v2/tests/` — 204 passed
- [x] `ruff check` and `black --check` clean on all changed files
- [x] Verified `lep job create --help` renders the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)