### PR TITLE
fix(cli): harden list-nodes argument and lifecycle compatibility

### DIFF
--- a/leptonai/cli/node.py
+++ b/leptonai/cli/node.py
@@ -471,6 +471,13 @@ def _format_state_cell(node):
     return f"{value}\n[dim]stage: {stage}[/dim]\n{scheduling}"
 
 
+def _node_public_ip(spec):
+    """Return the public IP, including the legacy misspelled API field."""
+    if not spec:
+        return None
+    return getattr(spec, "public_ip", None) or getattr(spec, "public_op", None)
+
+
 def _format_network_cell(node):
     spec = node.spec
     hostname = (
@@ -478,7 +485,7 @@ def _format_network_cell(node):
         or (getattr(node.status, "hostname", None) if node.status else None)
         or "-"
     )
-    public_ip = (getattr(spec, "public_ip", None) if spec else None) or "-"
+    public_ip = _node_public_ip(spec) or "-"
     local_ip = (getattr(spec, "local_ip", None) if spec else None) or "-"
     return f"{hostname}\n[dim]public: {public_ip}[/dim]\n[dim]local: {local_ip}[/dim]"
 
@@ -510,17 +517,25 @@ def _merge_nodes_with_machines(nodes, machines):
             spec.provider_region = (
                 spec.provider_region or machine_status.provider_region
             )
-            spec.public_ip = spec.public_ip or machine_status.public_ip
+            if not _node_public_ip(spec):
+                spec.public_ip = machine_status.public_ip
             spec.local_ip = spec.local_ip or machine_status.private_ip
 
         status = node.status
+        node_status_values = {
+            value
+            for value in (
+                [getattr(status, "machine_status", None)]
+                + ((getattr(status, "status", None) or []) if status else [])
+            )
+            if value
+        }
+        is_leaving = bool(node_status_values.intersection(LEAVING_NODE_STATUS_VALUES))
+        if not status:
+            status = node.status = NodeStatus(status=[])
         if status and not status.hostname:
             status.hostname = machine_status.hostname
-        if (
-            status
-            and machine_status.status == "Failed"
-            and status.machine_status not in LEAVING_NODE_STATUS_VALUES
-        ):
+        if machine_status.status == "Failed" and not is_leaving:
             old_status = status.machine_status
             status.machine_status = "Failed"
             status.status = [
@@ -528,6 +543,8 @@ def _merge_nodes_with_machines(nodes, machines):
             ]
             if "Failed" not in status.status:
                 status.status.append("Failed")
+        elif not status.machine_status and not is_leaving:
+            status.machine_status = machine_status.status
 
         merged.append(node)
 
