### PR TITLE
fix(api): handle missing workspace token expiry

### DIFF
--- a/leptonai/api/v2/tests/test_workspace_record_regressions.py
+++ b/leptonai/api/v2/tests/test_workspace_record_regressions.py
@@ -1,0 +1,13 @@
+from unittest import mock
+
+import pytest
+
+from leptonai.api.v2.workspace_record import WorkspaceRecord, _LocalWorkspaceRecord
+
+
+@pytest.mark.parametrize("workspace_id", [None, "missing-workspace"])
+def test_refresh_token_expiry_returns_none_for_missing_workspace(workspace_id):
+    with mock.patch.object(
+        WorkspaceRecord, "_singleton_record", _LocalWorkspaceRecord()
+    ):
+        assert WorkspaceRecord.refresh_token_expires_at(workspace_id) is None

--- a/leptonai/api/v2/workspace_record.py
+++ b/leptonai/api/v2/workspace_record.py
@@ -301,18 +301,11 @@ class WorkspaceRecord(object):
     ) -> Optional[int]:
         workspace_id = workspace_id if workspace_id else cls.get_current_workspace_id()
 
-        skip_flag = (
-            skip_if_token_exists
-            or workspace_id is None
-            or not cls.has(workspace_id)
-            or cls.get(workspace_id).token_expires_at is not None
-        )
-        if skip_flag:
-            return cls.get(workspace_id).token_expires_at
-
         info = cls.get(workspace_id)
         if not info:
             return None
+        if skip_if_token_exists or info.token_expires_at is not None:
+            return info.token_expires_at
         try:
             token_expires_at = _get_token_expires_at(
                 workspace_id,


### PR DESCRIPTION
`WorkspaceRecord.refresh_token_expires_at()` promises an optional expiry, but
raises `AttributeError` when there is no current workspace or when callers pass
an unknown workspace ID. Its missing-record conditions enter an early-return
branch that still dereferences the absent record.

Resolve the record once and return `None` when it does not exist. Cached-expiry
and skip-refresh behavior for existing records is unchanged.

Validation on Python 3.13.11:

- Regression: 2 failed on the base, 2 passed with the fix.
- Black, Ruff, compileall, and `git diff --check` pass.

The workspace CLI suite was attempted but could not be collected because the
local test environment lacks the `ray` dependency. The complete repository
suite and a live workspace API were not tested. Two existing Pydantic
deprecation warnings remain unchanged.

AI disclosure: The patch, tests, and this description were prepared with AI
assistance and have not yet been reviewed by a human.
