### PR TITLE
feat(cli): add lep tui to install, update, and launch lep-tui

### DIFF
--- a/leptonai/cli/cli.py
+++ b/leptonai/cli/cli.py
@@ -29,6 +29,7 @@ from . import log
 from . import raycluster
 from . import template
 from . import finetune
+from . import tui
 
 from .util import click_group
 
@@ -78,6 +79,7 @@ log.add_command(lep)
 raycluster.add_command(lep)
 template.add_command(lep)
 finetune.add_command(lep)
+tui.add_command(lep)
 
 
 @lep.command()

--- a/leptonai/cli/tests/test_tui_cli.py
+++ b/leptonai/cli/tests/test_tui_cli.py
@@ -1,0 +1,243 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from leptonai.cli import lep
+from leptonai.cli.tui import _cli_auth_env
+
+
+def _completed(returncode: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(returncode=returncode)
+
+
+def _no_auth_env():
+    return patch("leptonai.cli.tui._cli_auth_env", return_value=None)
+
+
+def test_tui_command_is_registered():
+    result = CliRunner().invoke(lep, ["tui", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "lep-tui" in result.output
+
+
+def test_tui_installs_when_missing_then_launches_with_passthrough_args():
+    with (
+        patch("leptonai.cli.tui._find_tui_binary", return_value=None),
+        patch("leptonai.cli.tui._install_tui", return_value="/fake/lep-tui") as install,
+        patch("leptonai.cli.tui.subprocess.run", return_value=_completed()) as run,
+        _no_auth_env(),
+    ):
+        result = CliRunner().invoke(lep, ["tui", "--mock", "jobs"])
+
+    assert result.exit_code == 0, result.output
+    install.assert_called_once_with(None)
+    run.assert_called_once_with(
+        ["/fake/lep-tui", "--mock", "jobs"], check=False, env=None
+    )
+
+
+def test_tui_updates_before_launch_and_propagates_exit_code():
+    calls = []
+
+    def record(argv, check, **kwargs):
+        calls.append(argv)
+        return _completed(3 if len(calls) > 1 else 0)
+
+    with (
+        patch("leptonai.cli.tui._find_tui_binary", return_value="/fake/lep-tui"),
+        patch("leptonai.cli.tui.subprocess.run", side_effect=record),
+        _no_auth_env(),
+    ):
+        result = CliRunner().invoke(lep, ["tui"])
+
+    assert calls == [["/fake/lep-tui", "update"], ["/fake/lep-tui"]]
+    assert result.exit_code == 3, result.output
+
+
+def test_tui_no_update_skips_the_self_update():
+    with (
+        patch("leptonai.cli.tui._find_tui_binary", return_value="/fake/lep-tui"),
+        patch("leptonai.cli.tui.subprocess.run", return_value=_completed()) as run,
+        _no_auth_env(),
+    ):
+        result = CliRunner().invoke(lep, ["tui", "--no-update"])
+
+    assert result.exit_code == 0, result.output
+    run.assert_called_once_with(["/fake/lep-tui"], check=False, env=None)
+
+
+def test_tui_version_pin_flows_into_update_target():
+    with (
+        patch("leptonai.cli.tui._find_tui_binary", return_value="/fake/lep-tui"),
+        patch("leptonai.cli.tui.subprocess.run", return_value=_completed()) as run,
+        _no_auth_env(),
+    ):
+        result = CliRunner().invoke(lep, ["tui", "--tui-version", "0.1.0"])
+
+    assert result.exit_code == 0, result.output
+    assert run.call_args_list[0].args[0] == [
+        "/fake/lep-tui",
+        "update",
+        "--target",
+        "0.1.0",
+    ]
+
+
+def test_tui_version_pin_conflicts_with_no_update():
+    result = CliRunner().invoke(lep, ["tui", "--no-update", "--tui-version", "0.1.0"])
+
+    assert result.exit_code == 2, result.output
+    assert "--no-update" in result.output
+
+
+def test_tui_failed_update_still_launches():
+    calls = []
+
+    def record(argv, check, **kwargs):
+        calls.append(argv)
+        return _completed(1 if argv[-1] == "update" else 0)
+
+    with (
+        patch("leptonai.cli.tui._find_tui_binary", return_value="/fake/lep-tui"),
+        patch("leptonai.cli.tui.subprocess.run", side_effect=record),
+        _no_auth_env(),
+    ):
+        result = CliRunner().invoke(lep, ["tui"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [["/fake/lep-tui", "update"], ["/fake/lep-tui"]]
+    assert "self-update failed" in result.output
+
+
+def test_tui_installer_download_failure_mentions_the_network():
+    import requests
+
+    failing = Mock()
+    failing.RequestException = requests.RequestException
+    failing.get.side_effect = requests.RequestException("boom")
+    with (
+        patch("leptonai.cli.tui._find_tui_binary", return_value=None),
+        patch.dict("sys.modules", {"requests": failing}),
+    ):
+        result = CliRunner().invoke(lep, ["tui"])
+
+    assert result.exit_code == 1, result.output
+    assert "VPN" in result.output
+
+
+def test_tui_installer_uses_pinned_version_url_and_flag():
+    response = Mock()
+    response.text = "#!/bin/sh\nexit 0\n"
+    response.raise_for_status.return_value = None
+    fake_requests = Mock()
+    fake_requests.get.return_value = response
+    import requests
+
+    fake_requests.RequestException = requests.RequestException
+    with (
+        patch("leptonai.cli.tui._find_tui_binary", side_effect=[None, "/fake/lep-tui"]),
+        patch.dict("sys.modules", {"requests": fake_requests}),
+        patch("leptonai.cli.tui.subprocess.run", return_value=_completed()) as run,
+        _no_auth_env(),
+    ):
+        result = CliRunner().invoke(lep, ["tui", "--tui-version", "0.2.0-rc.1"])
+
+    assert result.exit_code == 0, result.output
+    fake_requests.get.assert_called_once_with(
+        "https://gitlab-master.nvidia.com/api/v4/projects/186903"
+        "/packages/generic/lep-tui/0.2.0-rc.1/install.sh",
+        timeout=15,
+    )
+    installer_argv = run.call_args_list[0].args[0]
+    assert installer_argv[0] == "sh"
+    assert installer_argv[2:] == ["--version", "0.2.0-rc.1"]
+    assert run.call_args_list[1].args[0] == ["/fake/lep-tui"]
+
+
+def _fake_record(workspace_id, token, url="https://gw.example.com/api/v2/x"):
+    record = Mock()
+    record.get_current_workspace_id.return_value = workspace_id
+    record.current.return_value = (
+        None
+        if workspace_id is None
+        else SimpleNamespace(auth_token=token, url=url, id_=workspace_id)
+    )
+    return record
+
+
+def test_cli_auth_env_projects_the_current_workspace():
+    record = _fake_record("ws1", "nvapi-secret")
+    with (
+        patch("leptonai.api.v2.workspace_record.WorkspaceRecord", record),
+        patch.dict(os.environ, {}, clear=False),
+    ):
+        os.environ.pop("LEPTON_WORKSPACE", None)
+        os.environ.pop("LEPTON_AUTH_TOKEN", None)
+        env = _cli_auth_env()
+
+    assert env == {
+        "LEPTON_WORKSPACE": "ws1",
+        "LEPTON_AUTH_TOKEN": "nvapi-secret",
+        "LEPTON_API_URL": "https://gw.example.com/api/v2/x",
+    }
+
+
+def test_cli_auth_env_refuses_unusable_states():
+    # A token shape lep-tui rejects must not be handed over.
+    with patch(
+        "leptonai.api.v2.workspace_record.WorkspaceRecord",
+        _fake_record("ws1", "legacy-token"),
+    ):
+        assert _cli_auth_env() is None
+    # No current workspace.
+    with patch(
+        "leptonai.api.v2.workspace_record.WorkspaceRecord",
+        _fake_record(None, None),
+    ):
+        assert _cli_auth_env() is None
+    # Caller-provided TUI variables win over projection.
+    with (
+        patch(
+            "leptonai.api.v2.workspace_record.WorkspaceRecord",
+            _fake_record("ws1", "nvapi-secret"),
+        ),
+        patch.dict(os.environ, {"LEPTON_AUTH_TOKEN": "nvapi-mine"}),
+    ):
+        assert _cli_auth_env() is None
+
+
+def test_tui_launches_with_projected_credentials():
+    overrides = {
+        "LEPTON_WORKSPACE": "ws1",
+        "LEPTON_AUTH_TOKEN": "nvapi-secret",
+        "LEPTON_API_URL": "https://gw.example.com/api/v2/x",
+    }
+    with (
+        patch("leptonai.cli.tui._find_tui_binary", return_value="/fake/lep-tui"),
+        patch("leptonai.cli.tui._cli_auth_env", return_value=dict(overrides)),
+        patch("leptonai.cli.tui.subprocess.run", return_value=_completed()) as run,
+    ):
+        result = CliRunner().invoke(lep, ["tui", "--no-update"])
+
+    assert result.exit_code == 0, result.output
+    assert "ws1" in result.output
+    launch_env = run.call_args.kwargs["env"]
+    for key, value in overrides.items():
+        assert launch_env[key] == value
+    assert "PATH" in launch_env  # merged over os.environ, not replacing it
+
+
+def test_tui_no_auth_skips_credential_projection():
+    with (
+        patch("leptonai.cli.tui._find_tui_binary", return_value="/fake/lep-tui"),
+        patch("leptonai.cli.tui._cli_auth_env") as project,
+        patch("leptonai.cli.tui.subprocess.run", return_value=_completed()) as run,
+    ):
+        result = CliRunner().invoke(lep, ["tui", "--no-update", "--no-auth"])
+
+    assert result.exit_code == 0, result.output
+    project.assert_not_called()
+    run.assert_called_once_with(["/fake/lep-tui"], check=False, env=None)

--- a/leptonai/cli/tui.py
+++ b/leptonai/cli/tui.py
@@ -1,0 +1,209 @@
+"""Launcher for lep-tui, the terminal UI for DGX Cloud Lepton.
+
+lep-tui is a standalone Bun-compiled binary released from the platform
+monorepo to a GitLab generic package registry that allows anonymous pulls
+(NVIDIA network or VPN required, no credentials). `lep tui` stays a thin
+orchestrator on purpose:
+
+- a first install runs the official ``install.sh`` so the blessed install
+  path (platform probe, checksum verification, macOS re-signing, atomic
+  rename into ``~/.local/bin``) has exactly one implementation, and
+- updates delegate to the binary's own ``lep-tui update``, which owns the
+  staging logic and the state behind ``lep-tui rollback``.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import click
+
+from .util import console
+
+# Keep in sync with apps/tui/scripts/install.sh and src/update/registry.ts in
+# the platform monorepo; its RELEASING.md lists the places this URL lives.
+TUI_REGISTRY_URL = (
+    "https://gitlab-master.nvidia.com/api/v4/projects/186903/packages/generic/lep-tui"
+)
+TUI_BINARY_NAME = "lep-tui"
+
+# lep-tui's environment contract (apps/tui src/auth/resolve.ts): the workspace
+# and token must be set together, and credentials arriving this way run an
+# ephemeral session — lep-tui never writes them into its own config file.
+TUI_ENV_WORKSPACE = "LEPTON_WORKSPACE"
+TUI_ENV_TOKEN = "LEPTON_AUTH_TOKEN"
+TUI_ENV_GATEWAY = "LEPTON_API_URL"
+# lep-tui refuses to start on a token without a gateway-routable prefix
+# (src/auth/credentials.ts), so such a token must not be handed over at all —
+# launching without it lands on the TUI's own login instead.
+TUI_TOKEN_PREFIXES = ("nvapi-", "lapi-")
+
+
+def _cli_auth_env() -> Optional[Dict[str, str]]:
+    """Project the CLI's current workspace into lep-tui's env contract.
+
+    Returns None when there is nothing safe to hand over: the caller already
+    exported the TUI's variables, no workspace is logged in, or the token is
+    of a shape lep-tui would refuse.
+    """
+    if TUI_ENV_WORKSPACE in os.environ or TUI_ENV_TOKEN in os.environ:
+        return None
+    from ..api.v2.workspace_record import WorkspaceRecord
+
+    workspace_id = WorkspaceRecord.get_current_workspace_id()
+    info = WorkspaceRecord.current()
+    if not workspace_id or info is None or not info.auth_token:
+        return None
+    if not info.auth_token.startswith(TUI_TOKEN_PREFIXES):
+        return None
+    overrides = {TUI_ENV_WORKSPACE: workspace_id, TUI_ENV_TOKEN: info.auth_token}
+    if info.url:
+        # A full workspace API URL is fine here: lep-tui normalizes it down
+        # to the gateway origin.
+        overrides[TUI_ENV_GATEWAY] = info.url
+    return overrides
+
+
+def _default_install_dir() -> Path:
+    return Path.home() / ".local" / "bin"
+
+
+def _find_tui_binary() -> Optional[str]:
+    """Locate lep-tui on PATH, falling back to the installer's default dir."""
+    found = shutil.which(TUI_BINARY_NAME)
+    if found:
+        return found
+    candidate = _default_install_dir() / TUI_BINARY_NAME
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
+
+
+def _install_tui(version: Optional[str]) -> str:
+    """Run the official installer and return the installed binary path."""
+    import requests
+
+    label = f"version {version}" if version else "the latest release"
+    source = (
+        f"{TUI_REGISTRY_URL}/{version}/install.sh"
+        if version
+        else f"{TUI_REGISTRY_URL}/latest/install.sh"
+    )
+    console.print(f"lep-tui is not installed; installing {label}...")
+    try:
+        response = requests.get(source, timeout=15)
+        response.raise_for_status()
+    except requests.RequestException as error:
+        raise click.ClickException(
+            f"Could not download the lep-tui installer from {source}"
+            f" ({error}). lep-tui is distributed on the NVIDIA network —"
+            " check your network or VPN."
+        )
+    handle = tempfile.NamedTemporaryFile(
+        "w", prefix="lep-tui-install.", suffix=".sh", delete=False
+    )
+    try:
+        with handle:
+            handle.write(response.text)
+        argv = ["sh", handle.name]
+        if version:
+            argv += ["--version", version]
+        completed = subprocess.run(argv, check=False)
+    finally:
+        os.unlink(handle.name)
+    if completed.returncode:
+        raise click.ClickException(
+            "The lep-tui installer failed; see its output above."
+        )
+    binary = _find_tui_binary()
+    if not binary:
+        raise click.ClickException(
+            f"The installer finished but {TUI_BINARY_NAME} was found neither"
+            f" on PATH nor in {_default_install_dir()}."
+        )
+    return binary
+
+
+def _update_tui(binary: str, version: Optional[str]) -> None:
+    """Self-update in place; a failure only skips the update, never the run."""
+    argv = [binary, "update"]
+    if version:
+        argv += ["--target", version]
+    completed = subprocess.run(argv, check=False)
+    if completed.returncode:
+        console.print(
+            "[yellow]lep-tui self-update failed; launching the installed"
+            " version.[/yellow]"
+        )
+
+
+@click.command(name="tui", context_settings={"ignore_unknown_options": True})
+@click.option(
+    "--no-update",
+    is_flag=True,
+    default=False,
+    help="Launch the installed lep-tui without the pre-launch update.",
+)
+@click.option(
+    "--tui-version",
+    help="Install or update to a specific lep-tui version (prereleases too).",
+)
+@click.option(
+    "--no-auth",
+    is_flag=True,
+    default=False,
+    help=(
+        "Do not sign lep-tui in as the CLI's current workspace; use"
+        " lep-tui's own logins."
+    ),
+)
+@click.argument("tui_args", nargs=-1, type=click.UNPROCESSED)
+def tui(
+    no_update: bool,
+    tui_version: Optional[str],
+    no_auth: bool,
+    tui_args: Tuple[str, ...],
+):
+    """Launch lep-tui, installing or updating it first.
+
+    lep-tui is the terminal UI for DGX Cloud Lepton. Installing and
+    updating needs the NVIDIA network or VPN but no credentials. When the
+    CLI is logged into a workspace, lep-tui starts signed in to it for
+    this session only. Unknown arguments are passed through, e.g. `lep
+    tui --mock` or `lep tui jobs`; use `--` before flags lep and lep-tui
+    both understand.
+    """
+    if sys.platform.startswith("win"):
+        raise click.UsageError(
+            "lep-tui ships macOS and Linux builds only; Windows is not supported."
+        )
+    if no_update and tui_version:
+        raise click.UsageError(
+            "--tui-version needs the install/update step; drop --no-update."
+        )
+    binary = _find_tui_binary()
+    if binary is None:
+        binary = _install_tui(tui_version)
+    elif not no_update:
+        _update_tui(binary, tui_version)
+    launch_env = None
+    if not no_auth:
+        overrides = _cli_auth_env()
+        if overrides:
+            console.print(
+                "Signing lep-tui in as the CLI's current workspace"
+                f" [green]{overrides[TUI_ENV_WORKSPACE]}[/] (session only;"
+                " lep-tui's own logins stay untouched)."
+            )
+            launch_env = {**os.environ, **overrides}
+    completed = subprocess.run([binary, *tui_args], check=False, env=launch_env)
+    if completed.returncode:
+        raise click.exceptions.Exit(completed.returncode)
+
+
+def add_command(cli_group: click.Group) -> None:
+    cli_group.add_command(tui)


### PR DESCRIPTION
## Summary

- New `lep tui` command: finds `lep-tui` (PATH, then `~/.local/bin`), installs it on first use by running the official `install.sh` from the GitLab generic package registry (anonymous pull, NVIDIA network/VPN), and launches it with all unknown arguments passed through (`lep tui --mock`, `lep tui jobs`).
- Before each launch it runs `lep-tui update` so the binary stays current; a failed update only skips the update and still launches the installed version. `--tui-version` installs/updates to a pinned release (prereleases included), `--no-update` skips the step.
- When the CLI is logged into a workspace, the launch projects the current workspace into lep-tui's environment contract (`LEPTON_WORKSPACE` / `LEPTON_AUTH_TOKEN` / `LEPTON_API_URL`), which lep-tui resolves as an **ephemeral** session — no login prompt, and lep-tui's own `~/.config/lepton/tui.json` is never written. Projection backs off when those variables are already exported, when no workspace is logged in, when the token shape is one lep-tui would reject, or with `--no-auth`.

Install and replacement logic deliberately stays in the TUI's own tooling (`install.sh`, `lep-tui update`/`rollback`) so it has exactly one implementation; this command is a thin orchestrator with no new dependencies.

## Test plan

- [x] 13 unit tests in `leptonai/cli/tests/test_tui_cli.py` (install/update/passthrough/exit-code propagation, credential projection and every back-off path)
- [x] E2E on macOS arm64: first run installed lep-tui 0.1.0 to `~/.local/bin` and launched it; second run hit the "up to date" update path; credential projection signed into the CLI's current workspace without a login prompt
- [x] ruff / black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)