@@ -597,7 +614,7 @@ def _filter_nodes(
                 getattr(metadata, "name", None) if metadata else None,
                 getattr(status, "hostname", None) if status else None,
                 getattr(spec, "hostname", None) if spec else None,
-                getattr(spec, "public_ip", None) if spec else None,
+                _node_public_ip(spec),
                 getattr(spec, "local_ip", None) if spec else None,
                 getattr(spec, "gpu_clique_id", None) if spec else None,
                 getattr(spec, "provider", None) if spec else None,
@@ -670,6 +687,8 @@ def _filter_nodes(
 @click.option(
     "--search",
     "--keyword",
+    "-search",
+    "-keyword",
     "-q",
     "keyword",
     type=str,
@@ -681,6 +700,8 @@ def _filter_nodes(
 @click.option(
     "--label",
     "--labels",
+    "-label",
+    "-labels",
     "labels",
     type=str,
     multiple=True,

--- a/leptonai/cli/node.py
+++ b/leptonai/cli/node.py
@@ -254,12 +254,12 @@ def list_command(detail=False, node_group=None):
 
     For each node group this shows node health (healthy/error/total), whether it
     is Lepton-managed or customer BYOC, and the aggregated GPU/CPU/memory/disk
-    usage. For per-node detail, use 'lep node list-nodes <node-group>'.
+    usage. For per-node detail, use 'lep node list-nodes -ng <node-group>'.
     """
     if detail:
         console.print(
             "[yellow]Note:[/yellow] '-d/--detail' has been removed. For per-node"
-            " detail, use [bold]lep node list-nodes <node-group>[/bold].\n"
+            " detail, use [bold]lep node list-nodes -ng <node-group>[/bold].\n"
         )
 
     client = get_client()
@@ -683,7 +683,13 @@ def _filter_nodes(
 
 
 @node.command(name="list-nodes")
-@click.argument("name", type=str)
+@click.argument("name", type=str, required=False)
+@click.option(
+    "--node-group",
+    "-ng",
+    type=str,
+    help="Node group name or ID. Partial matching is supported (for example, 'h100').",
+)
 @click.option(
     "--search",
     "--keyword",
@@ -751,7 +757,8 @@ def _filter_nodes(
     help="Show only nodes with unschedulable=true.",
 )
 def list_nodes_command(
-    name,
+    name=None,
+    node_group=None,
     keyword=None,
     labels=(),
     statuses=(),
@@ -764,7 +771,8 @@ def list_nodes_command(
     """
     List the nodes under a node group with per-node resource detail.
 
-    NAME is the node group name or ID (partial match supported, e.g. 'h100').
+    Use --node-group/-ng to select a node group. Partial name/ID matching is
+    supported (for example, 'h100'). The positional NAME form is deprecated.
     For each node it shows name/ID/labels, provider/region/GPU clique ID,
     status/stage/scheduling state, resources, hostname, and public/local IPs.
 
@@ -772,7 +780,18 @@ def list_nodes_command(
     them together. Different filter categories and repeated label filters are
     combined with AND.
     """
-    node_groups = resolve_node_groups([name], is_exact_match=False)
+    if name:
+        ignored = " and is ignored" if node_group else ""
+        console.print(
+            "[yellow]Warning:[/yellow] Positional NODE_GROUP is deprecated"
+            f"{ignored}; use [green]--node-group/-ng[/green] instead."
+        )
+
+    node_group = node_group or name
+    if not node_group:
+        raise click.UsageError("Missing option '--node-group' / '-ng'.")
+
+    node_groups = resolve_node_groups([node_group], is_exact_match=False)
     if not node_groups:
         return
 

--- a/leptonai/cli/tests/test_node_cli.py
+++ b/leptonai/cli/tests/test_node_cli.py
@@ -27,6 +27,7 @@ from leptonai.api.v2.types.storage_permission import StoragePermission
 from leptonai.cli import lep as cli
 from leptonai.cli.node import (
     _filter_nodes,
+    _format_network_cell,
     _merge_nodes_with_machines,
     console as node_console,
     node,
@@ -1257,6 +1258,14 @@ def test_filter_nodes_unschedulable_only(nodes):
     assert [item.metadata.id_ for item in filtered] == ["node-2"]
 
 
+def test_legacy_public_op_is_displayed_and_searchable(nodes):
+    nodes[0].spec.public_ip = None
+    nodes[0].spec.public_op = "192.0.2.15"
+
+    assert "192.0.2.15" in _format_network_cell(nodes[0])
+    assert _filter_nodes(nodes, keyword="2.15") == [nodes[0]]
+
+
 def test_merge_nodes_with_machines_enriches_matching_node(nodes):
     nodes[0].spec.machine_id = "machine-1"
     nodes[0].spec.hostname = None
@@ -1281,6 +1290,35 @@ def test_merge_nodes_with_machines_enriches_matching_node(nodes):
     assert merged[0].status.status == ["Ready", "Failed"]
     assert nodes[0].spec.hostname is None
     assert nodes[0].status.machine_status == "Healthy"
+
+
+def test_merge_nodes_with_failed_machine_preserves_leaving_status(nodes):
+    nodes[0].spec.machine_id = "machine-1"
+    nodes[0].status.machine_status = None
+    nodes[0].status.status = ["Leaving"]
+    machine = Machine(
+        metadata=Metadata(name="machine-1"),
+        status=MachineStatus(machine_id="machine-1", status="Failed"),
+    )
+
+    merged = _merge_nodes_with_machines([nodes[0]], [machine])
+
+    assert merged[0].status.machine_status is None
+    assert merged[0].status.status == ["Leaving"]
+
+
+def test_merge_nodes_with_failed_machine_populates_missing_node_status(nodes):
+    nodes[0].spec.machine_id = "machine-1"
+    nodes[0].status = None
+    machine = Machine(
+        metadata=Metadata(name="machine-1"),
+        status=MachineStatus(machine_id="machine-1", status="Failed"),
+    )
+
+    merged = _merge_nodes_with_machines([nodes[0]], [machine])
+
+    assert merged[0].status.machine_status == "Failed"
+    assert merged[0].status.status == ["Failed"]
 
 
 def test_merge_nodes_with_machines_adds_provisioning_machine():
@@ -1372,6 +1410,36 @@ def test_list_nodes_command_applies_repeatable_filters(nodes):
     assert "node-3" not in result.output
 
 
+@pytest.mark.parametrize(
+    ("flag", "value", "expected"),
+    [
+        ("-search", "alpha", "Alpha-Node"),
+        ("-keyword", "alpha", "Alpha-Node"),
+        ("-q", "alpha", "Alpha-Node"),
+        ("-label", "env:dev", "Gamma-Node"),
+        ("-labels", "env:dev", "Gamma-Node"),
+    ],
+)
+def test_list_nodes_command_accepts_documented_single_dash_aliases(
+    nodes, monkeypatch, flag, value, expected
+):
+    node_group = SimpleNamespace(metadata=SimpleNamespace(name="gpu-group", id_="ng-1"))
+    client = SimpleNamespace(
+        nodegroup=SimpleNamespace(
+            list_nodes=Mock(return_value=nodes),
+            list_machines=Mock(return_value=[]),
+        )
+    )
+    monkeypatch.setattr(node_console, "width", 240)
+
+    with patch("leptonai.cli.node.resolve_node_groups", return_value=[node_group]):
+        with patch("leptonai.cli.node.get_client", return_value=client):
+            result = CliRunner().invoke(node, ["list-nodes", "gpu-group", flag, value])
+
+    assert result.exit_code == 0, result.output
+    assert expected in result.output
+
+
 def test_list_nodes_command_displays_webui_inventory_fields(nodes, monkeypatch):
     node_group = SimpleNamespace(metadata=SimpleNamespace(name="gpu-group", id_="ng-1"))
     client = SimpleNamespace(
@@ -1397,6 +1465,28 @@ def test_list_nodes_command_displays_webui_inventory_fields(nodes, monkeypatch):
         "10.0.0.10",
     ):
         assert value in result.output
+
+
+def test_list_nodes_command_warns_and_keeps_nodes_when_machines_fail(
+    nodes, monkeypatch
+):
+    node_group = SimpleNamespace(metadata=SimpleNamespace(name="gpu-group", id_="ng-1"))
+    client = SimpleNamespace(
+        nodegroup=SimpleNamespace(
+            list_nodes=Mock(return_value=[nodes[0]]),
+            list_machines=Mock(side_effect=RuntimeError("machines unavailable")),
+        )
+    )
+    monkeypatch.setattr(node_console, "width", 240)
+
+    with patch("leptonai.cli.node.resolve_node_groups", return_value=[node_group]):
+        with patch("leptonai.cli.node.get_client", return_value=client):
+            result = CliRunner().invoke(node, ["list-nodes", "gpu-group"])
+
+    assert result.exit_code == 0, result.output
+    assert "Warning:" in result.output
+    assert "machines unavailable" in result.output
+    assert "Alpha-Node" in result.output
 
 
 def test_list_nodes_command_rejects_unknown_status():

--- a/leptonai/cli/tests/test_node_cli.py
+++ b/leptonai/cli/tests/test_node_cli.py
@@ -1391,6 +1391,7 @@ def test_list_nodes_command_applies_repeatable_filters(nodes):
                 node,
                 [
                     "list-nodes",
+                    "--node-group",
                     "gpu-group",
                     "--status",
                     "Draining",
@@ -1408,6 +1409,51 @@ def test_list_nodes_command_applies_repeatable_filters(nodes):
     assert "node-2" in result.output
     assert "node-1" not in result.output
     assert "node-3" not in result.output
+
+
+@pytest.mark.parametrize("flag", ["--node-group", "-ng"])
+def test_list_nodes_command_accepts_node_group_option(flag):
+    resolve = Mock(return_value=[])
+
+    with patch("leptonai.cli.node.resolve_node_groups", resolve):
+        result = CliRunner().invoke(node, ["list-nodes", flag, "gpu-group"])
+
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with(["gpu-group"], is_exact_match=False)
+    assert "deprecated" not in result.output
+
+
+def test_list_nodes_command_deprecates_positional_node_group():
+    resolve = Mock(return_value=[])
+
+    with patch("leptonai.cli.node.resolve_node_groups", resolve):
+        result = CliRunner().invoke(node, ["list-nodes", "legacy-group"])
+
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with(["legacy-group"], is_exact_match=False)
+    assert "Positional NODE_GROUP is deprecated" in result.output
+    assert "--node-group/-ng" in result.output
+
+
+def test_list_nodes_command_node_group_option_wins_over_positional():
+    resolve = Mock(return_value=[])
+
+    with patch("leptonai.cli.node.resolve_node_groups", resolve):
+        result = CliRunner().invoke(
+            node,
+            ["list-nodes", "legacy-group", "-ng", "preferred-group"],
+        )
+
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with(["preferred-group"], is_exact_match=False)
+    assert "Positional NODE_GROUP is deprecated and is ignored" in result.output
+
+
+def test_list_nodes_command_requires_a_node_group():
+    result = CliRunner().invoke(node, ["list-nodes"])
+
+    assert result.exit_code == 2
+    assert "Missing option '--node-group' / '-ng'" in result.output
 
 
 @pytest.mark.parametrize(
@@ -1434,7 +1480,9 @@ def test_list_nodes_command_accepts_documented_single_dash_aliases(
 
     with patch("leptonai.cli.node.resolve_node_groups", return_value=[node_group]):
         with patch("leptonai.cli.node.get_client", return_value=client):
-            result = CliRunner().invoke(node, ["list-nodes", "gpu-group", flag, value])
+            result = CliRunner().invoke(
+                node, ["list-nodes", "-ng", "gpu-group", flag, value]
+            )
 
     assert result.exit_code == 0, result.output
     assert expected in result.output
@@ -1452,7 +1500,9 @@ def test_list_nodes_command_displays_webui_inventory_fields(nodes, monkeypatch):
 
     with patch("leptonai.cli.node.resolve_node_groups", return_value=[node_group]):
         with patch("leptonai.cli.node.get_client", return_value=client):
-            result = CliRunner().invoke(node, ["list-nodes", "gpu-group"])
+            result = CliRunner().invoke(
+                node, ["list-nodes", "--node-group", "gpu-group"]
+            )
 
     assert result.exit_code == 0, result.output
     for value in (
@@ -1481,7 +1531,9 @@ def test_list_nodes_command_warns_and_keeps_nodes_when_machines_fail(
 
     with patch("leptonai.cli.node.resolve_node_groups", return_value=[node_group]):
         with patch("leptonai.cli.node.get_client", return_value=client):
-            result = CliRunner().invoke(node, ["list-nodes", "gpu-group"])
+            result = CliRunner().invoke(
+                node, ["list-nodes", "--node-group", "gpu-group"]
+            )
 
     assert result.exit_code == 0, result.output
     assert "Warning:" in result.output
@@ -1491,7 +1543,8 @@ def test_list_nodes_command_warns_and_keeps_nodes_when_machines_fail(
 
 def test_list_nodes_command_rejects_unknown_status():
     result = CliRunner().invoke(
-        node, ["list-nodes", "gpu-group", "--status", "Unknown"]
+        node,
+        ["list-nodes", "--node-group", "gpu-group", "--status", "Unknown"],
     )
 
     assert result.exit_code == 2


### PR DESCRIPTION
## Summary

- add `--node-group` / `-ng` as the preferred node-group selector for `lep node list-nodes`
- deprecate the positional node-group argument while keeping it as a compatibility fallback; when both forms are supplied, the option value wins
- accept the documented single-dash keyword and label aliases
- display and search the legacy `public_op` public-IP field when `public_ip` is unavailable
- preserve leaving/terminating node lifecycle states when the machine reports `Failed`, and populate missing node status from machine data
- cover machine API fallback so existing nodes remain visible when machine details cannot be fetched

## Testing

- `uv run --frozen --extra test pytest -q leptonai/cli/tests --no-cov` (110 passed)
- `uv run --frozen --extra test pytest -q leptonai --ignore=leptonai/util/tests/test_s3cache.py --no-cov` (233 passed)
- `uv run --frozen --extra lint black --check leptonai/cli/node.py leptonai/cli/tests/test_node_cli.py`
- `uv run --frozen --extra lint ruff check leptonai/cli/node.py leptonai/cli/tests/test_node_cli.py`