### PR TITLE
fix(api): handle absent auth tokens during client setup

### DIFF
--- a/leptonai/api/v2/client.py
+++ b/leptonai/api/v2/client.py
@@ -299,11 +299,16 @@ class APIClient(object):
             # print(f"workspace_origin_url: {workspace_origin_url}")
             self._header["origin"] = workspace_origin_url
 
+        masked_auth_token = (
+            f"{self.auth_token[:2]}****{self.auth_token[-2:]}"
+            if self.auth_token
+            else None
+        )
         logger.trace(
             "Current workspace info:\n"
             f"  id: {self.workspace_id}\n"
             f"  url: {self.url}\n"
-            f"  auth_token: {self.auth_token[:2]}****{self.auth_token[-2:]}\n"
+            f"  auth_token: {masked_auth_token}\n"
             f"  workspace_origin_url: {self.workspace_origin_url}"
         )
 

--- a/leptonai/api/v2/tests/test_client_optional_token.py
+++ b/leptonai/api/v2/tests/test_client_optional_token.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+from leptonai.api.v2.client import APIClient
+from leptonai.api.v2.workspace_record import WorkspaceRecord
+
+
+def test_client_allows_missing_optional_auth_token(monkeypatch):
+    monkeypatch.delenv("LEPTON_WORKSPACE_TOKEN", raising=False)
+
+    with patch.object(WorkspaceRecord, "has", return_value=False):
+        client = APIClient(
+            workspace_id="public-workspace",
+            auth_token=None,
+            url="https://api.example",
+        )
+
+    try:
+        assert client.auth_token is None
+        assert "Authorization" not in client._header
+    finally:
+        client._session.close()
+
+
+def test_client_keeps_auth_token_masked_in_trace(monkeypatch):
+    monkeypatch.delenv("LEPTON_WORKSPACE_TOKEN", raising=False)
+
+    with (
+        patch.object(WorkspaceRecord, "has", return_value=False),
+        patch("leptonai.api.v2.client.logger.trace") as trace,
+    ):
+        client = APIClient(
+            workspace_id="private-workspace",
+            auth_token="secret-token",
+            url="https://api.example",
+        )
+
+    try:
+        message = trace.call_args.args[0]
+        assert "se****en" in message
+        assert "secret-token" not in message
+    finally:
+        client._session.close()


### PR DESCRIPTION
`APIClient` accepts an optional auth token and already omits `Authorization` when no token resolves. Its trace message nevertheless slices the missing token, so constructing the client raises `TypeError` even when trace logging is disabled.

Build the masked trace value only when a token exists. The tests invoke the real constructor and check tokenless headers and preserved masking for an explicit token.

Validation on Python 3.13.11:

- Regression: 1 failed / 1 passed on the base; 2 passed with the fix.
- Black, Ruff, and `git diff --check` pass.

The full repository suite and live services were not tested. A broader API dispatch run reached 48 passing tests before a CLI import failed because this local environment lacks `ray`; that broader run was not compared against the base.

AI disclosure: The patch, tests, and this description were prepared with AI assistance and have not yet been reviewed by a human.
