### PR TITLE
fix(api): serialize job models on update

### DIFF
--- a/leptonai/api/v2/job.py
+++ b/leptonai/api/v2/job.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Iterator, Optional
+from typing import Union, List, Iterator, Optional, Dict, Any
 
 from .api_resource import APIResourse
 from .job_validation import validate_job_create
@@ -99,8 +99,13 @@ class JobAPI(APIResourse):
         )
         return self.ensure_type(response, LeptonJob)
 
-    def update(self, name_or_job: Union[str, LeptonJob], spec: LeptonJob) -> bool:
-        response = self._patch(f"/jobs/{self._to_id(name_or_job)}", json=spec)
+    def update(
+        self,
+        name_or_job: Union[str, LeptonJob],
+        spec: Union[LeptonJob, Dict[str, Any]],
+    ) -> bool:
+        payload = self.safe_json(spec) if isinstance(spec, LeptonJob) else spec
+        response = self._patch(f"/jobs/{self._to_id(name_or_job)}", json=payload)
         return self.ensure_ok(response)
 
     def delete(

--- a/leptonai/api/v2/tests/test_job_update.py
+++ b/leptonai/api/v2/tests/test_job_update.py
@@ -1,0 +1,50 @@
+import os
+import tempfile
+import json
+
+import requests
+import responses
+
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+from leptonai.api.v2.client import APIClient
+from leptonai.api.v2.job import JobAPI
+from leptonai.api.v2.types.common import Metadata
+from leptonai.api.v2.types.job import LeptonJob
+
+
+def _job_api() -> JobAPI:
+    client = APIClient.__new__(APIClient)
+    client.url = "https://workspace.example/api/v1"
+    client._header = {}
+    client._timeout = 120
+    client._session = requests.Session()
+    return JobAPI(client)
+
+
+@responses.activate
+def test_update_serializes_job_model():
+    responses.patch(
+        "https://workspace.example/api/v1/jobs/job-1",
+        json={},
+        status=200,
+    )
+
+    job = LeptonJob(metadata=Metadata(id="job-1"))
+
+    assert _job_api().update("job-1", job)
+    body = json.loads(responses.calls[0].request.body)
+    assert body["metadata"]["id"] == "job-1"
+
+
+@responses.activate
+def test_update_preserves_partial_dict_payload():
+    responses.patch(
+        "https://workspace.example/api/v1/jobs/job-1",
+        json={},
+        status=200,
+    )
+    payload = {"spec": {"stopped": True}}
+
+    assert _job_api().update("job-1", payload)
+    assert json.loads(responses.calls[0].request.body) == payload


### PR DESCRIPTION
`JobAPI.update` accepts a `LeptonJob`, but passed that Pydantic model directly
to `requests` as the JSON body. SDK callers therefore hit `TypeError: Object of
type LeptonJob is not JSON serializable` before any PATCH was sent.

Serialize model inputs through the API resource's existing `safe_json` path
while preserving the partial dictionary payloads used by the CLI's start/stop
commands.

Validation on Python 3.13.11:

- Regression: 1 failed / 1 passed on the base; 2 passed with the fix.
- Job update and validation tests: 18 passed.
- Black, Ruff, compileall, and `git diff --check` pass.

The complete repository suite and live workspace API were not tested. The
broader API v2 run reached 115 passing tests before one test imported the CLI
and failed because the local environment lacks the optional `ray` dependency.

AI disclosure: The patch, tests, and this description were prepared with AI
assistance and have not yet been reviewed by a human.
