### PR TITLE
fix(api): preserve case-insensitive header overrides

### DIFF
--- a/leptonai/api/v2/client.py
+++ b/leptonai/api/v2/client.py
@@ -621,9 +621,10 @@ class APIClient(object):
         """
         kwargs.setdefault("headers", self._header)
         kwargs.setdefault("timeout", self._timeout)
-        # if kwargs does have headers, but does not have Authorization, we will add it.
+        header_names = {name.casefold() for name in kwargs["headers"]}
         for k, v in self._header.items():
-            kwargs["headers"].setdefault(k, v)
+            if k.casefold() not in header_names:
+                kwargs["headers"][k] = v
         return kwargs
 
     def _get(self, path: str, *args, **kwargs):

--- a/leptonai/api/v2/tests/test_client_request_headers.py
+++ b/leptonai/api/v2/tests/test_client_request_headers.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+import responses
+
+from leptonai.api.v2.client import APIClient
+from leptonai.api.v2.workspace_record import WorkspaceRecord
+
+
+BASE_URL = "https://api.example"
+
+
+def make_client():
+    with patch.object(WorkspaceRecord, "has", return_value=False):
+        return APIClient(
+            workspace_id="workspace",
+            auth_token="default-token",
+            url=BASE_URL,
+            workspace_origin_url="https://workspace.example",
+        )
+
+
+@responses.activate
+def test_request_preserves_case_insensitive_header_overrides():
+    client = make_client()
+    responses.get(f"{BASE_URL}/resource", json={})
+
+    try:
+        client._get(
+            "/resource",
+            headers={
+                "authorization": "Bearer override-token",
+                "Origin": "https://override.example",
+            },
+        )
+
+        request_headers = responses.calls[0].request.headers
+        assert request_headers["Authorization"] == "Bearer override-token"
+        assert request_headers["Origin"] == "https://override.example"
+    finally:
+        client._session.close()
+
+
+@responses.activate
+def test_request_adds_default_headers_to_custom_headers():
+    client = make_client()
+    responses.get(f"{BASE_URL}/resource", json={})
+
+    try:
+        client._get("/resource", headers={"X-Request-ID": "request-id"})
+
+        request_headers = responses.calls[0].request.headers
+        assert request_headers["Authorization"] == "Bearer default-token"
+        assert request_headers["Origin"] == "https://workspace.example"
+        assert request_headers["X-Request-ID"] == "request-id"
+    finally:
+        client._session.close()


### PR DESCRIPTION
## Summary

- preserve request-specific headers when their casing differs from API client defaults
- continue adding the workspace Authorization and Origin defaults when callers omit them
- cover the behavior at the prepared HTTP request boundary

HTTP header names are case-insensitive, but `_safe_add` previously used `dict.setdefault`. A request containing `authorization: Bearer override-token` therefore also received `Authorization: Bearer default-token`, and `requests` sent the later default value after normalizing the duplicate names. Comparing header names case-insensitively keeps the explicit request override intact.

## Testing

- Base regression: 1 failed, 1 passed.
- Focused request-header tests: 2 passed with the fix.
- Related v2 translation/auth/header tests: 68 passed.
- Black, Ruff, and `git diff --check` pass.

The complete v2 test collection was blocked locally by the optional `ray` dependency. The failing collection path imports `leptonai.cli.raycluster` and is unrelated to the changed request header merge.

## AI disclosure

This change and its tests were prepared with AI assistance. Human review has not yet occurred.
