### PR TITLE
fix(api): decode job list response envelopes

### DIFF
--- a/leptonai/api/v2/job.py
+++ b/leptonai/api/v2/job.py
@@ -77,7 +77,7 @@ class JobAPI(APIResourse):
             "query": pattern,
         }
         responses = self._get("/jobs", params=params)
-        return self.ensure_list(responses, LeptonJob)
+        return self.ensure_list(responses, LeptonJob, list_key="jobs")
 
     def create(self, spec: LeptonJob) -> LeptonJob:
         """

--- a/leptonai/api/v2/tests/test_job_api_regressions.py
+++ b/leptonai/api/v2/tests/test_job_api_regressions.py
@@ -1,0 +1,38 @@
+import json
+from types import SimpleNamespace
+
+from requests import Response
+
+from leptonai.api.v2.job import JobAPI
+
+
+def _response(payload):
+    response = Response()
+    response.status_code = 200
+    response._content = json.dumps(payload).encode()
+    response.headers["Content-Type"] = "application/json"
+    return response
+
+
+def _resource_client(get):
+    return SimpleNamespace(
+        _get=get,
+        _post=lambda *args, **kwargs: None,
+        _put=lambda *args, **kwargs: None,
+        _patch=lambda *args, **kwargs: None,
+        _delete=lambda *args, **kwargs: None,
+        _head=lambda *args, **kwargs: None,
+    )
+
+
+def test_list_matching_decodes_enveloped_job_response():
+    calls = []
+
+    def get(path, **kwargs):
+        calls.append((path, kwargs))
+        return _response({"jobs": [{"metadata": {"id": "job-123"}}]})
+
+    jobs = JobAPI(_resource_client(get)).list_matching("team=platform")
+
+    assert [job.metadata.id_ for job in jobs] == ["job-123"]
+    assert calls == [("/jobs", {"params": {"query": "team=platform"}})]


### PR DESCRIPTION
`JobAPI.list_matching()` queries the same paginated `/jobs` endpoint as
`list_all()`, but decoded the response as a bare list. Current responses wrap
jobs under a `jobs` key, so the SDK iterated the key string, emitted a parsing
warning, and silently returned an empty result even when jobs matched.

Decode the `jobs` envelope through the API resource's existing `ensure_list`
support. Bare-list responses remain supported by that helper.

Validation on Python 3.13.11:

- Regression: 1 failed on the base, 1 passed with the fix.
- Job API and validation tests: 17 passed, including 70 subtests.
- Black, Ruff, compileall, and `git diff --check` pass.

The complete repository suite and a live workspace API were not tested. The
broader API v2 collection is blocked in this local environment by missing
`responses` and `ray` dependencies. Two existing Pydantic deprecation warnings
remain unchanged.

AI disclosure: The patch, tests, and this description were prepared with AI
assistance and have not yet been reviewed by a human.
