### PR TITLE
fix(client): decode non-chunked streaming responses

### DIFF
--- a/leptonai/client.py
+++ b/leptonai/client.py
@@ -477,7 +477,8 @@ class Client(object):
         # use context to ensure that the response is properly closed.
         with ctx as res:  # type: ignore
             self._raise_for_detailed_status(res)
-            if res.headers.get("content-type", None) == "application/json":
+            content_type = res.headers.get("content-type", "").partition(";")[0].strip()
+            if content_type.lower() == "application/json":
                 # For a json response, we will return the json object directly,
                 # as it does not make sense to stream a json object.
                 res.read()
@@ -486,6 +487,7 @@ class Client(object):
                 yield True, None
                 yield from res.iter_bytes(chunk_size=self.chunk_size)
             else:
+                res.read()
                 yield False, res.content
 
     def _get_proper_res_content(self, res: httpx.Response):

--- a/leptonai/tests/test_client_response_decoding.py
+++ b/leptonai/tests/test_client_response_decoding.py
@@ -1,0 +1,120 @@
+import httpx
+import pytest
+import respx
+
+from leptonai.client import Client
+
+
+BASE_URL = "https://deployment.example"
+
+
+@pytest.fixture
+def make_client():
+    clients = []
+
+    def _make_client(*, stream):
+        client = Client.__new__(Client)
+        client.url = BASE_URL
+        client.stream = stream
+        client.chunk_size = 2
+        client._session = httpx.Client()
+        clients.append(client)
+        return client
+
+    yield _make_client
+
+    for client in clients:
+        client._session.close()
+
+
+def test_decodes_buffered_binary_response(make_client):
+    client = make_client(stream=False)
+
+    with respx.mock:
+        respx.get(f"{BASE_URL}/data").mock(
+            return_value=httpx.Response(200, content=b"binary")
+        )
+
+        response = client._get("data")
+        assert client._get_proper_res_content(response) == b"binary"
+
+
+@pytest.mark.parametrize("has_content_length", [True, False])
+def test_decodes_non_chunked_streaming_binary_response(make_client, has_content_length):
+    client = make_client(stream=True)
+    response = (
+        httpx.Response(200, content=b"binary")
+        if has_content_length
+        else httpx.Response(200, stream=httpx.ByteStream(b"binary"))
+    )
+    assert ("content-length" in response.headers) is has_content_length
+
+    with respx.mock:
+        respx.get(f"{BASE_URL}/data").mock(return_value=response)
+
+        response = client._get("data")
+        assert client._get_proper_res_content(response) == b"binary"
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_decodes_json_content_type_with_charset(make_client, stream):
+    client = make_client(stream=stream)
+
+    with respx.mock:
+        respx.get(f"{BASE_URL}/data").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": "ok"},
+                headers={"content-type": "application/json; charset=utf-8"},
+            )
+        )
+
+        response = client._get("data")
+        assert client._get_proper_res_content(response) == {"result": "ok"}
+
+
+def test_decodes_exact_json_content_type(make_client):
+    client = make_client(stream=True)
+
+    with respx.mock:
+        respx.get(f"{BASE_URL}/data").mock(
+            return_value=httpx.Response(
+                200,
+                json={"result": "ok"},
+                headers={"content-type": "application/json"},
+            )
+        )
+
+        response = client._get("data")
+        assert client._get_proper_res_content(response) == {"result": "ok"}
+
+
+def test_preserves_chunked_streaming_response(make_client):
+    client = make_client(stream=True)
+
+    with respx.mock:
+        respx.get(f"{BASE_URL}/data").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"binary",
+                headers={"transfer-encoding": "chunked"},
+            )
+        )
+
+        response = client._get("data")
+        content = client._get_proper_res_content(response)
+        assert not isinstance(content, bytes)
+        assert b"".join(content) == b"binary"
+
+
+def test_preserves_streaming_http_error_details(make_client):
+    client = make_client(stream=True)
+
+    with respx.mock:
+        respx.get(f"{BASE_URL}/data").mock(
+            return_value=httpx.Response(400, json={"error": "invalid input"})
+        )
+
+        response = client._get("data")
+        with pytest.raises(httpx.HTTPStatusError, match="Detail: invalid input"):
+            client._get_proper_res_content(response)


### PR DESCRIPTION
`Client(stream=True)` raises `httpx.ResponseNotRead` for successful binary responses without `Transfer-Encoding: chunked`. Read the body before returning bytes from that existing decoder branch, and recognize JSON media types with parameters such as `application/json; charset=utf-8`. Chunked responses remain iterators.

The regression tests exercise real client code with HTTP transport mocked by RESPX. They cover fixed-length and unframed responses, buffered and streaming JSON, chunked iteration, and detailed HTTP errors.

Validation on Python 3.13.11:

- Regression tests: 4 failed / 4 passed on the base; 8 passed with this change.
- `pytest -q leptonai/tests`: 35 passed, with existing Pydantic deprecation warnings.
- Black, Ruff and `git diff --check` pass for the changed files.

The complete repository suite and live deployments were not tested. This is separate from the error-response path previously repaired by #504; it does not close #424.

AI disclosure: The patch, tests, and this description were prepared with AI assistance and have not yet been reviewed by a human.
