### PR TITLE
feat(cli): adaptive parallel log retrieval for lep log get

### DIFF
--- a/leptonai/api/v2/log.py
+++ b/leptonai/api/v2/log.py
@@ -1,10 +1,92 @@
-from typing import Union
+from typing import Any, Dict, Optional, Union
 
 from leptonai.api.v2.api_resource import APIResourse
 from leptonai.api.v2.types.deployment import LeptonDeployment
 from leptonai.api.v2.types.job import LeptonJob
 from leptonai.api.v2.types.replica import Replica
 from leptonai.api.v2.types.job import LeptonJobQueryMode
+
+
+class LogAPIError(RuntimeError):
+    """Structured error raised by `LogAPI.get_log` on any non-2xx `/logs` response.
+
+    A `RuntimeError` subclass so `str(e)` and exception-handling behavior for
+    every existing non-429 caller (the probe, the LEGACY path,
+    `_fetch_log_unit`'s generic `except Exception` branch) is unchanged from
+    today's bare `RuntimeError`. `status_code`/`retry_after` are new,
+    additive attributes callers may optionally inspect.
+    """
+
+    def __init__(
+        self, message: str, status_code: int, retry_after: Optional[float] = None
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        # Seconds, parsed from the response's `Retry-After` header when present
+        # and in delay-in-seconds form; `None` otherwise.
+        self.retry_after = retry_after
+
+
+def _is_epoch_zero(value) -> bool:
+    """Whether `value` represents an epoch timestamp of zero.
+
+    Matches the Python `int` `0`, or a `str` that parses via `int(...)`
+    (after stripping whitespace) to `0` -- e.g. `"0"`, `"00"`, `" 0 "`.
+    Deliberately uses `int(...)` rather than `float(...)`, so a value like
+    `"0.0"` is not treated as zero, and a non-numeric string is not either
+    (a `ValueError` from `int(...)` means "not zero", it is not caught and
+    reinterpreted). Any other type is never treated as zero.
+    """
+    if isinstance(value, int):
+        return value == 0
+    if isinstance(value, str):
+        try:
+            return int(value.strip()) == 0
+        except ValueError:
+            return False
+    return False
+
+
+def _to_epoch_int(value) -> Optional[int]:
+    """Best-effort coercion of a start/end value to int for comparison.
+
+    Mirrors `_is_epoch_zero`'s `str`-vs-`int` handling: returns `value`
+    unchanged for a Python `int`; for a `str`, returns `int(value.strip())`
+    if that parses without raising; otherwise (including any other type)
+    returns `None`. A `None` result means "cannot be safely compared as an
+    epoch integer" -- callers must treat that as "skip this check", never
+    raise from the coercion itself.
+    """
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_retry_after(response) -> Optional[float]:
+    """Parse a `Retry-After` header's delay-in-seconds form, if present.
+
+    Only the integer delay-in-seconds form is parsed; an HTTP-date value is
+    treated as absent (`None`), since it is not the form Loki's rate-limit
+    middleware sends in practice. A parsed value that is non-positive
+    (<= 0) is also treated as absent, the same as an unparseable value --
+    it is not a usable delay, and passing it through would let a
+    server-supplied negative value reach a caller's sleep/wait call.
+    """
+    header_value = response.headers.get("Retry-After")
+    if header_value is None:
+        return None
+    try:
+        parsed = float(int(header_value))
+    except (TypeError, ValueError):
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
 
 
 class LogAPI(APIResourse):
@@ -108,18 +190,46 @@ class LogAPI(APIResourse):
         limit: int = 5000,
         q: str = "",
         job_query_mode: str = "alive_and_archive",
-    ) -> str:
+        direction: str = "backward",
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """
+        Args:
+            timeout: optional per-request timeout in seconds, passed through
+                to the underlying HTTP GET. When omitted (the default),
+                behavior is unchanged: the client's normal request timeout
+                (`self._client._timeout`, 120s) applies. Existing callers
+                that do not pass `timeout` are unaffected.
+        """
         query_kwargs = {}
-        if start and end:
+        # `is not None` (not truthiness) checks distinguish "not provided"
+        # from a literal 0. A literal 0 is rejected below rather than
+        # forwarded, since the /logs API cannot distinguish it from omitted.
+        if _is_epoch_zero(start) or _is_epoch_zero(end):
+            raise RuntimeError(
+                "start=0/end=0 cannot be distinguished from an omitted"
+                " start/end by the /logs API - pass a non-zero epoch"
+                " timestamp, or omit both start and end for the default"
+                " range."
+            )
+        start_int = _to_epoch_int(start)
+        end_int = _to_epoch_int(end)
+        if (start_int is not None and start_int < 0) or (
+            end_int is not None and end_int < 0
+        ):
+            raise RuntimeError("start/end must be a non-negative epoch timestamp")
+        if start is not None and end is not None:
+            if start_int is not None and end_int is not None and end_int <= start_int:
+                raise RuntimeError("end must be after start for historical logs")
             query_kwargs["start"] = start
             query_kwargs["end"] = end
             query_kwargs["timestamps"] = True
-            query_kwargs["direction"] = "backward"
+            query_kwargs["direction"] = direction
             query_kwargs["limit"] = limit
             query_kwargs["q"] = q
             if job_query_mode:
                 query_kwargs["job_query_mode"] = job_query_mode
-        elif start or end:
+        elif (start is not None) != (end is not None):
             raise RuntimeError(
                 "For historical logs, both start or end must be specified"
             )
@@ -148,13 +258,15 @@ class LogAPI(APIResourse):
             replica_id = replica if isinstance(replica, str) else replica.metadata.id_
             query_kwargs["replica"] = replica_id
 
-        response = self._get(
-            "/logs",
-            params=query_kwargs,
-        )
+        get_kwargs = {"params": query_kwargs}
+        if timeout is not None:
+            get_kwargs["timeout"] = timeout
+        response = self._get("/logs", **get_kwargs)
         if not response.ok:
-            raise RuntimeError(
+            raise LogAPIError(
                 f"API call failed with status code {response.status_code}. Details:"
-                f" {response.text}"
+                f" {response.text}",
+                status_code=response.status_code,
+                retry_after=_parse_retry_after(response),
             )
         return response.json()

--- a/leptonai/api/v2/tests/test_log_api.py
+++ b/leptonai/api/v2/tests/test_log_api.py
@@ -1,0 +1,429 @@
+"""Unit tests for LogAPI.get_log's `direction` parameter.
+
+These construct a LogAPI instance directly with a fake `_client` exposing a
+mocked `_get`, avoiding a real HTTP call, and assert on the `params` dict
+`_get` was called with -- i.e. the request shape LogAPI builds, not the
+network layer itself.
+"""
+
+import os
+import tempfile
+
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from leptonai.api.v2.client import APIClient
+from leptonai.api.v2.log import LogAPI, LogAPIError
+
+
+class _FakeResponse:
+    def __init__(self, payload, ok=True, status_code=200, text="", headers=None):
+        self.ok = ok
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.headers = headers or {}
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self):
+        self.new_deployment_api_enabled = False
+        self._get = MagicMock(return_value=_FakeResponse({"data": {"result": []}}))
+        self._post = MagicMock()
+        self._put = MagicMock()
+        self._patch = MagicMock()
+        self._delete = MagicMock()
+        self._head = MagicMock()
+
+
+class TestLogAPIDirection(unittest.TestCase):
+    def setUp(self):
+        self.client = _FakeClient()
+        self.log_api = LogAPI(self.client)
+
+    def test_default_direction_is_backward(self):
+        """Omitting `direction` preserves today's default."""
+        self.log_api.get_log(name_or_deployment="dep-1", start=100, end=200)
+
+        _, kwargs = self.client._get.call_args
+        params = kwargs["params"]
+        self.assertEqual(params["direction"], "backward")
+        self.assertEqual(params["start"], 100)
+        self.assertEqual(params["end"], 200)
+
+    def test_explicit_forward_direction_is_honored(self):
+        """explicit direction="forward" is sent through."""
+        self.log_api.get_log(
+            name_or_deployment="dep-1", start=100, end=200, direction="forward"
+        )
+
+        _, kwargs = self.client._get.call_args
+        params = kwargs["params"]
+        self.assertEqual(params["direction"], "forward")
+        self.assertEqual(params["start"], 100)
+        self.assertEqual(params["end"], 200)
+
+    def test_explicit_backward_direction_is_honored(self):
+        self.log_api.get_log(
+            name_or_deployment="dep-1", start=100, end=200, direction="backward"
+        )
+
+        _, kwargs = self.client._get.call_args
+        params = kwargs["params"]
+        self.assertEqual(params["direction"], "backward")
+
+    def test_start_end_are_passed_through_unchanged(self):
+        """[start, end) request-shape regression: start/end are sent verbatim."""
+        self.log_api.get_log(name_or_deployment="dep-1", start=12345, end=67890)
+
+        _, kwargs = self.client._get.call_args
+        params = kwargs["params"]
+        self.assertEqual(params["start"], 12345)
+        self.assertEqual(params["end"], 67890)
+
+
+class TestLogAPITimeout(unittest.TestCase):
+    """`get_log`'s optional `timeout` parameter, passed through to the
+    underlying HTTP GET when provided and omitted (falling back to the
+    client's own default) when not -- so existing callers that never pass
+    `timeout` see unchanged behavior.
+    """
+
+    def setUp(self):
+        self.client = _FakeClient()
+        self.log_api = LogAPI(self.client)
+
+    def test_timeout_omitted_by_default(self):
+        self.log_api.get_log(name_or_deployment="dep-1", start=100, end=200)
+
+        _, kwargs = self.client._get.call_args
+        self.assertNotIn("timeout", kwargs)
+
+    def test_explicit_timeout_is_passed_through(self):
+        self.log_api.get_log(name_or_deployment="dep-1", start=100, end=200, timeout=30)
+
+        _, kwargs = self.client._get.call_args
+        self.assertEqual(kwargs["timeout"], 30)
+
+    def test_explicit_timeout_does_not_affect_params(self):
+        """`timeout` is a request-transport kwarg, not a query param."""
+        self.log_api.get_log(name_or_deployment="dep-1", start=100, end=200, timeout=30)
+
+        _, kwargs = self.client._get.call_args
+        self.assertNotIn("timeout", kwargs["params"])
+
+
+class TestLogAPITimeoutReachesTransport(unittest.TestCase):
+    """Fix 2: closes the gap between "the `timeout` kwarg reaches
+    `LogAPI.get_log`" (`TestLogAPITimeout` above, mocked at the `get_log`
+    boundary) and "`get_log`'s actual HTTP request honors it". Mocks one
+    level below `get_log` -- `requests.Session.get`, via a real `APIClient`
+    (constructed with explicit credentials, so no env/login state or
+    network I/O is involved) and a real `LogAPI` wrapping it -- so a
+    regression that dropped `timeout` somewhere in `get_log` ->
+    `self._get` -> `APIClient._get` -> `self._session.get` would be caught
+    here even though it would not be caught by only asserting on `_get`.
+    """
+
+    def setUp(self):
+        self.client = APIClient(
+            workspace_id="test-workspace",
+            auth_token="test-token",
+            url="http://fake-workspace.example",
+        )
+        self.log_api = LogAPI(self.client)
+
+    def test_timeout_reaches_the_underlying_session_get_call(self):
+        fake_response = _FakeResponse({"data": {"result": []}})
+        with patch.object(
+            self.client._session, "get", return_value=fake_response
+        ) as mock_get:
+            self.log_api.get_log(
+                name_or_deployment="dep-1", start=100, end=200, timeout=42
+            )
+
+        self.assertEqual(mock_get.call_count, 1)
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["timeout"], 42)
+
+    def test_timeout_omitted_falls_back_to_client_default_at_transport(self):
+        fake_response = _FakeResponse({"data": {"result": []}})
+        with patch.object(
+            self.client._session, "get", return_value=fake_response
+        ) as mock_get:
+            self.log_api.get_log(name_or_deployment="dep-1", start=100, end=200)
+
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["timeout"], self.client._timeout)
+
+
+class TestLogAPIErrorContract(unittest.TestCase):
+    """`get_log` raises structured `LogAPIError` for any
+    non-2xx response, carrying `status_code`/`retry_after`; message text is
+    byte-for-byte identical to the pre-existing bare-`RuntimeError` message.
+    """
+
+    def setUp(self):
+        self.client = _FakeClient()
+        self.log_api = LogAPI(self.client)
+
+    def test_non_429_error_is_runtimeerror_compatible_with_identical_message(self):
+        self.client._get.return_value = _FakeResponse(
+            None, ok=False, status_code=500, text="internal error"
+        )
+        with self.assertRaises(LogAPIError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=1, end=200)
+        exc = cm.exception
+        self.assertIsInstance(exc, RuntimeError)
+        self.assertEqual(exc.status_code, 500)
+        self.assertEqual(
+            str(exc), "API call failed with status code 500. Details: internal error"
+        )
+
+    def test_429_threads_status_code_and_retry_after(self):
+        self.client._get.return_value = _FakeResponse(
+            None,
+            ok=False,
+            status_code=429,
+            text="rate limited",
+            headers={"Retry-After": "10"},
+        )
+        with self.assertRaises(LogAPIError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=1, end=200)
+        exc = cm.exception
+        self.assertEqual(exc.status_code, 429)
+        self.assertEqual(exc.retry_after, 10.0)
+
+    def test_429_without_retry_after_header_leaves_it_none(self):
+        self.client._get.return_value = _FakeResponse(
+            None, ok=False, status_code=429, text="rate limited", headers={}
+        )
+        with self.assertRaises(LogAPIError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=1, end=200)
+        self.assertIsNone(cm.exception.retry_after)
+
+    def test_http_date_retry_after_is_treated_as_absent(self):
+        """Only the delay-in-seconds form is parsed."""
+        self.client._get.return_value = _FakeResponse(
+            None,
+            ok=False,
+            status_code=429,
+            text="rate limited",
+            headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"},
+        )
+        with self.assertRaises(LogAPIError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=1, end=200)
+        self.assertIsNone(cm.exception.retry_after)
+
+    def test_negative_retry_after_is_treated_as_absent(self):
+        """A non-positive Retry-After is not a usable delay -- treated the
+        same as an unparseable value, never passed through as a negative
+        `retry_after`."""
+        self.client._get.return_value = _FakeResponse(
+            None,
+            ok=False,
+            status_code=429,
+            text="rate limited",
+            headers={"Retry-After": "-5"},
+        )
+        with self.assertRaises(LogAPIError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=1, end=200)
+        self.assertIsNone(cm.exception.retry_after)
+
+    def test_zero_retry_after_is_treated_as_absent(self):
+        self.client._get.return_value = _FakeResponse(
+            None,
+            ok=False,
+            status_code=429,
+            text="rate limited",
+            headers={"Retry-After": "0"},
+        )
+        with self.assertRaises(LogAPIError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=1, end=200)
+        self.assertIsNone(cm.exception.retry_after)
+
+    def test_positive_retry_after_still_parses(self):
+        self.client._get.return_value = _FakeResponse(
+            None,
+            ok=False,
+            status_code=429,
+            text="rate limited",
+            headers={"Retry-After": "3"},
+        )
+        with self.assertRaises(LogAPIError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=1, end=200)
+        self.assertEqual(cm.exception.retry_after, 3.0)
+
+
+class TestLogAPIEpochZeroRejected(unittest.TestCase):
+    """`start=0`/`end=0` are explicitly rejected, never silently passed
+    through to the /logs API or substituted with a default window."""
+
+    def setUp(self):
+        self.client = _FakeClient()
+        self.log_api = LogAPI(self.client)
+
+    def test_start_zero_with_valid_end_raises_and_makes_no_request(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(
+                name_or_deployment="dep-1",
+                start=0,
+                end=1_000_000_000,
+                direction="forward",
+            )
+        message = str(cm.exception)
+        self.assertNotIn("both start or end must be specified", message)
+        # The message must actually explain the epoch-zero/omitted
+        # ambiguity, not merely avoid colliding with the sibling message.
+        self.assertIn("cannot be distinguished", message)
+        self.assertIn("omitted", message)
+        self.client._get.assert_not_called()
+
+    def test_end_zero_with_valid_start_raises_and_makes_no_request(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=5, end=0)
+        message = str(cm.exception)
+        self.assertNotIn("both start or end must be specified", message)
+        self.assertIn("cannot be distinguished", message)
+        self.assertIn("omitted", message)
+        self.client._get.assert_not_called()
+
+    def test_only_start_provided_raises(self):
+        # Companion regression guard: the exactly-one-provided branch must
+        # raise its own distinct message, not be conflated with the
+        # epoch-zero rejection above.
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=5, end=None)
+        message = str(cm.exception)
+        self.assertIn("both start or end must be specified", message)
+        self.assertNotIn("cannot be distinguished", message)
+        self.client._get.assert_not_called()
+
+    def test_only_end_provided_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=None, end=5)
+        message = str(cm.exception)
+        self.assertIn("both start or end must be specified", message)
+        self.assertNotIn("cannot be distinguished", message)
+        self.client._get.assert_not_called()
+
+    def test_non_zero_start_and_end_are_not_rejected(self):
+        """Control case: the `start == 0 or end == 0` guard must only fire
+        on a literal zero, not on any other falsy-adjacent small value."""
+        self.log_api.get_log(
+            name_or_deployment="dep-1",
+            start=1,
+            end=1_000_000_000,
+            direction="forward",
+        )
+        _, kwargs = self.client._get.call_args
+        params = kwargs["params"]
+        self.assertEqual(params["start"], 1)
+        self.assertEqual(params["end"], 1_000_000_000)
+        self.assertIn("direction", params)
+        self.assertIn("limit", params)
+        self.assertIn("q", params)
+        self.assertIn("job_query_mode", params)
+
+    def test_neither_provided_omits_time_range_params(self):
+        self.log_api.get_log(name_or_deployment="dep-1")
+        _, kwargs = self.client._get.call_args
+        params = kwargs["params"]
+        self.assertNotIn("start", params)
+        self.assertNotIn("end", params)
+
+
+class TestLogAPIEndAfterStartAndNegativeRejected(unittest.TestCase):
+    """`end <= start` and negative `start`/`end` timestamps are rejected as
+    clear client-side errors, without changing the `start`/`end` type
+    annotation (both remain `str`).
+    """
+
+    def setUp(self):
+        self.client = _FakeClient()
+        self.log_api = LogAPI(self.client)
+
+    def test_end_equal_start_int_form_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(
+                name_or_deployment="dep-1", start=1_000_000_000, end=1_000_000_000
+            )
+        self.assertIn("end must be after start", str(cm.exception))
+        self.client._get.assert_not_called()
+
+    def test_end_before_start_int_form_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(
+                name_or_deployment="dep-1", start=1_000_000_000, end=500_000_000
+            )
+        self.assertIn("end must be after start", str(cm.exception))
+        self.client._get.assert_not_called()
+
+    def test_end_before_start_string_form_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(
+                name_or_deployment="dep-1", start="1000000000", end="500000000"
+            )
+        self.assertIn("end must be after start", str(cm.exception))
+        self.client._get.assert_not_called()
+
+    def test_negative_start_int_form_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(
+                name_or_deployment="dep-1", start=-1, end=1_000_000_000
+            )
+        self.assertIn("non-negative", str(cm.exception))
+        self.client._get.assert_not_called()
+
+    def test_negative_start_string_form_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(
+                name_or_deployment="dep-1", start="-1", end="1000000000"
+            )
+        self.assertIn("non-negative", str(cm.exception))
+        self.client._get.assert_not_called()
+
+    def test_negative_end_int_form_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(
+                name_or_deployment="dep-1", start=1_000_000_000, end=-1
+            )
+        self.assertIn("non-negative", str(cm.exception))
+        self.client._get.assert_not_called()
+
+    def test_negative_end_string_form_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(
+                name_or_deployment="dep-1", start="1000000000", end="-1"
+            )
+        self.assertIn("non-negative", str(cm.exception))
+        self.client._get.assert_not_called()
+
+    def test_negative_single_sided_start_raises_before_both_required_error(self):
+        # Only `start` provided (negative) -- the negative check must fire
+        # before the "both must be specified" mismatch check.
+        with self.assertRaises(RuntimeError) as cm:
+            self.log_api.get_log(name_or_deployment="dep-1", start=-1, end=None)
+        message = str(cm.exception)
+        self.assertIn("non-negative", message)
+        self.assertNotIn("both start or end must be specified", message)
+        self.client._get.assert_not_called()
+
+    def test_valid_ascending_non_negative_non_zero_pair_succeeds(self):
+        """Control case: an ordinary valid range is not over-tightened."""
+        self.log_api.get_log(
+            name_or_deployment="dep-1", start=1_000_000_000, end=2_000_000_000
+        )
+        _, kwargs = self.client._get.call_args
+        params = kwargs["params"]
+        self.assertEqual(params["start"], 1_000_000_000)
+        self.assertEqual(params["end"], 2_000_000_000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/cli/log.py
+++ b/leptonai/cli/log.py
@@ -1,6 +1,13 @@
+import contextlib
+import heapq
+import itertools
+import random
 import re
 import sys
+import threading
 import traceback
+from dataclasses import dataclass
+from typing import Callable, List, NoReturn, Optional, Tuple
 
 from loguru import logger
 from .util import _get_newest_job_by_name
@@ -8,6 +15,7 @@ from .util import click_group, console
 from .util import resolve_save_path, PathResolutionError
 
 from ..api.v2.client import APIClient
+from ..api.v2.log import LogAPIError
 
 import json
 import click
@@ -15,7 +23,11 @@ import time
 
 from datetime import datetime, timedelta, timezone
 from rich.progress import Progress
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    ThreadPoolExecutor,
+    wait,
+)
 
 str_time_format = "%Y-%m-%d %H:%M:%S.%f"
 str_date_format = "%Y-%m-%d"
@@ -168,9 +180,7 @@ def _epoch_to_time_str(nanoseconds, local_time=False):
     if isinstance(nanoseconds, str):
         nanoseconds = int(nanoseconds)
 
-    # Convert nanoseconds to seconds
     seconds = nanoseconds / 1e9
-    # Create an aware UTC datetime object
     if local_time:
         time_obj = datetime.fromtimestamp(seconds)
     else:
@@ -186,63 +196,1152 @@ def safe_load_json(string):
         return string
 
 
-def fetch_all_within_time_slot(
+########################################################################
+# Adaptive parallel log retrieval (no-`--limit` path)
+#
+# Work-queue / bisection scheduler: workers pull [start, end) intervals,
+# fetch forward, and only bisect the unscanned remainder of an interval
+# when a fetch saturates the per-request limit. See
+# docs/log-adaptive-fetch/spec.md for the full design.
+########################################################################
+
+# Per-request page size for the adaptive scheduler's forward fetches --
+# matches the LEGACY `--limit` path's existing request cap.
+_ADAPTIVE_PAGE_LIMIT = 10000
+
+# Maximum number of failed time ranges listed inline in the saved --path
+# file's footer. The full untruncated list still goes to the trace log.
+_FAILED_RANGES_FILE_CAP = 5
+
+# Per-request timeout for the adaptive scheduler's fetches, shorter than the
+# client's normal 120s default. Bounds how long a sink-failure-triggered
+# shutdown can be stalled waiting for a worker mid-HTTP-request.
+_ADAPTIVE_FETCH_TIMEOUT_SEC = 30
+
+# Retry policy for `_fetch_log_unit`'s per-unit fetch: up to 5 attempts,
+# exponential backoff starting at 1.0s (1/2/4/8s schedule), capped at 60s --
+# also the cap applied to a 429 response's `Retry-After` value.
+_ADAPTIVE_RETRY_MAX_ATTEMPTS = 5
+_ADAPTIVE_RETRY_BASE_DELAY_SEC = 1.0
+_ADAPTIVE_RETRY_AFTER_CAP_SEC = 60.0
+
+
+@dataclass(frozen=True)
+class LogEntry:
+    """A single fetched log record, canonicalized for hashing/equality.
+
+    `stream_labels`/`metadata` are sorted tuples (rather than dicts) so
+    `LogEntry` is hashable and has well-defined equality, which the
+    commit-watermark buffer's flush-time de-duplication relies on.
+    """
+
+    stream_labels: Tuple[Tuple[str, str], ...]
+    timestamp_ns: int
+    line: str
+    metadata: Tuple[Tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class WorkUnit:
+    """One schedulable half-open interval `[start, end)` (ns epoch).
+
+    `seq_id` is assigned in submission order (parent before its children,
+    left child before right child) from a counter allocated only by the
+    scheduler's owning thread, and doubles as the buffer's tie-break key.
+    """
+
+    seq_id: int
+    start: int
+    end: int
+
+    def __lt__(self, other: "WorkUnit") -> bool:
+        """Total order by `(start, seq_id)` for use as a `heapq` key.
+
+        Hand-written rather than `@dataclass(order=True)`, which would
+        compare fields in declaration order (`seq_id` before `start`) and
+        require reordering the fields, breaking existing positional
+        `WorkUnit(seq_id, start, end)` construction call sites.
+        """
+        return (self.start, self.seq_id) < (other.start, other.seq_id)
+
+
+@dataclass(frozen=True)
+class FetchUnitResult:
+    """Outcome of one single-unit forward fetch, produced by `_fetch_log_unit`."""
+
+    entries: List[LogEntry]
+    saturated: bool
+    min_ts: Optional[int]
+    max_ts: Optional[int]
+    failed: bool
+
+
+class _MalformedLogResponseError(Exception):
+    """Raised when a 2xx `/logs` response body doesn't match the expected
+    `data.result[].{stream,values}` shape, or a parsed entry's
+    `timestamp_ns` falls outside the requested `[start, end)`. Always caught
+    by `_fetch_log_unit`'s retry loop -- never reaches the scheduler
+    directly.
+    """
+
+
+class _WatermarkRegressionError(Exception):
+    """Raised when a recomputed commit watermark is less than
+    `self.last_watermark` -- a handled control-flow branch instead of a bare
+    `assert`, so a backend bug funnels into the same fail-fast shutdown as a
+    sink failure instead of an uncaught traceback.
+    """
+
+
+class _RateLimitSignal:
+    """Thread-safe shared 429 signal.
+
+    Workers call `signal(cooldown_seconds)` from `_fetch_log_unit` when they
+    observe a 429; the scheduler's owning thread calls `active()` from
+    `_submit_ready` before submitting new work.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._until = 0.0  # time.monotonic() deadline; 0.0 == inactive
+
+    def signal(self, cooldown_seconds: float) -> None:
+        with self._lock:
+            self._until = max(self._until, time.monotonic() + cooldown_seconds)
+
+    def active(self) -> bool:
+        with self._lock:
+            return time.monotonic() < self._until
+
+
+# A sink consumes entries in chronological order, as released by the commit
+# watermark; it must propagate any write failure by raising.
+EmitFn = Callable[[List[LogEntry]], None]
+
+
+_HASHABLE_SCALAR_TYPES = (str, int, float, bool, type(None))
+
+
+def _validate_positive_int_limit(limit: int) -> None:
+    """Raise `ValueError` unless `limit` is a positive `int`.
+
+    `limit` is an internal contract (always `_ADAPTIVE_PAGE_LIMIT` in
+    production), not backend data -- a violation is our own bug, so it's a
+    plain precondition failure, not `_MalformedLogResponseError`, and is
+    checked before any HTTP call so it is never retried as transient.
+    """
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+        raise ValueError(f"limit must be a positive int, got {limit!r}")
+
+
+def _validate_str_keys(d: dict, label: str) -> None:
+    """Raise `_MalformedLogResponseError` if any key in `d` is not a `str`.
+
+    Must run before `sorted(d.items())`: mixed/unorderable key types would
+    otherwise make `sorted()` raise a raw `TypeError` instead of the
+    diagnosable error every other validation failure here uses.
+    """
+    for key in d.keys():
+        if not isinstance(key, str):
+            raise _MalformedLogResponseError(
+                f"unsupported {label} key {key!r}: {type(key).__name__}"
+            )
+
+
+def _validate_hashable_scalar_values(d: dict, label: str) -> None:
+    """Raise `_MalformedLogResponseError` if any value in `d` is not a
+    hashable scalar (`str`/`int`/`float`/`bool`/`None`).
+
+    `LogEntry.stream_labels`/`metadata` must be hashable; an unhashable
+    value would otherwise parse successfully here and only fail later, when
+    the scheduler's flush-time dedup hashes the resulting `LogEntry`.
+    """
+    for key, value in d.items():
+        if not isinstance(value, _HASHABLE_SCALAR_TYPES):
+            raise _MalformedLogResponseError(
+                f"unsupported {label} value for key {key!r}:"
+                f" {type(value).__name__}: {value!r}"
+            )
+
+
+def _parse_log_entries(
+    log_dict, limit: int, start: int, end: int
+) -> Tuple[List[LogEntry], int]:
+    """Convert a Loki `query_range`-shaped response into `LogEntry` records,
+    retaining only the smallest-timestamp `limit` of them.
+
+    Combines each `data.result[i].stream` label dict with that entry's
+    `values` tuples (`[ts_ns, line]` or `[ts_ns, line, metadata_dict]`).
+    Every examined record is validated strictly, regardless of whether it
+    ends up retained: shape, `timestamp_ns` inside `[start, end)`, and
+    hashable stream/metadata values. Any deviation raises
+    `_MalformedLogResponseError` rather than silently defaulting or
+    dropping the record, which would make a malformed response
+    indistinguishable from a legitimately empty or partial one.
+
+    Retention is bounded to O(`limit`) additional memory via an incremental
+    max-heap (by timestamp) rather than materializing and sorting the full
+    response. This bound is about entries retained by this parser only --
+    `log_dict` has already been fully decoded into memory by the client
+    layer before reaching this function.
+
+    Returns `(retained, examined_count)`: `retained` holds at most `limit`
+    entries, sorted ascending by timestamp -- the true smallest-`limit`
+    records across the whole response. `examined_count` lets the caller
+    detect an oversized response.
+    """
+    _validate_positive_int_limit(limit)
+
+    if not isinstance(log_dict, dict):
+        raise _MalformedLogResponseError(
+            f"expected a dict response body, got {type(log_dict).__name__}"
+        )
+    data = log_dict.get("data")
+    if not isinstance(data, dict):
+        raise _MalformedLogResponseError("response missing/invalid 'data' key")
+    result = data.get("result")
+    if not isinstance(result, list):
+        raise _MalformedLogResponseError("response missing/invalid 'data.result' key")
+
+    # Bounded max-heap (by timestamp) of at most `limit` retained entries.
+    # `heap[0]` is always the current largest-timestamp retained entry --
+    # the eviction candidate -- since the key negates `timestamp_ns`.
+    heap: List[Tuple[int, int, LogEntry]] = []
+    insertion_index = 0
+    examined = 0
+
+    for item in result:
+        if not isinstance(item, dict):
+            raise _MalformedLogResponseError(
+                f"expected a dict result entry, got {type(item).__name__}"
+            )
+        stream = item.get("stream")
+        values = item.get("values")
+        if not isinstance(stream, dict) or not isinstance(values, list):
+            raise _MalformedLogResponseError(
+                "result entry missing/invalid 'stream' or 'values' key"
+            )
+        # Validated once per stream, not per record: `stream` is unchanged
+        # across this iteration's `values`.
+        _validate_str_keys(stream, "stream")
+        _validate_hashable_scalar_values(stream, "stream")
+        stream_labels = tuple(sorted(stream.items()))
+        for value in values:
+            if not isinstance(value, (list, tuple)) or len(value) not in (2, 3):
+                raise _MalformedLogResponseError(f"malformed values tuple: {value!r}")
+            # bool is an int subclass and float silently truncates under
+            # int() -- reject both explicitly rather than letting int()
+            # below coerce them into a wrong-but-valid-looking timestamp.
+            if isinstance(value[0], (bool, float)):
+                raise _MalformedLogResponseError(
+                    f"non-integer timestamp in values tuple: {value!r}"
+                )
+            try:
+                timestamp_ns = int(value[0])
+            except (TypeError, ValueError) as e:
+                raise _MalformedLogResponseError(
+                    f"non-integer timestamp in values tuple: {value!r}"
+                ) from e
+            if not (start <= timestamp_ns < end):
+                raise _MalformedLogResponseError(
+                    f"entry timestamp_ns={timestamp_ns} outside requested"
+                    f" range=[{start}, {end})"
+                )
+            line = value[1]
+            if not isinstance(line, str):
+                raise _MalformedLogResponseError(
+                    f"expected a str log line, got {type(line).__name__}: {line!r}"
+                )
+            metadata = ()
+            if len(value) == 3 and value[2] is not None and value[2] != {}:
+                # `None`/`{}` are the accepted "no metadata" forms; checked
+                # by content, not truthiness, so a wrong-typed-but-falsy
+                # value (`0`, `""`, `[]`) is still rejected below.
+                if not isinstance(value[2], dict):
+                    raise _MalformedLogResponseError(
+                        "malformed metadata: expected a dict, got"
+                        f" {type(value[2]).__name__}: {value[2]!r}"
+                    )
+                _validate_str_keys(value[2], "metadata")
+                _validate_hashable_scalar_values(value[2], "metadata")
+                metadata = tuple(sorted(value[2].items()))
+            entry = LogEntry(stream_labels, timestamp_ns, line, metadata)
+            examined += 1
+
+            if len(heap) < limit:
+                heapq.heappush(heap, (-timestamp_ns, insertion_index, entry))
+                insertion_index += 1
+            elif timestamp_ns < -heap[0][0]:
+                heapq.heapreplace(heap, (-timestamp_ns, insertion_index, entry))
+                insertion_index += 1
+
+    retained = [entry for _, _, entry in heap]
+    retained.sort(key=lambda e: e.timestamp_ns)
+    return retained, examined
+
+
+def _quiet_close(f) -> None:
+    """Best-effort-close an open file handle, never raising or printing.
+
+    Used by every early-exit-after-failure path in `run()` so content
+    already streamed to disk is flushed before the process exits, without
+    disturbing whatever primary failure message that path is about to
+    report.
+    """
+    if f is None:
+        return
+    try:
+        f.close()
+    except OSError:
+        pass
+
+
+def _render_time_range_summary(
+    first_utc_time: str, last_utc_time: str, total_lines: int, elapsed_sec: float
+) -> str:
+    """Render the `Time range: ... Total: ... Duration: ...` console block
+    shared by both the `--path` and stdout completion branches of `run()`.
+    """
+    return (
+        f"\n[bold]Time range[/]: [bold cyan]UTC|{first_utc_time}[/]"
+        f" → [blue]UTC|{last_utc_time}[/]\n[bold]Total[/]:"
+        f" [green]{total_lines}[/] lines \n[bold cyan]Duration[/]:"
+        f" [magenta]{elapsed_sec:.2f}s[/]\n"
+    )
+
+
+def _render_file_footer_text(
+    first_utc_time: str,
+    last_utc_time: str,
+    total_lines: int,
+    failed_units: List[Tuple[int, int]],
+) -> str:
+    """Render the `--path` output file's footer: the neutral `Time range`
+    line, plus a capped `PARTIAL RESULT` line naming failed ranges when
+    `failed_units` is non-empty (the untruncated list still goes to the
+    trace log).
+    """
+    text = (
+        f"Time range: UTC|{first_utc_time} → "
+        f"UTC|{last_utc_time} | total {total_lines} lines \n"
+    )
+    if failed_units:
+        capped = failed_units[:_FAILED_RANGES_FILE_CAP]
+        ranges_str = ", ".join(
+            f"[{_epoch_to_time_str(s)}, {_epoch_to_time_str(e)})" for s, e in capped
+        )
+        remaining = len(failed_units) - len(capped)
+        if remaining > 0:
+            ranges_str += f" (+{remaining} more, see trace log for full list)"
+            logger.trace(
+                "adaptive fetch: full list of failed ranges:"
+                f" {[(s, e) for s, e in failed_units]}"
+            )
+        text += (
+            f"PARTIAL RESULT: {len(failed_units)} time"
+            " range(s) could not be fetched and are missing from"
+            f" this file: {ranges_str}\n"
+        )
+    return text
+
+
+def _interruptible_sleep(delay: float, cancelled: Optional[threading.Event]) -> None:
+    """Sleep `delay` seconds, waking early if `cancelled` is set.
+
+    Uses `cancelled.wait(delay)` rather than `time.sleep(delay)` so a
+    cancellation recorded mid-sleep -- including a `Retry-After`-bounded
+    sleep up to 60s -- wakes the caller promptly instead of blocking for the
+    remainder of the delay.
+    """
+    if cancelled is not None:
+        cancelled.wait(delay)
+    else:
+        time.sleep(delay)
+
+
+def _fixed_backoff_delay(attempt: int, base_delay: float) -> float:
+    """Fixed exponential backoff delay for a non-429 retry attempt."""
+    return base_delay * (2**attempt)
+
+
+def _rate_limit_retry_delay(
+    e: LogAPIError, attempt: int, base_delay: float, retry_after_cap: float
+) -> float:
+    """Delay before retrying a 429, honoring `Retry-After` when present
+    (bounded to `retry_after_cap`), else jittered exponential backoff. This
+    same value is also used as the shared rate-limit signal's cooldown.
+    """
+    if e.retry_after is not None:
+        return min(e.retry_after, retry_after_cap)
+    return min(retry_after_cap, base_delay * (2**attempt) * random.uniform(1.0, 1.5))
+
+
+# Checks `cancelled` before the first attempt, before each retry sleep, and
+# before a 429 sleep, so a cancellation is observed promptly rather than
+# after a long sleep completes. Backoff/retry sleeps themselves are also
+# interruptible mid-sleep via `_interruptible_sleep`.
+def _fetch_log_unit(
     deployment,
     job,
     replica,
     job_history_name,
     query,
-    time_start,
-    time_end,
-    cur_log_result,
-):
+    start: int,
+    end: int,
+    limit: int = _ADAPTIVE_PAGE_LIMIT,
+    cancelled: Optional[threading.Event] = None,
+    rate_limit_signal: Optional[_RateLimitSignal] = None,
+) -> FetchUnitResult:
+    """Fetch exactly one page for `[start, end)`, forward-direction, with retry.
+
+    Retried up to `_ADAPTIVE_RETRY_MAX_ATTEMPTS` times and returns a
+    structured `FetchUnitResult` -- never loops or shrinks its own range;
+    the scheduler owns splitting a saturated result into child `WorkUnit`s.
+    A 429 honors `Retry-After` (bounded) or falls back to jittered
+    exponential backoff and signals the shared `rate_limit_signal`; any
+    other failure uses fixed exponential backoff. A running HTTP call
+    cannot be forcibly aborted once started, so a unit already mid-request
+    when cancellation is requested can still delay the caller by up to
+    `_ADAPTIVE_FETCH_TIMEOUT_SEC`. `start`/`end` are validated by the CLI
+    dispatch path before the scheduler's root work unit is ever
+    constructed, so this loop's retries are only ever for a genuine
+    backend/parse failure, never a precondition violation.
+    """
+    _validate_positive_int_limit(limit)
+
     client = APIClient()
-    while time_end >= time_start:
-        max_retries = 5
-        base_delay = 0.5
-        log_dict = None
-        for retry in range(max_retries):
-            try:
-                log_dict = client.log.get_log(
-                    name_or_deployment=deployment,
-                    name_or_job=job,
-                    replica=replica,
-                    job_history_name=job_history_name,
-                    start=time_start,
-                    end=time_end,
-                    limit=10000,
-                    q=query,
-                )
-                break
-            except Exception as e:
-                logger.trace(traceback.format_exc())
-                logger.trace(e)
-                delay = base_delay * (2 ** (retry))
-                if retry < max_retries - 1:
-                    time.sleep(delay)
+    max_retries = _ADAPTIVE_RETRY_MAX_ATTEMPTS
+    base_delay = _ADAPTIVE_RETRY_BASE_DELAY_SEC
+    retry_after_cap = _ADAPTIVE_RETRY_AFTER_CAP_SEC
 
-        if log_dict is None:
-            console.print(
-                "[yellow]Warning[/]: failed to fetch logs for time range"
-                f" {_epoch_to_time_str(time_start)}–{_epoch_to_time_str(time_end)} after"
-                f" {max_retries} retries; skipping this time range. Output may be"
-                " incomplete. "
+    for attempt in range(max_retries):
+        if cancelled is not None and cancelled.is_set():
+            return FetchUnitResult(
+                entries=[], saturated=False, min_ts=None, max_ts=None, failed=True
             )
+        try:
+            logger.trace(
+                f"fetching unit range=[{start}, {end})"
+                f" attempt={attempt + 1}/{max_retries}"
+            )
+            log_dict = client.log.get_log(
+                name_or_deployment=deployment,
+                name_or_job=job,
+                replica=replica,
+                job_history_name=job_history_name,
+                start=start,
+                end=end,
+                limit=limit,
+                q=query,
+                direction="forward",
+                timeout=_ADAPTIVE_FETCH_TIMEOUT_SEC,
+            )
+            entries, examined_count = _parse_log_entries(log_dict, limit, start, end)
+
+            if examined_count > limit:
+                logger.trace(
+                    f"unit range=[{start}, {end}) backend returned"
+                    f" {examined_count} entries, exceeding limit={limit}; capped to"
+                    f" {limit}"
+                )
+
+            min_ts = entries[0].timestamp_ns if entries else None
+            max_ts = entries[-1].timestamp_ns if entries else None
+            saturated = examined_count >= limit
+            logger.trace(
+                f"unit range=[{start}, {end}) fetched {len(entries)} entries"
+                f" saturated={saturated}"
+            )
+            return FetchUnitResult(
+                entries=entries,
+                saturated=saturated,
+                min_ts=min_ts,
+                max_ts=max_ts,
+                failed=False,
+            )
+        except Exception as e:
+            # A single classified retry step for both `LogAPIError` (where
+            # status-code/retry-after info is available) and any other
+            # failure: only the delay selection differs -- 429s honor
+            # `Retry-After` (capped) or fall back to jittered backoff and
+            # signal the shared rate-limit signal; anything else uses fixed
+            # exponential backoff. Cancellation-check-and-interruptible-sleep
+            # is shared, run exactly once regardless of failure type.
+            logger.trace(traceback.format_exc())
+            logger.trace(e)
+            if attempt >= max_retries - 1:
+                break
+            if cancelled is not None and cancelled.is_set():
+                return FetchUnitResult(
+                    entries=[], saturated=False, min_ts=None, max_ts=None, failed=True
+                )
+            if isinstance(e, LogAPIError) and e.status_code == 429:
+                delay = _rate_limit_retry_delay(e, attempt, base_delay, retry_after_cap)
+                if e.retry_after is not None:
+                    logger.trace(
+                        f"429 rate limit: unit=[{start},{end}) honoring"
+                        f" Retry-After={e.retry_after}s (capped to {delay}s)"
+                    )
+                else:
+                    logger.trace(
+                        f"429 rate limit: unit=[{start},{end}) no Retry-After,"
+                        f" jittered backoff={delay:.2f}s attempt={attempt + 1}"
+                    )
+                if rate_limit_signal is not None:
+                    rate_limit_signal.signal(delay)
+            else:
+                delay = _fixed_backoff_delay(attempt, base_delay)
+                logger.trace(
+                    f"retrying unit range=[{start}, {end}) after {delay}s"
+                    f" (attempt {attempt + 1}/{max_retries})"
+                )
+            _interruptible_sleep(delay, cancelled)
+
+    logger.trace(f"unit range=[{start}, {end}) failed after {max_retries} retries")
+    return FetchUnitResult(
+        entries=[], saturated=False, min_ts=None, max_ts=None, failed=True
+    )
+
+
+class _EmitBookkeeping:
+    """Running total_lines/first_utc_time/last_utc_time for the final summary.
+
+    Updated by whichever sink (`_make_file_sink`/`_make_stdout_sink`) is
+    active, in emitted (chronological) order.
+    """
+
+    def __init__(self):
+        self.total_lines = 0
+        self.first_utc_time: Optional[str] = None
+        self.last_utc_time: Optional[str] = None
+
+    def record(self, utc_time: str) -> None:
+        if self.total_lines == 0:
+            self.first_utc_time = utc_time
+        self.last_utc_time = utc_time
+        self.total_lines += 1
+
+
+class _LazyFileSink:
+    """The `--path` sink. Directory resolution and file opening are deferred
+    to the first actual write need: until `ensure_open`/`emit` is first
+    called, the filesystem is completely untouched -- no directory created,
+    no file opened, no pre-existing file at `raw_path` truncated. `run()`
+    triggers the deferred open from two call sites: the first emitted batch
+    of entries (`emit`), or -- for a run that emits nothing but still has
+    failure information worth recording -- explicitly via `ensure_open`
+    right before the footer is written.
+    """
+
+    def __init__(
+        self,
+        raw_path: str,
+        name_hint: str,
+        without_timestamp: bool,
+        bookkeeping: _EmitBookkeeping,
+    ):
+        self._raw_path = raw_path
+        self._name_hint = name_hint
+        self.without_timestamp = without_timestamp
+        self.bookkeeping = bookkeeping
+        # Set once `resolve_save_path` succeeds, independent of whether the
+        # subsequent `open()` call itself then succeeds.
+        self.path: Optional[str] = None
+        self._f = None
+
+    def ensure_open(self) -> None:
+        """Resolve `raw_path` (creating its directory if needed) and open the
+        file, if not already done. Idempotent: a no-op once the file is open.
+
+        Raises `PathResolutionError` (directory creation failure) or
+        `OSError` (file open failure) -- callers decide how to report and
+        handle it, since the appropriate response differs depending on
+        whether workers are still active.
+        """
+        if self._f is not None:
             return
+        default_filename = (
+            f"log-{self._name_hint}{datetime.now().strftime('%Y%m%d-%H%M%S')}.txt"
+        )
+        self.path = resolve_save_path(self._raw_path, default_filename)
+        self._f = open(self.path, "w", encoding="utf-8")
 
-        lines = log_dict["data"]["result"]
-        cur_log_list = []
-        for line in lines:
-            values = line["values"]
-            for value in values:
-                cur_log_list.append((int(value[0]), value[1]))
+    def emit(self, entries: List[LogEntry]) -> None:
+        self.ensure_open()
+        for entry in entries:
+            utc_time = _epoch_to_time_str(entry.timestamp_ns)
+            cur_line = safe_load_json(entry.line)
+            if self.without_timestamp:
+                self._f.write(f"{cur_line}\n")
+            else:
+                self._f.write(f"{utc_time}｜{cur_line}\n")
+            self.bookkeeping.record(utc_time)
 
-        if len(cur_log_list) == 0:
-            break
-        cur_log_list.sort(key=lambda x: x[0], reverse=True)
-        time_end = cur_log_list[-1][0]
-        if len(cur_log_list) > 0:
-            cur_log_result.extend(cur_log_list)
+    def write_footer(self, text: str) -> None:
+        self._f.write(text)
+
+    def close(self) -> None:
+        self._f.close()
+
+    def quiet_close(self) -> None:
+        _quiet_close(self._f)
+
+
+def _make_stdout_sink(without_timestamp: bool, bookkeeping: _EmitBookkeeping) -> EmitFn:
+    """Build the no-`--path` sink: prints each entry via the shared `console`."""
+
+    def emit(entries: List[LogEntry]) -> None:
+        for entry in entries:
+            utc_time = _epoch_to_time_str(entry.timestamp_ns)
+            cur_line = safe_load_json(entry.line)
+            if not without_timestamp:
+                console.print(f"[green]{utc_time}|[/]", end="")
+            console.print(json.dumps(cur_line, ensure_ascii=False), markup=False)
+            bookkeeping.record(utc_time)
+
+    return emit
+
+
+class _AdaptiveLogScheduler:
+    """Adaptive bisection scheduler for the no-`--limit` fetch path.
+
+    Encapsulates the scheduler's mutable state (pending queue, active-future
+    map, commit-watermark buffer, cancellation event, `seq_id` counter,
+    progress bookkeeping, failed units, sink state) as instance attributes.
+    All methods, including `run`, execute only on the single thread that owns
+    the `ThreadPoolExecutor` context; worker threads only ever call the free
+    function `_fetch_log_unit` and never touch scheduler state directly --
+    they never enqueue work or allocate `seq_id`s themselves.
+    """
+
+    def __init__(
+        self,
+        deployment,
+        job,
+        replica,
+        job_history_name,
+        query,
+        unix_start: int,
+        unix_end: int,
+        workers: Optional[int],
+        without_timestamp: bool,
+        path: Optional[str],
+    ):
+        """
+        Args:
+            path: the raw, unresolved `--path` value (may name a directory
+                or a file, or be `None` for stdout) -- NOT yet resolved to a
+                concrete file path. Resolution (which may create a
+                directory) and opening the file are both deferred to the
+                first actual write need, via `self.sink`; see
+                `_LazyFileSink`.
+        """
+        self.deployment = deployment
+        self.job = job
+        self.replica = replica
+        self.job_history_name = job_history_name
+        self.query = query
+        self.unix_start = unix_start
+        self.unix_end = unix_end
+        self.effective_workers = workers if workers is not None else 32
+        self.without_timestamp = without_timestamp
+
+        self.bookkeeping = _EmitBookkeeping()
+        # Same default-filename precedence `fetch_log` used before path
+        # resolution was made lazy: deployment/job/replica/job_history_name,
+        # in that order, first truthy one wins.
+        name_hint = job or deployment or replica or job_history_name or ""
+        self.sink = (
+            _LazyFileSink(path, name_hint, without_timestamp, self.bookkeeping)
+            if path
+            else None
+        )
+
+        self.cancelled = threading.Event()
+        self.rate_limit_signal = _RateLimitSignal()
+        self._seq_counter = itertools.count()
+
+        # Min-heap keyed by WorkUnit's (start, seq_id) total order -- always
+        # dispatches the smallest-`start` pending unit next, never FIFO.
+        self.pending: List[WorkUnit] = []
+        heapq.heappush(self.pending, WorkUnit(self._next_seq(), unix_start, unix_end))
+        self.active = {}  # future -> WorkUnit
+
+        self.buffer = (
+            []
+        )  # heap of (timestamp_ns, unit_seq_id, response_index, LogEntry)
+        self.failed_units: List[Tuple[int, int]] = []
+
+        # Admission-control cap for `_submit_ready`'s buffered-plus-reserved
+        # accounting (see `cap_blocks` there): `effective_workers` in-flight
+        # units can each contribute up to `_ADAPTIVE_PAGE_LIMIT` entries to
+        # the buffer before the watermark advances past them, plus one unit
+        # of slack. The frontier exemption (see `_submit_ready`) is the sole
+        # source of a bounded one-page overshoot above this cap.
+        self._max_buffered_entries = (self.effective_workers + 1) * _ADAPTIVE_PAGE_LIMIT
+
+        self.last_watermark = unix_start
+        self.progress_total = 1
+
+    def _next_seq(self) -> int:
+        """Allocate the next `WorkUnit.seq_id` from the counter.
+
+        Only ever called from the scheduler's owning thread (the
+        constructor, called once, and `_handle_result`, called only from
+        `run()`'s main loop) -- worker threads never enqueue work or
+        allocate sequence IDs themselves, only ever call the free function
+        `_fetch_log_unit` and return `FetchUnitResult` values.
+        """
+        return next(self._seq_counter)
+
+    def _admission_blocked(self) -> bool:
+        """Whether admission control currently blocks submitting another unit.
+
+        Bounds the resident-entry count (buffered + reserved-for-active,
+        accounting for the unit about to be admitted) to
+        self._max_buffered_entries. `len(active) >= 1` is mandatory, not an
+        optimization: it exempts the frontier (smallest-start) pending unit
+        from ever being blocked when nothing is in flight, which is what
+        guarantees the scheduler always has a path to advance the watermark
+        and can never deadlock with pending work and nothing submitted --
+        the sole source of a bounded one-page overshoot above the cap.
+        """
+        return (
+            len(self.active) >= 1
+            and (len(self.buffer) + (len(self.active) + 1) * _ADAPTIVE_PAGE_LIMIT)
+            > self._max_buffered_entries
+        )
+
+    def _submit_ready(self, executor: ThreadPoolExecutor) -> None:
+        """Fill the active-future map up to `effective_workers` from the pending queue.
+
+        Never more than `effective_workers` `_fetch_log_unit` calls in flight
+        at once, no new submissions once `cancelled` is set, and always
+        dispatches the smallest-`(start, seq_id)` pending unit, never FIFO.
+        While the shared rate-limit signal is active, zero new submissions
+        are made this pass; already-active units continue uninterrupted.
+        Also gated by `_admission_blocked` below -- except the frontier
+        (smallest-`start`) unit is never blocked by it when nothing is
+        active.
+        """
+        while (
+            self.pending
+            and len(self.active) < self.effective_workers
+            and not (self.cancelled.is_set() or self.rate_limit_signal.active())
+        ):
+            if self._admission_blocked():
+                break
+
+            unit = heapq.heappop(self.pending)
+            future = executor.submit(
+                _fetch_log_unit,
+                self.deployment,
+                self.job,
+                self.replica,
+                self.job_history_name,
+                self.query,
+                unit.start,
+                unit.end,
+                _ADAPTIVE_PAGE_LIMIT,
+                self.cancelled,
+                self.rate_limit_signal,
+            )
+            self.active[future] = unit
+            logger.trace(
+                f"submitted unit seq={unit.seq_id} range=[{unit.start}, {unit.end})"
+            )
+
+    def _handle_result(self, unit: WorkUnit, result: FetchUnitResult) -> bool:
+        """Process one completed unit's `FetchUnitResult`: buffer entries and,
+        on saturation, enqueue bisected children of the unscanned remainder.
+
+        The same-timestamp saturation check (Case A/B below) always takes
+        priority over the general single-vs-two-child bisection heuristic --
+        it must be evaluated first to keep sibling-split coverage gap-free
+        and duplicate-free outside the one accepted same-timestamp
+        exception. Returns whether progress should advance by one unit
+        (False when the unit was split, since children were added to the
+        total instead).
+        """
+        progress_advance = True
+
+        if result.failed:
+            self.failed_units.append((unit.start, unit.end))
+            logger.trace(
+                f"unit seq={unit.seq_id} range=[{unit.start}, {unit.end}) failed"
+                " after retries"
+            )
+            return progress_advance
+
+        if not result.entries:
+            logger.trace(
+                f"unit seq={unit.seq_id} range=[{unit.start}, {unit.end}) empty"
+            )
+            return progress_advance
+
+        for idx, entry in enumerate(result.entries):
+            heapq.heappush(self.buffer, (entry.timestamp_ns, unit.seq_id, idx, entry))
+
+        if not result.saturated:
+            return progress_advance
+
+        split_point = result.max_ts
+
+        # Case A -- width-<=1ns remainder (terminal): [T, unit.end) cannot
+        # contain more than one distinct ns value going forward. No valid
+        # mid exists to bisect around, so the unit resolves with zero
+        # children.
+        if split_point >= unit.end - 1:
+            logger.trace(
+                "same-timestamp saturation safeguard: unit="
+                f"{unit.seq_id} range=[{unit.start},{unit.end}) ts={split_point}"
+                f" limit={_ADAPTIVE_PAGE_LIMIT} — output for this timestamp may"
+                " be incomplete"
+            )
+            return progress_advance
+
+        # Case B -- saturated single-timestamp page (continues past T): the
+        # whole page shares timestamp_ns == T, so the page could not see
+        # past T -- this does not mean (T, unit.end) is empty. The T group
+        # is resolved via the existing flush-time dedup/cap safeguard
+        # (accepted tradeoff), but scanning continues by enqueuing a single
+        # child at [T + 1, unit.end). T + 1 is safe only in this branch --
+        # never in the general saturated-boundary handling below.
+        if result.min_ts == split_point:
+            child = WorkUnit(self._next_seq(), split_point + 1, unit.end)
+            heapq.heappush(self.pending, child)
+            progress_advance = False
+            logger.trace(
+                "same-timestamp saturation safeguard: unit="
+                f"{unit.seq_id} range=[{unit.start},{unit.end}) ts={split_point}"
+                f" limit={_ADAPTIVE_PAGE_LIMIT} — T group capped/deduplicated,"
+                " continuing scan at T+1"
+            )
+            return progress_advance
+
+        # Whether to bisect the unscanned remainder [T, unit.end) or hand it
+        # off whole depends on WHERE in the originally-fetched interval
+        # saturation occurred (not on the remainder itself): late saturation
+        # suggests a small remainder (single unsplit child; it can still
+        # split further next time it saturates), early saturation suggests
+        # a dense remainder (split immediately).
+        #
+        # branch_mid MUST use true (float) division, never integer floor
+        # division: at an odd-sum interval, floor division rounds the
+        # midpoint down by half a nanosecond and can silently flip the
+        # branch decision.
+        branch_mid = (unit.start + unit.end) / 2
+        if split_point >= branch_mid:
+            child = WorkUnit(self._next_seq(), split_point, unit.end)
+            assert child.start == split_point and child.end == unit.end
+            heapq.heappush(self.pending, child)
+            progress_advance = False
+            logger.trace(
+                "split unit (single child, saturation at/past fetched midpoint)"
+                f" seq={unit.seq_id} range=[{unit.start}, {unit.end}) at"
+                f" T={split_point} branch_mid={branch_mid} into"
+                f" child=[{child.start}, {child.end})"
+            )
+        else:
+            mid = split_point + (unit.end - split_point) // 2
+            left = WorkUnit(self._next_seq(), split_point, mid)
+            right = WorkUnit(self._next_seq(), mid, unit.end)
+            assert (
+                left.end == right.start
+                and left.start == split_point
+                and right.end == unit.end
+            )
+            heapq.heappush(self.pending, left)
+            heapq.heappush(self.pending, right)
+            self.progress_total += 1
+            progress_advance = False
+            logger.trace(
+                "split unit (two children, saturation before fetched midpoint)"
+                f" seq={unit.seq_id} range=[{unit.start}, {unit.end}) at"
+                f" T={split_point} branch_mid={branch_mid} into"
+                f" left=[{left.start}, {left.end}) right=[{right.start}, {right.end})"
+            )
+
+        return progress_advance
+
+    def _compute_watermark(self) -> int:
+        """Recompute the commit watermark: the minimum `start` across all
+        pending-or-active units, or `unix_end` once none remain.
+
+        The watermark never regresses -- `run` raises
+        `_WatermarkRegressionError`, a handled failure, if it ever does.
+        """
+        starts = [u.start for u in self.pending]
+        starts.extend(u.start for u in self.active.values())
+        return min(starts) if starts else self.unix_end
+
+    def _drain_and_emit(self, watermark: int, emit_fn: EmitFn) -> None:
+        """Pop and emit all buffered entries strictly below `watermark`,
+        de-duplicating exact `LogEntry` repeats at flush time.
+        """
+        to_emit: List[LogEntry] = []
+        seen = set()
+        while self.buffer and self.buffer[0][0] < watermark:
+            _, _, _, entry = heapq.heappop(self.buffer)
+            if entry in seen:
+                continue
+            seen.add(entry)
+            to_emit.append(entry)
+        if to_emit:
+            emit_fn(to_emit)
+
+    def run(self) -> NoReturn:
+        """Run the scheduler loop to completion and terminate the process.
+
+        Drives the fill/wait/handle-result loop over a `ThreadPoolExecutor`
+        bounded by `effective_workers`, then prints the final summary and
+        exits: 0 on success, 1 on sink failure, 2 on partial fetch failure.
+        On sink failure, `cancelled` is set and no further units are
+        submitted; a unit already inside a blocking HTTP call still delays
+        shutdown up to `_ADAPTIVE_FETCH_TIMEOUT_SEC`, since `future.cancel()`
+        cannot abort a call already in flight. This is the only method that
+        calls `sys.exit`, and the only one that triggers `self.sink`'s lazy
+        open (via `emit_fn` or, at finalization, a direct `ensure_open`
+        call) -- see `_LazyFileSink`.
+        """
+        start_perf = time.perf_counter()
+
+        emit_fn = (
+            self.sink.emit
+            if self.sink
+            else _make_stdout_sink(self.without_timestamp, self.bookkeeping)
+        )
+
+        progress_cm = Progress() if self.sink else contextlib.nullcontext()
+        sink_exc = None
+        watermark_exc: Optional[_WatermarkRegressionError] = None
+
+        # `self.sink`, once open, stays open (no `finally: close()`) so the
+        # footer can be written through the same handle later. Each error
+        # exit path below (including BrokenPipeError) does a silent
+        # best-effort close right before exiting, to flush already-streamed
+        # content without disturbing that path's own primary error message.
+        with progress_cm as progress:
+            task = (
+                progress.add_task("Fetching logs...", total=self.progress_total)
+                if self.sink
+                else None
+            )
+
+            with ThreadPoolExecutor(max_workers=self.effective_workers) as executor:
+                while (
+                    (self.pending or self.active)
+                    and sink_exc is None
+                    and watermark_exc is None
+                ):
+                    self._submit_ready(executor)
+
+                    if not self.active:
+                        if self.cancelled.is_set() or not self.pending:
+                            break
+                        # Nothing in flight, likely because the rate-limit
+                        # signal is blocking new submissions. Wait briefly
+                        # rather than exiting with pending work undone.
+                        time.sleep(0.05)
+                        continue
+
+                    done, _ = wait(
+                        list(self.active.keys()), return_when=FIRST_COMPLETED
+                    )
+                    for future in done:
+                        unit = self.active.pop(future)
+                        if self.cancelled.is_set():
+                            continue
+
+                        result = future.result()
+                        progress_advance = self._handle_result(unit, result)
+
+                        if self.sink:
+                            if progress_advance:
+                                progress.update(task, advance=1)
+                            else:
+                                progress.update(task, total=self.progress_total)
+
+                        # Handled control-flow branch, not a bare `assert`
+                        # (which raises uncaught and is compiled out under
+                        # -O).
+                        try:
+                            watermark = self._compute_watermark()
+                            if watermark < self.last_watermark:
+                                raise _WatermarkRegressionError(
+                                    "watermark regressed from"
+                                    f" {self.last_watermark} to {watermark}"
+                                )
+                            self.last_watermark = watermark
+                            logger.trace(f"watermark advanced to {watermark}")
+
+                            self._drain_and_emit(watermark, emit_fn)
+                        except _WatermarkRegressionError as e:
+                            self.cancelled.set()
+                            watermark_exc = e
+                            break
+                        except BrokenPipeError:
+                            self.cancelled.set()
+                            if self.sink is not None:
+                                self.sink.quiet_close()
+                            raise
+                        except Exception as e:
+                            self.cancelled.set()
+                            sink_exc = e
+                            break
+
+                # Fail-fast shutdown: cancel not-yet-started futures and join the rest.
+                for future in list(self.active.keys()):
+                    future.cancel()
+
+        if watermark_exc is not None:
+            if self.sink is not None:
+                self.sink.quiet_close()
+            console.print(f"[red]Internal scheduling error[/]: {watermark_exc}")
+            sys.exit(1)
+
+        if sink_exc is not None:
+            if self.sink is not None:
+                self.sink.quiet_close()
+            console.print(f"[red]Failed to write logs[/]: {sink_exc}")
+            sys.exit(1)
+
+        elapsed_sec = time.perf_counter() - start_perf
+        first_utc_time = self.bookkeeping.first_utc_time or _epoch_to_time_str(
+            self.unix_start
+        )
+        last_utc_time = self.bookkeeping.last_utc_time or _epoch_to_time_str(
+            self.unix_end
+        )
+        total_lines = self.bookkeeping.total_lines
+
+        # Every unit genuinely succeeded and found nothing (as opposed to
+        # some units failing, where we don't actually know). `self.sink` is
+        # guaranteed to still be unopened here (nothing was ever emitted,
+        # and this branch is reached before the failed-units footer-write
+        # path below could have opened it), so for `--path` the filesystem
+        # is completely untouched: no directory created, no file opened.
+        if total_lines == 0 and not self.failed_units:
+            console.print("[yellow]No logs found in the specified time range.[/]")
+            sys.exit(0)
+
+        if self.failed_units:
+            ranges_str = ", ".join(
+                f"[{_epoch_to_time_str(s)}, {_epoch_to_time_str(e)})"
+                for s, e in self.failed_units
+            )
+            console.print(
+                f"[yellow]Warning[/]: {len(self.failed_units)} time range(s) could"
+                " not be fetched after 5 retries and are missing from the output:"
+                f" {ranges_str}"
+            )
+
+        logger.trace(
+            f"adaptive fetch complete: total_lines={total_lines}"
+            f" failed_units={len(self.failed_units)}"
+        )
+
+        if self.sink is not None:
+            # Reaching here with `self.sink` still unopened means nothing
+            # was ever emitted but `self.failed_units` is non-empty (a
+            # partial run must still produce its output file, with the
+            # failure-summary footer, even at total_lines == 0) -- open it
+            # now, lazily, right before the footer is written.
+            try:
+                self.sink.ensure_open()
+            except (PathResolutionError, OSError) as e:
+                console.print(f"[red]Failed to write logs[/]: {e}")
+                sys.exit(1)
+
+            # Footer written through the same still-open handle used for
+            # streaming entries -- no second `open(path, "a")` call.
+            try:
+                self.sink.write_footer(
+                    _render_file_footer_text(
+                        first_utc_time, last_utc_time, total_lines, self.failed_units
+                    )
+                )
+            except OSError as e:
+                # Footer write failed: silent best-effort close so entries
+                # already streamed are flushed, even though the footer
+                # itself is absent/incomplete. Never raises/prints its own
+                # message -- only the footer-write failure below is
+                # reported, and the write is not retried after closing.
+                self.sink.quiet_close()
+                console.print(f"[red]Failed to write log file footer[/]: {e}")
+                sys.exit(1)
+
+            try:
+                self.sink.close()
+            except OSError as e:
+                # Close failure after a successful footer write still exits
+                # 1 without printing success/partial text, even though the
+                # footer content was already flushed.
+                console.print(f"[red]Failed to close output file[/]: {e}")
+                sys.exit(1)
+
+            console.print(
+                _render_time_range_summary(
+                    first_utc_time, last_utc_time, total_lines, elapsed_sec
+                )
+            )
+            if self.failed_units:
+                console.print(
+                    "\n[bold yellow]Partial result[/bold yellow]: saved"
+                    f" incomplete log to: {self.sink.path}\n"
+                )
+            else:
+                console.print(
+                    "\n[bold green]Successfully saved the log"
+                    f" to:[/bold green] {self.sink.path}\n"
+                )
+        else:
+            console.print(
+                f"\n👆Time range: [blue]UTC|{first_utc_time}[/] →"
+                f" [blue]UTC|{last_utc_time}[/] total"
+                f" [green]{total_lines}[/] lines \n"
+            )
+            if self.failed_units:
+                console.print(
+                    "\n[bold yellow]Partial result[/bold yellow]: log output"
+                    " is incomplete\n"
+                )
+
+        sys.exit(2 if self.failed_units else 0)
+
+
+def fetch_logs_adaptive_parallel(
+    deployment,
+    job,
+    replica,
+    job_history_name,
+    query,
+    unix_start: int,
+    unix_end: int,
+    workers: Optional[int],
+    without_timestamp: bool,
+    path: Optional[str],
+) -> NoReturn:
+    """Construct and run an `_AdaptiveLogScheduler` for one fetch.
+
+    `path` is the raw, unresolved `--path` value (a directory, a file path,
+    or `None` for stdout) -- resolution and file creation are deferred by
+    the scheduler itself until actually needed; see `_LazyFileSink`.
+    Terminal: always calls `sys.exit(...)` and never returns (see
+    `_AdaptiveLogScheduler.run`).
+    """
+    _AdaptiveLogScheduler(
+        deployment,
+        job,
+        replica,
+        job_history_name,
+        query,
+        unix_start,
+        unix_end,
+        workers,
+        without_timestamp,
+        path,
+    ).run()
 
 
 @click_group()
@@ -254,6 +1353,10 @@ def log():
     - They are NOT recommended for downloading logs \n
     - Prefer using Workspace Dashboard -> Settings -> Logs Export for downloading
       large-volume logs (jobs/endpoints long-running or with many replicas). \n
+    - When --limit is NOT used, retrieval adapts to the requested range: workers
+      fetch it in parallel and only split further when a fetch saturates the
+      per-request page limit, so the number of requests made depends on how
+      dense the logs are, not on a fixed number of windows. \n
     - Concurrency (workers) is applied only when --limit is NOT used. \n
     - --limit is deprecated and not recommended. When set, logs will be fetched
       sequentially without parallelism. It will be removed in a future release. \n
@@ -395,6 +1498,10 @@ def log_command(
     - They are NOT recommended for downloading logs.
     - Prefer using Workspace Dashboard -> Settings -> Logs Export for downloading
       large-volume logs (jobs/endpoints long-running or with many replicas).
+    - When --limit is NOT used, retrieval adapts to the requested range: workers
+      fetch it in parallel and only split further when a fetch saturates the
+      per-request page limit, so the number of requests made depends on how
+      dense the logs are, not on a fixed number of windows.
     - Concurrency (workers) is applied only when --limit is NOT used.
     - --limit is deprecated and not recommended. When set, logs will be fetched
       sequentially without parallelism. It will be removed in a future release.
@@ -494,26 +1601,6 @@ def log_command(
         )
         start = "today"
 
-    try:
-        unix_start_probe = _preprocess_time(start, epoch=True)
-        unix_end_probe = _preprocess_time(end, epoch=True)
-        probe = client.log.get_log(
-            name_or_deployment=deployment,
-            name_or_job=job,
-            replica=replica,
-            job_history_name=job_history_name,
-            start=unix_start_probe,
-            end=unix_end_probe,
-            limit=1,
-            q=query,
-        )
-        if not probe or not probe.get("data", {}).get("result"):
-            console.print("[yellow]No logs found in the specified time range.[/]")
-            sys.exit(0)
-    except Exception as e:
-        console.print(f"[red]Failed to query logs[/]: {e}")
-        sys.exit(1)
-
     def fetch_log(start, end, limit, path=None):
         unix_start = _preprocess_time(start, epoch=True)
         unix_end = _preprocess_time(end, epoch=True)
@@ -524,133 +1611,40 @@ def log_command(
             sys.exit(1)
 
         if limit is None:
-            time_range = unix_end - unix_start
-            MIN_SLOT_NS = 1_000_000_000
-            time_slot = max(MIN_SLOT_NS, time_range // 1600)
-
-            time_windows = []
-            for start_ns in range(unix_start, unix_end, time_slot):
-                end_ns = min(start_ns + time_slot, unix_end)
-                time_windows.append((start_ns, end_ns))
-            log_list = [[] for _ in range(len(time_windows))]
-            start_perf = time.perf_counter()
-            # Resolve save path early before starting progress/executor
-            if path:
-                default_filename = (
-                    f"log-{job or deployment or replica or job_history_name or ''}{datetime.now().strftime('%Y%m%d-%H%M%S')}.txt"
+            # Reject a non-positive start/end at the CLI boundary, before
+            # any request is dispatched: mirrors LogAPI.get_log's own
+            # _is_epoch_zero/negative rejection semantics, but enforced here
+            # so an invalid range fails immediately (no worker dispatched,
+            # no retry loop) instead of being discovered the slow way by
+            # `_fetch_log_unit`'s retry machinery on the root work unit.
+            if unix_start <= 0 or unix_end <= 0:
+                console.print(
+                    "[red]Warning[/red] start/end must be a positive"
+                    " (non-zero) epoch timestamp for adaptive log"
+                    " retrieval; 0 cannot be distinguished from an omitted"
+                    " value, and negative timestamps are not valid."
                 )
-                try:
-                    path = resolve_save_path(path, default_filename)
-                except PathResolutionError as e:
-                    console.print(
-                        "[red][ERROR]failed to create directory:[/]"
-                        f" {e.directory} ({e.cause})"
-                    )
-                    sys.exit(1)
-            with Progress() as progress:
-                worker_count = (
-                    min(len(time_windows), workers)
-                    if workers is not None
-                    else min(len(time_windows), 32)
-                )
-                with ThreadPoolExecutor(max_workers=worker_count) as executor:
-                    task = progress.add_task(
-                        "Fetching logs...", total=len(time_windows)
-                    )
-                    futures = []
-                    future_to_index = {}
-                    for index, (time_start, time_end) in enumerate(time_windows):
-                        future = executor.submit(
-                            fetch_all_within_time_slot,
-                            deployment,
-                            job,
-                            replica,
-                            job_history_name,
-                            query,
-                            time_start,
-                            time_end,
-                            log_list[index],
-                        )
-                        futures.append(future)
-                        future_to_index[future] = index
+                sys.exit(1)
 
-                    future_complete_list = [False for _ in range(len(time_windows))]
-                    if path:
-                        next_writing_index = 0
-                        total_lines = 0
-                        first_utc_time = ""
-                        last_utc_time = ""
-                        last_epoch_ns = unix_start
-                        with open(path, "w", encoding="utf-8") as f:
-                            for future in as_completed(futures):
-                                future.result()
-                                index = future_to_index[future]
-                                while next_writing_index < len(time_windows) and (
-                                    future_complete_list[next_writing_index] is True
-                                    or index == next_writing_index
-                                ):
-                                    if len(log_list[next_writing_index]) > 0:
-                                        if total_lines == 0:
-                                            first_utc_time = _epoch_to_time_str(
-                                                log_list[next_writing_index][-1][0]
-                                            )
-
-                                        total_lines += len(log_list[next_writing_index])
-
-                                        cur_max_candidate = log_list[
-                                            next_writing_index
-                                        ][0][0]
-                                        if cur_max_candidate is not None:
-                                            last_epoch_ns = (
-                                                cur_max_candidate
-                                                if cur_max_candidate > last_epoch_ns
-                                                else last_epoch_ns
-                                            )
-                                        for log in reversed(
-                                            log_list[next_writing_index]
-                                        ):
-                                            utc_time = _epoch_to_time_str(log[0])
-                                            cur_line = safe_load_json(log[1])
-                                            if without_timestamp:
-                                                f.write(f"{cur_line}\n")
-                                            else:
-                                                f.write(f"{utc_time}｜{cur_line}\n")
-                                    log_list[next_writing_index] = None
-                                    next_writing_index += 1
-                                    if index == next_writing_index:
-                                        progress.update(task, advance=1)
-                                else:
-                                    future_complete_list[index] = True
-                                    progress.update(task, advance=1)
-                            elapsed_sec = time.perf_counter() - start_perf
-                            last_utc_time = _epoch_to_time_str(last_epoch_ns)
-                            f.write(
-                                f"Time range: UTC|{first_utc_time} → "
-                                f"UTC|{last_utc_time} | total {total_lines} lines \n"
-                            )
-                        console.print(
-                            f"\n[bold]Time range[/]: [bold cyan]UTC|{first_utc_time}[/]"
-                            f" → [blue]UTC|{last_utc_time}[/]\n[bold]Total[/]:"
-                            f" [green]{total_lines}[/] lines \n[bold cyan]Duration[/]:"
-                            f" [magenta]{elapsed_sec:.2f}s[/]\n"
-                        )
-                        console.print(
-                            "\n[bold green]Successfully saved the log to:[/bold green]"
-                            f" {path}\n"
-                        )
-
-                        sys.exit(0)
-                    else:
-                        result_log_list = []
-                        for future in as_completed(futures):
-                            future.result()
-                            index = future_to_index[future]
-                            progress.update(task, advance=1)
-
-                        for log in reversed(log_list):
-                            result_log_list.extend(log)
-
-                    return result_log_list
+            # Path resolution (including any directory creation) is
+            # deferred to the scheduler itself -- see
+            # `_AdaptiveLogScheduler`/`_LazyFileSink` -- so a genuinely
+            # empty adaptive result never creates a directory or file.
+            #
+            # Terminal: fetch_logs_adaptive_parallel always sys.exit()s and
+            # never returns to this caller.
+            fetch_logs_adaptive_parallel(
+                deployment,
+                job,
+                replica,
+                job_history_name,
+                query,
+                unix_start,
+                unix_end,
+                workers,
+                without_timestamp,
+                path,
+            )
 
         # ======================================================================
         # LEGACY MODE
@@ -683,7 +1677,6 @@ def log_command(
                     for value in values:
                         cur_log_list.append((int(value[0]), value[1]))
 
-                # Break out of the loop if no logs exist in the specified time range
                 if len(cur_log_list) == 0:
                     progress.update(task, completed=True)
                     break
@@ -764,8 +1757,34 @@ def log_command(
         return first_utc_time, last_utc_time
 
     if not limit:
+        # Adaptive (no-`--limit`) path: dispatch straight into the adaptive
+        # scheduler. Its own root work unit fetches this exact
+        # `[start, end)` interval immediately, so a separate one-record
+        # probe request first would be redundant.
         fetch_and_print_logs(start, end, limit, path)
     else:
+        # LEGACY MODE (deprecated `--limit` path): probe first for a quick
+        # empty-range check before fetching sequentially.
+        try:
+            unix_start_probe = _preprocess_time(start, epoch=True)
+            unix_end_probe = _preprocess_time(end, epoch=True)
+            probe = client.log.get_log(
+                name_or_deployment=deployment,
+                name_or_job=job,
+                replica=replica,
+                job_history_name=job_history_name,
+                start=unix_start_probe,
+                end=unix_end_probe,
+                limit=1,
+                q=query,
+            )
+            if not probe or not probe.get("data", {}).get("result"):
+                console.print("[yellow]No logs found in the specified time range.[/]")
+                sys.exit(0)
+        except Exception as e:
+            console.print(f"[red]Failed to query logs[/]: {e}")
+            sys.exit(1)
+
         first_utc_time, last_utc_time = fetch_and_print_logs(start, end, limit, path)
         while True and sys.stdin.isatty():
             console.print(
@@ -817,7 +1836,7 @@ def log_command(
                     )
                     continue
 
-                seconds_str = param[:-1]  # remove the trailing 's'
+                seconds_str = param[:-1]
                 try:
                     float_seconds = float(seconds_str)
                 except ValueError:

--- a/leptonai/cli/tests/_log_test_helpers.py
+++ b/leptonai/cli/tests/_log_test_helpers.py
@@ -1,0 +1,169 @@
+"""Shared test scaffolding for the adaptive log-fetch test suites
+(`test_log_cli.py`, `test_log_adaptive_scheduler.py`,
+`test_log_adaptive_worker.py`, `test_log_adaptive_output.py`): Loki response
+construction, fake `APIClient`/`client.log` factories, and small
+thread-timing helpers used across these files' concurrency/backoff tests.
+
+Test ownership, going forward: worker handles page/retry; scheduler
+handles queue/order; output handles sinks; CLI handles wiring.
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+# Captured before any test patches `time.sleep` -- `time` here is the same
+# stdlib module object every other test module imports, so patching one
+# attribute patches it process-wide. Anything that needs to actually sleep a
+# bounded real duration from inside a patched `time.sleep` side_effect must
+# go through this reference to avoid infinite self-recursion.
+_REAL_SLEEP = time.sleep
+
+
+def pad_entries(n, lo, hi, prefix):
+    """n distinct-line entries with timestamps cycling through [lo, hi],
+    guaranteeing at least one entry at exactly `lo` and one at exactly `hi`
+    (so callers can rely on min/max of the resulting saturated page)."""
+    span = hi - lo
+    entries = [(lo + (i % (span + 1)), f"{prefix}{i}", {}) for i in range(n - 1)]
+    entries.append((hi, f"{prefix}-max", {}))
+    return entries
+
+
+def loki_response(entries):
+    """Build a Loki query_range-shaped payload from (ts_ns, line, stream) tuples."""
+    by_stream = {}
+    for ts, line, stream in entries:
+        by_stream.setdefault(tuple(sorted(stream.items())), []).append([str(ts), line])
+    result = [
+        {"stream": dict(stream_items), "values": values}
+        for stream_items, values in by_stream.items()
+    ]
+    return {"data": {"result": result}}
+
+
+class RecordingFakeLogAPI:
+    """Fake `client.log` recording every `get_log` call and its `direction`.
+
+    `script` maps (start, end) -> either a scripted response dict, an
+    Exception instance (raised once) or a list of such (consumed in order,
+    last one repeats).
+    """
+
+    def __init__(self, script):
+        self.script = script
+        self.calls = []
+        self._call_counts = {}
+        self.lock = threading.Lock()
+
+    def get_log(self, **kwargs):
+        key = (kwargs.get("start"), kwargs.get("end"))
+        with self.lock:
+            self.calls.append(dict(kwargs))
+            self._call_counts[key] = self._call_counts.get(key, 0) + 1
+            n = self._call_counts[key]
+
+        outcome = self.script.get(key)
+        if isinstance(outcome, list):
+            outcome = outcome[min(n - 1, len(outcome) - 1)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        if outcome is None:
+            return {"data": {"result": []}}
+        return outcome
+
+
+class FakeHTTPResponse:
+    def __init__(self, payload, ok=True, status_code=200, text=""):
+        self.ok = ok
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+class RealLogAPIHTTPClient:
+    """Fake HTTP transport for a real `LogAPI` instance -- lets a test drive
+    `LogAPI`'s own request/response parsing (e.g. `Retry-After` header
+    handling, precondition rejection) end to end, instead of constructing an
+    already-parsed `LogAPIError` by hand."""
+
+    def __init__(self):
+        self.new_deployment_api_enabled = False
+        self._get = MagicMock(return_value=FakeHTTPResponse({"data": {"result": []}}))
+        self._post = MagicMock()
+        self._put = MagicMock()
+        self._patch = MagicMock()
+        self._delete = MagicMock()
+        self._head = MagicMock()
+
+
+class FakeDeploymentAPI:
+    def get(self, name):
+        return None
+
+    def get_replicas(self, name):
+        return []
+
+
+def make_client_class(fake_log_api):
+    """Build a fake `APIClient` class exposing `.log` and a no-op
+    `.deployment` (unused by scheduler-layer tests, but required by the
+    CLI's own pre-dispatch deployment lookup)."""
+
+    class _Client:
+        last_instance = None
+
+        def __init__(self, *args, **kwargs):
+            self.log = fake_log_api
+            self.deployment = FakeDeploymentAPI()
+            _Client.last_instance = self
+
+    return _Client
+
+
+class InFlightTracker:
+    """Tracks the max number of concurrently-in-flight fake get_log calls."""
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.current = 0
+        self.max_seen = 0
+
+    def enter(self):
+        with self.lock:
+            self.current += 1
+            self.max_seen = max(self.max_seen, self.current)
+
+    def leave(self):
+        with self.lock:
+            self.current -= 1
+
+
+def two_unit_cancellation_fixture():
+    """Shared (frontier, blocked) unit pair for sink-cancellation tests:
+    UNIT_LOW resolves once UNIT_BLOCK has genuinely started (via the
+    returned `block_started` event), triggering cancellation while
+    UNIT_BLOCK is still in flight. Returns
+    (UNIT_LOW, UNIT_BLOCK, block_duration, block_started)."""
+    return (0, 5), (100, 200), 0.2, threading.Event()
+
+
+def wait_for_quiescent_threads(timeout=2.0):
+    """Block until only the main thread remains (or `timeout` elapses).
+
+    `time.sleep` is a single process-wide stdlib attribute, so patching it
+    (as every 429/backoff test does) affects *every* thread in the process,
+    not just the one under test. A worker thread from a just-finished prior
+    test that hasn't fully wound down yet would then have its own
+    `time.sleep` call routed into the *next* test's recorder, inflating call
+    counts. Call this before installing a `time.sleep` patch in tests that
+    assert an exact concurrent call count, to guarantee no straggler thread
+    is still in flight.
+    """
+    start = time.monotonic()
+    while threading.active_count() > 1 and time.monotonic() - start < timeout:
+        _REAL_SLEEP(0.01)

--- a/leptonai/cli/tests/test_log_adaptive_output.py
+++ b/leptonai/cli/tests/test_log_adaptive_output.py
@@ -1,0 +1,884 @@
+"""Unit tests for adaptive log-fetch output/sink lifecycle: stdout vs
+`--path` formatting, progress-bar gating, the "Partial result"/"Successfully
+saved" text contract, the lazy (deferred-open) file sink's footer/close
+behavior, and broken-pipe handling.
+
+Scheduler-owned state (pending/active/buffer, watermark, split, admission)
+lives in `test_log_adaptive_scheduler.py`; single-request parsing/retry
+lives in `test_log_adaptive_worker.py`. This file retains no
+`_AdaptiveLogScheduler`-driven test beyond what's needed to exercise output
+formatting -- the sole scheduler-level test proving a sink failure cancels
+future submissions stays in `test_log_adaptive_scheduler.py`
+(`TestAdaptiveSchedulerSinkFailure`).
+"""
+
+import builtins
+import os
+import tempfile
+
+# Set cache dir to a temp dir before importing anything from leptonai, matching
+# the existing CLI test suite convention (test_job_cli.py).
+tmpdir = tempfile.mkdtemp()
+os.environ["LEPTON_CACHE_DIR"] = tmpdir
+
+import heapq
+import io
+import unittest
+from unittest.mock import patch
+
+from loguru import logger
+
+from leptonai.cli import log as log_mod
+from leptonai.cli.log import (
+    WorkUnit,
+    _AdaptiveLogScheduler,
+    _epoch_to_time_str,
+    _FAILED_RANGES_FILE_CAP,
+    fetch_logs_adaptive_parallel,
+)
+from leptonai.cli.tests._log_test_helpers import (
+    RecordingFakeLogAPI as _RecordingFakeLogAPI,
+    loki_response as _loki_response,
+    make_client_class as _make_client_class,
+)
+
+# Captured before any test patches `builtins.open` -- `ConfigurableFakeFile`
+# wraps a genuine file underneath a patched `open`, so it cannot call the
+# (patched) name `open` itself.
+_REAL_OPEN = open
+
+
+class ConfigurableFakeFile:
+    """Recording/flaky file-handle double for output-lifecycle tests. Wraps
+    a real file, optionally injecting a write or close failure.
+
+    `fail_write_at`: 1-indexed write() call at which (and after which)
+    `fail_write_exc` is raised instead of writing.
+    `fail_write_exc`: exception raised by a failing write(); defaults to
+    `OSError("disk full")`.
+    `fail_on_close`: if True, close() still closes the underlying file (so
+    prior content is flushed) but then raises OSError.
+    """
+
+    def __init__(
+        self,
+        path,
+        mode,
+        encoding,
+        fail_write_at=None,
+        fail_write_exc=None,
+        fail_on_close=False,
+    ):
+        self._f = _REAL_OPEN(path, mode, encoding=encoding)
+        self._fail_write_at = fail_write_at
+        self._fail_write_exc = fail_write_exc or OSError("disk full")
+        self._fail_on_close = fail_on_close
+        self.write_calls = 0
+        self.close_calls = 0
+
+    def write(self, data):
+        self.write_calls += 1
+        if self._fail_write_at is not None and self.write_calls >= self._fail_write_at:
+            raise self._fail_write_exc
+        return self._f.write(data)
+
+    def close(self):
+        self.close_calls += 1
+        self._f.close()
+        if self._fail_on_close:
+            raise OSError("close failed")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+def make_configurable_fake_open(**kwargs):
+    """`builtins.open`-shaped side_effect constructing a
+    `ConfigurableFakeFile` with the given failure config for every call.
+    Returns (fake_open, instances) -- `instances` records every handle
+    constructed, for assertions on write_calls/close_calls."""
+    instances = []
+
+    def fake_open(path, mode="r", encoding=None):
+        f = ConfigurableFakeFile(path, mode, encoding, **kwargs)
+        instances.append(f)
+        return f
+
+    return fake_open, instances
+
+
+class TestSinkFailureOutputMessages(unittest.TestCase):
+    """Output-message content/formatting for sink-cancellation failures --
+    the sole scheduler-level test proving cancellation itself (an
+    already-in-flight request bounding shutdown) lives in
+    test_log_adaptive_scheduler.py's TestAdaptiveSchedulerSinkFailure.
+    """
+
+    def test_stdout_sink_failure_cancels_and_propagates_without_further_calls(self):
+        # unit=[0, 20000); saturates into a single unsplit child covering
+        # [14999, 20000). The parent's own sub-T entries are drained/emitted
+        # right after the parent's future resolves -- before the child is
+        # ever submitted -- so a sink failure on that first emit call must
+        # prevent the child's request from ever being made.
+        first_page = [(t, f"l{t}", {}) for t in range(5000, 15000)]
+        fake = _RecordingFakeLogAPI({
+            (0, 20000): _loki_response(first_page),
+            (14999, 20000): _loki_response([(15500, "tail", {})]),
+        })
+
+        # A genuinely, permanently broken pipe fails on every write, not
+        # just the first -- this is also what makes the BrokenPipeError
+        # propagation path deterministic to test.
+        def flaky_print(*args, **kwargs):
+            raise BrokenPipeError("broken pipe")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.console, "print", side_effect=flaky_print),
+            self.assertRaises(BrokenPipeError),
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 20000, 4, True, None
+            )
+
+        # Only the parent's fetch happened; cancellation must have prevented
+        # the child unit from ever being submitted.
+        requested_ranges = {(c["start"], c["end"]) for c in fake.calls}
+        self.assertEqual(requested_ranges, {(0, 20000)})
+
+    def test_lazy_open_failure_mid_stream_cancels_and_prevents_further_submission(self):
+        """A lazy `--path` open failure surfacing mid-loop (via `emit()`,
+        while a worker's fetch is genuinely in flight) is reported through
+        the single generic sink-failure message, and must still cancel and
+        prevent the child unit produced by the parent's saturation from ever
+        being submitted.
+        """
+        first_page = [(t, f"l{t}", {}) for t in range(5000, 15000)]
+        fake = _RecordingFakeLogAPI({
+            (0, 20000): _loki_response(first_page),
+            (14999, 20000): _loki_response([(15500, "tail", {})]),
+        })
+        outpath = os.path.join(tmpdir, "midloop_open_fail_out.txt")
+        printed = []
+
+        def fake_print(*args, **kwargs):
+            printed.append(str(args[0]) if args else "")
+
+        def fake_open(path, mode="r", encoding=None):
+            raise OSError("disk full")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.console, "print", side_effect=fake_print),
+            patch("builtins.open", side_effect=fake_open),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 20000, 4, True, outpath
+            )
+
+        self.assertEqual(cm.exception.code, 1)
+        requested_ranges = {(c["start"], c["end"]) for c in fake.calls}
+        self.assertEqual(requested_ranges, {(0, 20000)})
+        output = "\n".join(printed)
+        self.assertIn("Failed to write logs", output)
+        self.assertIn("disk full", output)
+        self.assertNotIn("Successfully saved", output)
+        self.assertNotIn("Partial result", output)
+
+    def test_path_sink_broken_pipe_write_cancels_and_propagates_without_further_calls(
+        self,
+    ):
+        """Verifies BrokenPipeError propagation, cancellation, and that the
+        --path sink's file handle is closed."""
+        first_page = [(t, f"l{t}", {}) for t in range(5000, 15000)]
+        fake = _RecordingFakeLogAPI({
+            (0, 20000): _loki_response(first_page),
+            (14999, 20000): _loki_response([(15500, "tail", {})]),
+        })
+        outpath = os.path.join(tmpdir, "path_sink_broken_pipe_out.txt")
+        fake_open, instances = make_configurable_fake_open(
+            fail_write_at=1, fail_write_exc=BrokenPipeError("broken pipe")
+        )
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch("builtins.open", side_effect=fake_open),
+            self.assertRaises(BrokenPipeError),
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 20000, 4, True, outpath
+            )
+
+        requested_ranges = {(c["start"], c["end"]) for c in fake.calls}
+        self.assertEqual(requested_ranges, {(0, 20000)})
+        self.assertEqual(instances[0].close_calls, 1)
+
+    def test_lazy_open_failure_at_zero_entry_partial_finalization_exits_1(self):
+        """A zero-entry partial run (no entries ever emitted, but nonzero
+        `failed_units`) still reaches the footer-write finalization step,
+        which triggers the lazy open. If that open fails, `run()` must exit
+        1 before printing any summary/success text.
+        """
+        outpath = os.path.join(
+            tempfile.mkdtemp(dir=tmpdir), "finalization_open_fail.txt"
+        )
+
+        def fake_open(path, mode="r", encoding=None):
+            raise OSError("disk full")
+
+        sched = _AdaptiveLogScheduler(
+            None, "job-1", None, None, "", 0, 100, 4, True, outpath
+        )
+        sched.pending = []
+        # No entries were ever emitted, but nonzero `failed_units` still
+        # forces `run()` to reach the footer-write finalization step.
+        sched.failed_units = [(0, 100)]
+
+        printed = []
+
+        def fake_print(*args, **kwargs):
+            printed.append(str(args[0]) if args else "")
+
+        with (
+            patch.object(log_mod.console, "print", side_effect=fake_print),
+            patch("builtins.open", side_effect=fake_open),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            sched.run()
+
+        self.assertEqual(cm.exception.code, 1)
+        output = "\n".join(printed)
+        self.assertIn("Failed to write logs", output)
+        self.assertIn("disk full", output)
+        self.assertNotIn("Successfully saved", output)
+        self.assertNotIn("Partial result", output)
+        self.assertNotIn("Time range:", output)
+
+
+class TestProgressBarAndSummaryFormat(unittest.TestCase):
+    """`Progress()` is instantiated inside `_AdaptiveLogScheduler.run()`
+    itself (gated on whether `path` is set), not CLI/Click glue, so these
+    tests don't need the CLI layer. The one full end-to-end `--path` output
+    case (file content/format) lives in test_log_cli.py's
+    TestPathOutputAndProgressBar per the compact CLI-integration matrix.
+    """
+
+    def test_no_progress_bar_for_stdout_output(self):
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response([(1, "a", {})])})
+        progress_calls = []
+        real_progress_cls = log_mod.Progress
+
+        def spy_progress(*args, **kwargs):
+            progress_calls.append((args, kwargs))
+            return real_progress_cls(*args, **kwargs)
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod, "Progress", new=spy_progress),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 100, 4, True, None
+            )
+
+        self.assertEqual(cm.exception.code, 0)
+        self.assertFalse(
+            progress_calls, "Progress must NOT be instantiated for stdout output"
+        )
+
+    def test_stdout_summary_uses_one_line_emoji_format(self):
+        """Stdout mode's final summary must print the original one-line
+        `👆Time range: UTC|... → UTC|... total N lines` format, NOT the
+        multi-line `Time range:` / `Total:` / `Duration:` console block that
+        `--path` mode prints (that block remains `--path`-only). Redirects
+        the real `console`'s output file to a buffer (rather than capturing
+        raw `print()` call args) so markup is actually rendered to plain
+        text, the same way `CliRunner` renders it for a real terminal-less
+        run.
+        """
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response([(1, "hello", {})])})
+        buf = io.StringIO()
+        # `Console.file` is a property that, when the internal `_file` is
+        # None, dynamically resolves to the *current* `sys.stdout` on every
+        # access -- which is how `CliRunner` transparently captures rich
+        # output in other tests. Saving/restoring via the `.file` property
+        # itself would instead snapshot a *fixed* stdout reference into
+        # `_file`, permanently breaking that dynamic resolution for every
+        # later test in the process that relies on it (leaking across test
+        # files). Save/restore the private `_file` attribute directly so
+        # this redirection is fully undone afterward.
+        real_file = log_mod.console._file
+        log_mod.console.file = buf
+        try:
+            with (
+                patch.object(log_mod, "APIClient", _make_client_class(fake)),
+                self.assertRaises(SystemExit) as cm,
+            ):
+                fetch_logs_adaptive_parallel(
+                    None, "job-1", None, None, "", 0, 100, 4, True, None
+                )
+        finally:
+            log_mod.console._file = real_file
+
+        self.assertEqual(cm.exception.code, 0)
+        output = buf.getvalue()
+        self.assertIn("👆Time range: UTC|", output)
+        self.assertIn("total 1 lines", output)
+        self.assertNotIn("Total:", output)
+        self.assertNotIn("Duration:", output)
+        self.assertNotIn("Successfully saved", output)
+
+
+class TestNoSuccessTextOnPartialFailure(unittest.TestCase):
+    """When `failed_units` is non-empty (and there was no
+    sink failure), neither mode may print any success-implying leading text;
+    both must print the "Partial result" replacement instead.
+    """
+
+    def _run(self, path):
+        S, E = 0, 10000
+        T = 1_000  # < branch_mid=5000 -> two children
+        split_mid = T + (E - T) // 2
+        # 10000 entries cycling within [0, T] so the page saturates with
+        # max_ts == T (rather than the full [S, E) range).
+        page = [(i % (T + 1), f"l{i}", {}) for i in range(9999)]
+        page.append((T, "l-max", {}))
+        self.assertEqual(len(page), 10000)
+        fake = _RecordingFakeLogAPI({
+            (S, E): _loki_response(page),
+            (T, split_mid): RuntimeError("permanent"),
+            (split_mid, E): _loki_response([(split_mid + 5, "ok-sibling", {})]),
+        })
+        printed = []
+
+        def fake_print(*args, **kwargs):
+            printed.append(str(args[0]) if args else "")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod, "_interruptible_sleep", return_value=None),
+            patch.object(log_mod.console, "print", side_effect=fake_print),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", S, E, 4, True, path
+            )
+        self.assertEqual(cm.exception.code, 2)
+        return "\n".join(printed)
+
+    def test_path_mode_no_success_text_prints_partial_result(self):
+        outpath = os.path.join(tmpdir, "no_success_text_path_out.txt")
+        output = self._run(outpath)
+        self.assertNotIn("Successfully saved", output)
+        self.assertIn("Partial result", output)
+        self.assertIn(f"saved incomplete log to: {outpath}", output)
+
+    def test_stdout_mode_no_success_text_prints_partial_result(self):
+        output = self._run(None)
+        self.assertNotIn("Successfully saved", output)
+        self.assertIn("Partial result", output)
+        self.assertIn("log output is incomplete", output)
+
+    def _run_success(self, path):
+        """Same shape as `_run` above, but nothing fails -- proving the
+        gating above is bidirectional, not just a one-way "always show
+        partial" bug.
+        """
+        S, E = 0, 10000
+        T = 1_000
+        split_mid = T + (E - T) // 2
+        page = [(i % (T + 1), f"l{i}", {}) for i in range(9999)]
+        page.append((T, "l-max", {}))
+        fake = _RecordingFakeLogAPI({
+            (S, E): _loki_response(page),
+            (T, split_mid): _loki_response([(T + 5, "child-ok", {})]),
+            (split_mid, E): _loki_response([(split_mid + 5, "ok-sibling", {})]),
+        })
+        printed = []
+
+        def fake_print(*args, **kwargs):
+            printed.append(str(args[0]) if args else "")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.console, "print", side_effect=fake_print),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", S, E, 4, True, path
+            )
+        self.assertEqual(cm.exception.code, 0)
+        return "\n".join(printed)
+
+    def test_control_no_failure_bidirectional_gating(self):
+        path_output = self._run_success(
+            os.path.join(tmpdir, "no_success_text_control_path_out.txt")
+        )
+        self.assertIn("Successfully saved", path_output)
+        self.assertNotIn("Partial result", path_output)
+
+        stdout_output = self._run_success(None)
+        self.assertNotIn("Partial result", stdout_output)
+        self.assertNotIn("Successfully saved", stdout_output)
+
+
+class TestFileFooterPartialResultMarker(unittest.TestCase):
+    """The saved `--path` file's footer states partial/incomplete when
+    `failed_units` is non-empty, including a capped summary of failed
+    ranges; the file footer is unchanged when nothing failed.
+
+    Each test constructs an `_AdaptiveLogScheduler` with an empty `pending`
+    queue (so `run()`'s fetch loop does nothing) and manually seeds
+    `failed_units`, isolating the file-footer-writing behavior from
+    bisection/scheduling mechanics (already covered elsewhere in this file).
+    """
+
+    def _run_with_failed_units(self, failed_units):
+        path = os.path.join(tempfile.mkdtemp(dir=tmpdir), "out.txt")
+        sched = _AdaptiveLogScheduler(
+            None, "job-1", None, None, "", 0, 100, 4, True, path
+        )
+        sched.pending = []
+        sched.failed_units = list(failed_units)
+        # A genuinely empty run (0 lines, 0 failures) short-circuits via the
+        # "No logs found" branch, which never creates the output file at all
+        # -- seed a nonzero line count so the "empty -- footer unchanged"
+        # case still exercises (and this test can still read) the normal
+        # footer-write path being tested here.
+        sched.bookkeeping.total_lines = 1
+
+        records = []
+        handler_id = logger.add(
+            lambda msg: records.append(msg.record["message"]), level="TRACE"
+        )
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                sched.run()
+        finally:
+            logger.remove(handler_id)
+
+        with open(path, encoding="utf-8") as f:
+            content = f.read()
+        return cm.exception.code, content, records
+
+    def test_footer_cap_boundary_cases(self):
+        """Table-driven: the failed-units-count-vs-`_FAILED_RANGES_FILE_CAP`
+        boundary. All 5 cases share the exact same mechanism
+        (`_run_with_failed_units` + footer cap truncation), varying only the
+        failed-units count relative to the cap (zero, under, exactly-at,
+        one-over, exceeding); each still asserts exit code, footer line
+        count/text, and (for the truncating cases) that the full untruncated
+        list reaches the trace log while the file itself stays truncated.
+
+        Widely-spaced (10s apart) ranges are used whenever count > 1 so each
+        range formats to a distinct, non-overlapping display string --
+        microsecond-resolution formatting would otherwise collapse
+        tightly-packed ns timestamps.
+        """
+        step = 10_000_000_000
+        cap = _FAILED_RANGES_FILE_CAP
+
+        def _ranges(n):
+            return [(i * step, i * step + 5_000_000) for i in range(n)]
+
+        cases = [
+            ("empty -- footer unchanged", _ranges(0), None),
+            ("small, under cap -- uncapped", [(10, 20), (30, 40)], None),
+            ("exactly at cap -- not truncated", _ranges(cap), None),
+            ("one over cap -- '+1 more'", _ranges(cap + 1), 1),
+            ("exceeding cap -- '+N more'", _ranges(cap + 3), 3),
+        ]
+
+        for description, failed_units, remaining in cases:
+            with self.subTest(description=description):
+                exit_code, content, records = self._run_with_failed_units(failed_units)
+                lines = content.splitlines()
+
+                if not failed_units:
+                    self.assertEqual(exit_code, 0)
+                    self.assertEqual(len(lines), 1)
+                    self.assertTrue(lines[0].startswith("Time range: UTC|"))
+                    self.assertNotIn("PARTIAL RESULT", content)
+                    continue
+
+                self.assertEqual(exit_code, 2)
+                self.assertEqual(len(lines), 2)
+                self.assertTrue(lines[0].startswith("Time range: UTC|"))
+                capped = failed_units[:cap]
+                expected_ranges = ", ".join(
+                    f"[{_epoch_to_time_str(s)}, {_epoch_to_time_str(e)})"
+                    for s, e in capped
+                )
+                if remaining is None:
+                    # Under or exactly-at the cap: no truncation suffix.
+                    self.assertEqual(
+                        lines[1],
+                        f"PARTIAL RESULT: {len(failed_units)} time range(s) could"
+                        " not be fetched and are missing from this file:"
+                        f" {expected_ranges}",
+                    )
+                    self.assertNotIn("more, see trace log", content)
+                else:
+                    self.assertEqual(
+                        lines[1],
+                        f"PARTIAL RESULT: {len(failed_units)} time range(s) could"
+                        " not be fetched and are missing from this file:"
+                        f" {expected_ranges} (+{remaining} more,"
+                        " see trace log for full list)",
+                    )
+                    # Full untruncated list only goes to the trace log,
+                    # never the file.
+                    full_list_traced = any(
+                        all(str((s, e)) in r for s, e in failed_units) for r in records
+                    )
+                    self.assertTrue(full_list_traced)
+                    for s, e in failed_units[cap:]:
+                        self.assertNotIn(_epoch_to_time_str(s), content)
+
+
+class TestPartialRunWithZeroEntriesCreatesFileLazily(unittest.TestCase):
+    """A genuinely partial run -- its only unit fails permanently, so zero
+    entries are ever emitted but `failed_units`
+    ends up non-empty -- must still create the `--path` output file, with
+    the partial-result footer, driven through a real `run()` (unlike
+    `TestFileFooterPartialResultMarker` above, which manually seeds
+    `bookkeeping.total_lines`/`failed_units` to isolate the footer-writing
+    mechanics in isolation). This exercises the lazy sink's other deferred-
+    open trigger: reaching finalization with nonempty `failed_units`, not an
+    emitted entry.
+    """
+
+    def test_all_units_fail_still_creates_file_with_partial_footer(self):
+        fake = _RecordingFakeLogAPI({(0, 100): RuntimeError("permanent")})
+        outdir = tempfile.mkdtemp(dir=tmpdir)
+        outpath = os.path.join(outdir, "all_failed_out.txt")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod, "_interruptible_sleep", return_value=None),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 100, 4, True, outpath
+            )
+
+        self.assertEqual(cm.exception.code, 2)
+        self.assertTrue(
+            os.path.exists(outpath),
+            "the output file must be created for a partial run even when"
+            " zero entries were ever emitted",
+        )
+        with open(outpath, encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("total 0 lines", content)
+        self.assertIn("PARTIAL RESULT:", content)
+        self.assertIn(
+            "time range(s) could not be fetched and are missing from this file:",
+            content,
+        )
+
+
+class TestFooterViaOpenHandle(unittest.TestCase):
+    """The saved `--path` file's footer is written through the same still-
+    open `f` handle used for streaming entries -- no second `open(path, "a")`
+    call -- and output-lifecycle failures at the open/footer-write/close
+    steps are caught and reported via `console.print`, never left uncaught.
+    """
+
+    def _scheduler(self, path):
+        sched = _AdaptiveLogScheduler(
+            None, "job-1", None, None, "", 0, 100, 4, True, path
+        )
+        sched.pending = []  # isolate footer-writing behavior
+        # A genuinely empty run (0 lines, 0 failures) short-circuits via the
+        # "No logs found" branch before ever reaching the footer/close logic
+        # under test here -- seed a nonzero line count so these tests keep
+        # exercising the normal footer-write/close path.
+        sched.bookkeeping.total_lines = 1
+        return sched
+
+    def test_only_one_open_call_no_reopen_for_footer(self):
+        outdir = tempfile.mkdtemp(dir=tmpdir)
+        outpath = os.path.join(outdir, "single_open.txt")
+        sched = self._scheduler(outpath)
+
+        real_open = builtins.open
+        open_calls = []
+
+        def counting_open(path, mode="r", encoding=None, *args, **kwargs):
+            open_calls.append((path, mode))
+            return real_open(path, mode, encoding=encoding, *args, **kwargs)
+
+        with (
+            patch("builtins.open", side_effect=counting_open),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            sched.run()
+
+        self.assertEqual(cm.exception.code, 0)
+        matching = [c for c in open_calls if c[0] == outpath]
+        self.assertEqual(
+            len(matching),
+            1,
+            f"expected exactly one open() call for {outpath}, got {matching}",
+        )
+        self.assertEqual(matching[0][1], "w")
+
+    # A lazy-open failure at finalization time is covered by
+    # TestSinkFailureOutputMessages
+    # .test_lazy_open_failure_at_zero_entry_partial_finalization_exits_1.
+
+    def test_footer_write_vs_close_failure(self):
+        """Footer-write and close failures both print exactly one failure
+        message and no success text, but differ in whether the footer ends
+        up on disk (fail_write_at=1: no streaming writes precede the footer
+        write, so it's the first write() call; a close failure instead
+        happens strictly after a successful footer write)."""
+        cases = {
+            "footer_write_fails": {
+                "open_kwargs": {"fail_write_at": 1},
+                "expected_message": "Failed to write log file footer",
+                "footer_on_disk": False,
+            },
+            "close_fails_after_footer_written": {
+                "open_kwargs": {"fail_on_close": True},
+                "expected_message": "Failed to close output file",
+                "footer_on_disk": True,
+            },
+        }
+        for name, case in cases.items():
+            with self.subTest(name):
+                outdir = tempfile.mkdtemp(dir=tmpdir)
+                outpath = os.path.join(outdir, f"{name}.txt")
+                sched = self._scheduler(outpath)
+                fake_open, _ = make_configurable_fake_open(**case["open_kwargs"])
+                printed = []
+
+                def fake_print(*args, **kwargs):
+                    printed.append(str(args[0]) if args else "")
+
+                with (
+                    patch("builtins.open", side_effect=fake_open),
+                    patch.object(log_mod.console, "print", side_effect=fake_print),
+                    self.assertRaises(SystemExit) as cm,
+                ):
+                    sched.run()
+
+                self.assertEqual(cm.exception.code, 1)
+                output = "\n".join(printed)
+                self.assertIn(case["expected_message"], output)
+                self.assertNotIn("Successfully saved", output)
+                self.assertNotIn("Partial result", output)
+                self.assertEqual(
+                    sum(
+                        output.count(msg)
+                        for msg in (
+                            "Failed to write log file footer",
+                            "Failed to close output file",
+                        )
+                    ),
+                    1,
+                    "exactly one failure message must be printed",
+                )
+                with open(outpath, encoding="utf-8") as f:
+                    content = f.read()
+                self.assertEqual("Time range: UTC|" in content, case["footer_on_disk"])
+
+
+class TestPostRetrievalPrintFailurePropagatesUncaught(unittest.TestCase):
+    """Regression test for the removal of the old catch-and-translate
+    console-print helper: a `console.print` failure (e.g. `BrokenPipeError`)
+    at one of the
+    post-retrieval "success-path" print sites -- the failed-units warning,
+    the final rich summary block, and the success/partial-success lines --
+    is no longer caught and translated into `sys.exit(1)`; it now propagates
+    out of `run()` as a normal uncaught exception. The mid-stream/in-loop
+    case (a `console.print` failure while a fetch is still genuinely in
+    flight, which surfaces through the existing sink-failure machinery and
+    still exits 1) is unrelated and stays covered by
+    `TestSinkFailureOutputMessages` here and
+    `TestAdaptiveSchedulerSinkFailure` in test_log_adaptive_scheduler.py.
+    """
+
+    def test_broken_pipe_on_no_logs_found_print_propagates_uncaught(self):
+        # stdout mode (path=None), empty `pending` so `run()`'s fetch loop
+        # does nothing, and the constructor-seeded defaults (total_lines=0,
+        # failed_units=[]) drive straight into the zero-entry/no-failures
+        # "No logs found" branch -- the simplest post-retrieval print site
+        # to isolate, with only a single `console.print` call in play.
+        sched = _AdaptiveLogScheduler(
+            None, "job-1", None, None, "", 0, 100, 4, True, None
+        )
+        sched.pending = []
+
+        def flaky_print(*args, **kwargs):
+            raise BrokenPipeError("broken pipe")
+
+        with (
+            patch.object(log_mod.console, "print", side_effect=flaky_print),
+            self.assertRaises(BrokenPipeError),
+        ):
+            sched.run()
+
+
+class TestBestEffortCloseFlushesStreamedContent(unittest.TestCase):
+    """On a `sink_exc`/`watermark_exc` early exit or a footer-write failure,
+    a silent best-effort `f.close()` is attempted before `sys.exit(1)`: small
+    writes must be explicitly closed to reach disk, so these tests prove
+    already-streamed content isn't left stranded in the write buffer and
+    lost. Each covers a distinct trigger (entry-write failure, watermark
+    regression, footer-write failure), so they're kept as separate methods
+    rather than one table.
+
+    `assertRaises(SystemExit)` clears `run()`'s frame locals (including
+    `f`) as a side effect of clearing the caught exception's traceback,
+    which would incidentally flush `f` via its own implicit GC-driven close
+    regardless of whether `run()`'s own explicit best-effort close exists.
+    The entry-write-failure and watermark-regression tests below use a
+    plain try/except to avoid that false pass; the footer-write-failure
+    test's content is proven flushed independently by its own success (5
+    real entries streamed, only the 6th write -- the footer -- fails), so
+    it doesn't need the same workaround.
+    """
+
+    def test_entry_write_failure_preserves_streamed_content(self):
+        # A single small, non-saturating unit resolves in one shot, so its
+        # three entries are drained and emitted together in one batch, well
+        # under the TextIOWrapper write buffer's several-KB auto-flush
+        # threshold -- keeping content this small means the only way the
+        # first two entries' writes can reach disk before sys.exit is the
+        # best-effort explicit close on the sink_exc path, not an unrelated
+        # buffer auto-flush.
+        real_open = builtins.open
+        fake = _RecordingFakeLogAPI({
+            (0, 100): _loki_response([
+                (1, "s1", {}),
+                (2, "s2", {}),
+                (3, "s3", {}),
+            ]),
+        })
+        outpath = os.path.join(tmpdir, "sink_fail_flush_small_out.txt")
+        fake_open, _ = make_configurable_fake_open(fail_write_at=3)
+
+        exit_code = None
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch("builtins.open", side_effect=fake_open),
+        ):
+            try:
+                fetch_logs_adaptive_parallel(
+                    None, "job-1", None, None, "", 0, 100, 4, True, outpath
+                )
+            except SystemExit as exc:
+                exit_code = exc.code
+
+        self.assertEqual(exit_code, 1)
+        with real_open(outpath, encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("s1", content)
+        self.assertIn("s2", content)
+
+    def test_watermark_regression_preserves_streamed_content(self):
+        # Two small units, `--workers 1` so they resolve strictly serially:
+        # the first unit's two entries stream and its watermark advances
+        # normally before `_compute_watermark` is forced to regress on the
+        # second unit's call, injecting the watermark_exc failure only
+        # after real content has streamed.
+        real_open = builtins.open
+        fake = _RecordingFakeLogAPI({
+            (0, 10): _loki_response([(1, "wa1", {}), (2, "wa2", {})]),
+            (10, 20): _loki_response([(11, "wb1", {})]),
+        })
+        outpath = os.path.join(tmpdir, "watermark_fail_flush_small_out.txt")
+        fake_open, instances = make_configurable_fake_open()
+
+        real_compute_watermark = log_mod._AdaptiveLogScheduler._compute_watermark
+        call_state = {"n": 0}
+
+        def fake_compute_watermark(self):
+            call_state["n"] += 1
+            if call_state["n"] == 1:
+                return real_compute_watermark(self)
+            return -1
+
+        sched = _AdaptiveLogScheduler(
+            None, "job-1", None, None, "", 0, 20, 1, True, outpath
+        )
+        sched.pending = []  # drop the constructor-seeded [0, 20) unit
+        heapq.heappush(sched.pending, WorkUnit(sched._next_seq(), 0, 10))
+        heapq.heappush(sched.pending, WorkUnit(sched._next_seq(), 10, 20))
+
+        printed = []
+
+        def fake_print(*args, **kwargs):
+            printed.append(str(args[0]) if args else "")
+
+        exit_code = None
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch("builtins.open", side_effect=fake_open),
+            patch.object(log_mod.console, "print", side_effect=fake_print),
+            patch.object(
+                log_mod._AdaptiveLogScheduler,
+                "_compute_watermark",
+                fake_compute_watermark,
+            ),
+        ):
+            try:
+                sched.run()
+            except SystemExit as exc:
+                exit_code = exc.code
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Internal scheduling error", "\n".join(printed))
+        # A best-effort close IS attempted on the watermark_exc path.
+        self.assertEqual(instances[0].close_calls, 1)
+        with real_open(outpath, encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("wa1", content)
+        self.assertIn("wa2", content)
+
+    def test_footer_write_failure_preserves_streamed_content(self):
+        # A single, non-saturating page: one fetch resolves the whole
+        # range, all 5 entries stream successfully, and only afterward does
+        # the footer write (the 6th write() call) fail.
+        real_open = builtins.open
+        first_page = [(t, f"l{t}", {}) for t in range(10, 15)]
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response(first_page)})
+        outpath = os.path.join(tmpdir, "footer_fail_flush_out.txt")
+        fake_open, _ = make_configurable_fake_open(fail_write_at=6)
+
+        printed = []
+
+        def fake_print(*args, **kwargs):
+            printed.append(str(args[0]) if args else "")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch("builtins.open", side_effect=fake_open),
+            patch.object(log_mod.console, "print", side_effect=fake_print),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 100, 4, True, outpath
+            )
+
+        self.assertEqual(cm.exception.code, 1)
+        with real_open(outpath, encoding="utf-8") as f:
+            content = f.read()
+        # The 5 already-streamed lines survive the best-effort close, even
+        # though the footer itself is absent/incomplete.
+        for t in range(10, 15):
+            self.assertIn(f"l{t}", content)
+        self.assertNotIn("Time range: UTC|", content)
+
+        # Exactly one failure is reported -- the footer-write failure --
+        # never a second close-failure message, since the best-effort close
+        # on this path is silent even if it also fails.
+        output = "\n".join(printed)
+        self.assertIn("Failed to write log file footer", output)
+        self.assertNotIn("Failed to close output file", output)

--- a/leptonai/cli/tests/test_log_adaptive_scheduler.py
+++ b/leptonai/cli/tests/test_log_adaptive_scheduler.py
@@ -1,0 +1,1465 @@
+"""Unit tests for state owned by `_AdaptiveLogScheduler` itself: bisection
+math (including the fetched-interval midpoint heuristic for one- vs
+two-child splits), watermark computation, split/same-timestamp decisions,
+admission arithmetic, and the real-thread integrations that require genuine
+concurrency (chronological output despite reverse completion order, the
+frontier-exemption deadlock regression, and sink-failure cancellation of an
+already-in-flight request).
+
+Single-request-cycle behavior (`_parse_log_entries`, `LogEntry` identity,
+`_fetch_log_unit` retry/backoff) lives in `test_log_adaptive_worker.py`.
+Output/sink formatting lives in `test_log_adaptive_output.py`. Tests call
+`_fetch_log_unit` and `fetch_logs_adaptive_parallel` directly (both are
+public module-level symbols) rather than going through the full
+`lep log get` CLI invocation.
+"""
+
+import os
+import tempfile
+
+# Set cache dir to a temp dir before importing anything from leptonai, matching
+# the existing CLI test suite convention (test_job_cli.py).
+tmpdir = tempfile.mkdtemp()
+os.environ["LEPTON_CACHE_DIR"] = tmpdir
+
+import heapq
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from loguru import logger
+
+from leptonai.api.v2.log import LogAPIError
+from leptonai.cli import log as log_mod
+from leptonai.cli.log import (
+    FetchUnitResult,
+    LogEntry,
+    WorkUnit,
+    _AdaptiveLogScheduler,
+    _fetch_log_unit,
+    fetch_logs_adaptive_parallel,
+)
+from leptonai.cli.tests._log_test_helpers import (
+    RecordingFakeLogAPI as _RecordingFakeLogAPI,
+    loki_response as _loki_response,
+    make_client_class as _make_client_class,
+    pad_entries as _pad_entries,
+    two_unit_cancellation_fixture as _two_unit_cancellation_fixture,
+    wait_for_quiescent_threads as _wait_for_quiescent_threads,
+)
+
+
+class TestAdaptiveSchedulerBisection(unittest.TestCase):
+    """The fetched-interval-midpoint split heuristic:
+    saturation at/past the midpoint of the *fetched* unit yields one child
+    covering the whole remainder; saturation before it yields two children
+    bisecting the remainder.
+    """
+
+    def test_saturation_relative_to_fetched_midpoint_controls_child_count(self):
+        """Table-driven: unit=[0, 20000), fetched_mid=10000. A saturated
+        first page with max_ts >= fetched_mid yields exactly one child
+        covering the remainder; max_ts < fetched_mid bisects the remainder
+        into two children instead."""
+        mid = 9999 + (20000 - 9999) // 2
+        cases = [
+            (
+                "at/past fetched midpoint -> single child",
+                [(t, f"l{t}", {}) for t in range(5000, 15000)],
+                {(14999, 20000): _loki_response([(15500, "tail", {})])},
+                {(0, 20000), (14999, 20000)},
+            ),
+            (
+                "before fetched midpoint -> two children",
+                [(t, f"l{t}", {}) for t in range(0, 10000)],
+                {
+                    (9999, mid): _loki_response([(10100, "a", {})]),
+                    (mid, 20000): _loki_response([(18000, "b", {})]),
+                },
+                {(0, 20000), (9999, mid), (mid, 20000)},
+            ),
+        ]
+        for description, first_page, children_script, expected_ranges in cases:
+            with self.subTest(description=description):
+                self.assertEqual(len(first_page), 10000)
+                fake = _RecordingFakeLogAPI({
+                    (0, 20000): _loki_response(first_page),
+                    **children_script,
+                })
+                with (
+                    patch.object(log_mod, "APIClient", _make_client_class(fake)),
+                    self.assertRaises(SystemExit) as cm,
+                    patch.object(log_mod.console, "print"),
+                ):
+                    fetch_logs_adaptive_parallel(
+                        None, "job-1", None, None, "", 0, 20000, 4, True, None
+                    )
+                self.assertEqual(cm.exception.code, 0)
+                requested_ranges = {(c["start"], c["end"]) for c in fake.calls}
+                self.assertEqual(requested_ranges, expected_ranges)
+                self.assertEqual(len(fake.calls), len(expected_ranges))
+
+    def test_all_calls_use_forward_direction(self):
+        first_page = [(t, f"l{t}", {}) for t in range(5000, 15000)]
+        fake = _RecordingFakeLogAPI({
+            (0, 20000): _loki_response(first_page),
+            (14999, 20000): _loki_response([(15500, "tail", {})]),
+        })
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            self.assertRaises(SystemExit),
+            patch.object(log_mod.console, "print"),
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 20000, 4, True, None
+            )
+        self.assertTrue(fake.calls)
+        for call in fake.calls:
+            self.assertEqual(call["direction"], "forward")
+
+
+class TestChronologicalOutputAcrossRecursiveSplits(unittest.TestCase):
+    """This never needs the CLI/Click layer, only
+    `fetch_logs_adaptive_parallel` directly. Essential invariant #4
+    (chronological watermark emission): a 3-leaf, 2-level
+    bisecting tree where later-start (chronologically later) leaf units are
+    made to resolve *first* via real, per-key delays under a real
+    `ThreadPoolExecutor`, proving final output ordering reflects timestamp
+    order, not completion order.
+
+    Tree shape over [S, E): root saturates at T1=S+3000 (< branch_mid) ->
+    two children C1=[S+3000, S+9500), C2=[S+9500, E). C1 saturates at
+    T2=S+4000 (< its own branch_mid) -> two children D1=[S+4000, S+6750),
+    D2=[S+6750, S+9500). C2 terminates without further splitting. Leaves:
+    D1, D2, C2 -- three leaf units at different recursion depths.
+    """
+
+    S, E = 0, 16_000_000
+
+    class _DelayedFakeLogAPI:
+        def __init__(self, script, delay_fn):
+            self.script = script
+            self.delay_fn = delay_fn
+            self.calls = []
+            self.lock = threading.Lock()
+
+        def get_log(self, **kwargs):
+            key = (kwargs.get("start"), kwargs.get("end"))
+            with self.lock:
+                self.calls.append(dict(kwargs))
+            time.sleep(self.delay_fn(key))
+            outcome = self.script.get(key)
+            if outcome is None:
+                return {"data": {"result": []}}
+            return outcome
+
+    @classmethod
+    def _delay_for(cls, key):
+        start = key[0]
+        frac = (start - cls.S) / (cls.E - cls.S)
+        # Earlier-start units sleep longer, so later-start (chronologically
+        # later) leaf units' futures resolve first.
+        return max(0.002, 0.03 * (1 - frac))
+
+    def _build_tree_script(self):
+        S, E = self.S, self.E
+        root_page = _pad_entries(10000, S + 0, S + 3_000_000, "r")
+        c1_page = _pad_entries(10000, S + 3_000_000, S + 4_000_000, "c1")
+        d1_resp = _loki_response(
+            [(S + 4_500_000, "d1a", {}), (S + 4_600_000, "d1b", {})]
+        )
+        d2_resp = _loki_response([(S + 7_000_000, "d2a", {})])
+        c2_resp = _loki_response([(S + 12_000_000, "c2a", {})])
+        return {
+            (S, E): _loki_response(root_page),
+            (S + 3_000_000, S + 9_500_000): _loki_response(c1_page),
+            (S + 4_000_000, S + 6_750_000): d1_resp,
+            (S + 6_750_000, S + 9_500_000): d2_resp,
+            (S + 9_500_000, E): c2_resp,
+        }
+
+    def test_chronological_output_regardless_of_completion_order(self):
+        S, E = self.S, self.E
+        script = self._build_tree_script()
+        fake = self._DelayedFakeLogAPI(script, self._delay_for)
+        outpath = os.path.join(tmpdir, "recursive_split_chronological_out.txt")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", S, E, 4, True, outpath
+            )
+
+        self.assertEqual(cm.exception.code, 0)
+        self.assertEqual(len(fake.calls), 5)
+
+        with open(outpath, encoding="utf-8") as f:
+            content = f.read()
+        for marker in ("d1a", "d1b", "d2a", "c2a"):
+            self.assertIn(marker, content)
+        idx_d1a = content.index("d1a")
+        idx_d1b = content.index("d1b")
+        idx_d2a = content.index("d2a")
+        idx_c2a = content.index("c2a")
+        # d1 (ts=4500,4600) < d2 (ts=7000) < c2 (ts=12000), regardless of
+        # which unit's future resolved first.
+        self.assertTrue(idx_d1a < idx_d1b < idx_d2a < idx_c2a)
+
+
+class TestAdaptiveSchedulerBoundaryDedup(unittest.TestCase):
+    def test_boundary_timestamp_no_duplicate_no_drop(self):
+        # unit=[0, 20000); fetched_mid=10000. Parent saturates with max_ts
+        # (T)=14998 (>= fetched_mid) -> single child [14998, 20000). Parent's
+        # page includes two boundary entries at ts=14998 that the child
+        # re-fetches verbatim (exact duplicates), plus one entry the child
+        # sees that the parent didn't.
+        parent_entries = [(t, f"l{t}", {"pod": "p1"}) for t in range(5000, 14998)]
+        parent_entries.append((14998, "boundary-A", {"pod": "p1"}))
+        parent_entries.append((14998, "boundary-B", {"pod": "p1"}))
+        self.assertEqual(len(parent_entries), 10000)
+
+        child_entries = [
+            (14998, "boundary-A", {"pod": "p1"}),  # exact duplicate of parent's
+            (14998, "boundary-B", {"pod": "p1"}),  # exact duplicate of parent's
+            (14998, "boundary-C", {"pod": "p1"}),  # only visible to the child
+            (15500, "tail", {"pod": "p1"}),
+        ]
+
+        fake = _RecordingFakeLogAPI({
+            (0, 20000): _loki_response(parent_entries),
+            (14998, 20000): _loki_response(child_entries),
+        })
+
+        outpath = os.path.join(tmpdir, "boundary_out.txt")
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 20000, 4, False, outpath
+            )
+        self.assertEqual(cm.exception.code, 0)
+
+        with open(outpath, encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertEqual(content.count("boundary-A"), 1)
+        self.assertEqual(content.count("boundary-B"), 1)
+        self.assertEqual(content.count("boundary-C"), 1)
+
+
+class TestAdaptiveSchedulerSinkFailure(unittest.TestCase):
+    """Scheduler-level sink-failure/cancellation integrations that require
+    real ThreadPoolExecutor concurrency (an already-in-flight request).
+    Output-message content/formatting for sink failures lives in
+    test_log_adaptive_output.py's TestSinkFailureOutputMessages.
+    """
+
+    def test_real_fetch_log_unit_blocked_request_bounds_shutdown_and_uses_adaptive_timeout(
+        self,
+    ):
+        """Exercises the REAL `_fetch_log_unit` (only `get_log` is mocked) so
+        a regression in the `timeout=_ADAPTIVE_FETCH_TIMEOUT_SEC` wiring is
+        detectable, and proves shutdown stays bounded by the in-flight
+        request's own duration after cancellation."""
+        UNIT_LOW, UNIT_BLOCK, block_duration, block_started = (
+            _two_unit_cancellation_fixture()
+        )
+
+        class _BlockingFakeLogAPI:
+            def __init__(self):
+                self.calls = []
+                self.lock = threading.Lock()
+
+            def get_log(self, **kwargs):
+                key = (kwargs.get("start"), kwargs.get("end"))
+                with self.lock:
+                    self.calls.append(dict(kwargs))
+                if key == UNIT_LOW:
+                    assert block_started.wait(timeout=5), "UNIT_BLOCK never started"
+                    return _loki_response([(1, "low", {})])
+                if key == UNIT_BLOCK:
+                    # Simulates a worker blocked mid-HTTP-request, bounded by
+                    # whatever `timeout` `_fetch_log_unit` actually passed
+                    # through -- this is the real production call path.
+                    block_started.set()
+                    time.sleep(block_duration)
+                    return _loki_response([(150, "blocked", {})])
+                raise AssertionError(f"unexpected unit range {key}")
+
+        fake = _BlockingFakeLogAPI()
+
+        # A genuinely, permanently broken pipe fails on every print, not
+        # just the first -- this also makes the BrokenPipeError propagation
+        # path below deterministic to test.
+        def flaky_print(*args, **kwargs):
+            raise BrokenPipeError("broken pipe")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.console, "print", side_effect=flaky_print),
+        ):
+            sched = _AdaptiveLogScheduler(
+                None, "job-1", None, None, "", UNIT_LOW[0], UNIT_LOW[1], 2, True, None
+            )
+            heapq.heappush(sched.pending, WorkUnit(sched._next_seq(), *UNIT_BLOCK))
+
+            start_perf = time.perf_counter()
+            with self.assertRaises(BrokenPipeError):
+                sched.run()
+            elapsed = time.perf_counter() - start_perf
+
+        self.assertGreaterEqual(elapsed, block_duration)
+        self.assertLess(elapsed, 5.0)
+        self.assertFalse(sched.pending)
+
+        # The real `_fetch_log_unit` must have reached `get_log` with the
+        # bounded adaptive timeout for both units, including the one that
+        # was genuinely in-flight when cancellation happened.
+        calls_by_range = {(c["start"], c["end"]): c for c in fake.calls}
+        self.assertIn(UNIT_LOW, calls_by_range)
+        self.assertIn(UNIT_BLOCK, calls_by_range)
+        self.assertEqual(
+            calls_by_range[UNIT_LOW]["timeout"], log_mod._ADAPTIVE_FETCH_TIMEOUT_SEC
+        )
+        self.assertEqual(
+            calls_by_range[UNIT_BLOCK]["timeout"], log_mod._ADAPTIVE_FETCH_TIMEOUT_SEC
+        )
+
+
+class TestAdaptiveSchedulerRetryFailureSurfaced(unittest.TestCase):
+    def test_partial_failure_after_retries_exits_2_and_still_emits_others(self):
+        # unit=[0, 20000) split into two children (saturation before
+        # fetched_mid). One child permanently fails; the other succeeds.
+        first_page = [(t, f"l{t}", {}) for t in range(0, 10000)]
+        mid = 9999 + (20000 - 9999) // 2
+        fake = _RecordingFakeLogAPI({
+            (0, 20000): _loki_response(first_page),
+            (9999, mid): RuntimeError("permanent"),
+            (mid, 20000): _loki_response([(18000, "ok", {})]),
+        })
+
+        outpath = os.path.join(tmpdir, "partial_fail_out.txt")
+        # The scheduler always supplies a real `cancelled` threading.Event to
+        # `_fetch_log_unit`, so its backoff/retry sleeps go
+        # through `_interruptible_sleep(delay, cancelled)`, not
+        # `time.sleep(delay)` directly -- patch `_interruptible_sleep` itself
+        # rather than `threading.Event.wait`, which `threading.Thread.start()`
+        # also relies on internally and would break the executor's own
+        # worker threads if patched process-wide.
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod, "_interruptible_sleep", return_value=None),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 20000, 4, True, outpath
+            )
+
+        self.assertEqual(cm.exception.code, 2)
+        with open(outpath, encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("ok", content)
+        # The permanently-failing child was retried the full budget.
+        failing_calls = [c for c in fake.calls if (c["start"], c["end"]) == (9999, mid)]
+        self.assertEqual(len(failing_calls), 5)
+
+
+class TestWorkUnitHeapOrdering(unittest.TestCase):
+    """`WorkUnit`'s `(start, seq_id)` total order makes it
+    usable directly as a `heapq` key.
+    """
+
+    def test_smallest_start_dispatched_first_regardless_of_insertion_order(self):
+        pending = []
+        heapq.heappush(pending, WorkUnit(0, 5000, 6000))
+        heapq.heappush(pending, WorkUnit(1, 1000, 2000))
+        heapq.heappush(pending, WorkUnit(2, 3000, 4000))
+        popped = heapq.heappop(pending)
+        self.assertEqual((popped.start, popped.seq_id), (1000, 1))
+
+    def test_equal_start_tie_broken_by_seq_id_ascending(self):
+        pending = []
+        heapq.heappush(pending, WorkUnit(7, 2000, 3000))
+        heapq.heappush(pending, WorkUnit(3, 2000, 3000))
+        first = heapq.heappop(pending)
+        second = heapq.heappop(pending)
+        self.assertEqual(first.seq_id, 3)
+        self.assertEqual(second.seq_id, 7)
+
+    def test_dynamically_enqueued_child_dispatched_by_start_not_insertion_order(self):
+        """`--workers 1` (via `fetch_logs_adaptive_parallel` directly, no CLI
+        layer needed) makes dispatch order directly observable one call at
+        a time. Root splits (two-child, early saturation) into
+        C1=[T,split_mid), C2=[split_mid,E) -- inserted in that order. C1
+        itself then splits (late saturation, single unsplit child) into
+        C1'=[T2,split_mid), which is *inserted after* C2 (already pending)
+        but has a *smaller* start than C2. A min-heap must dispatch C1'
+        next (smallest start); a plain FIFO queue would dispatch C2 next
+        (inserted first) -- the case that distinguishes heap order from
+        insertion order for a unit that didn't even exist at the time its
+        sibling was enqueued.
+        """
+        S, E = 0, 4_000_000
+        T = S + 1_000_000  # < branch_mid=S+2_000_000 -> two-child split
+        split_mid = T + (E - T) // 2
+        self.assertEqual(split_mid, S + 2_500_000)
+        c1_start, c1_end = T, split_mid
+        c2_start, c2_end = split_mid, E
+
+        root_page = _pad_entries(10000, S, T, "root")
+        # C1 saturates late (T2 >= its own branch_mid=S+1_750_000) -> a
+        # single unsplit child C1'=[T2, c1_end).
+        T2 = S + 2_300_000
+        self.assertGreaterEqual(T2, (c1_start + c1_end) / 2)
+        c1_page = _pad_entries(10000, c1_start, T2, "c1")
+        c1_prime = (T2, c1_end)
+
+        fake = _RecordingFakeLogAPI({
+            (S, E): _loki_response(root_page),
+            (c1_start, c1_end): _loki_response(c1_page),
+            c1_prime: _loki_response([(T2 + 5, "c1-prime", {})]),
+            (c2_start, c2_end): _loki_response([(c2_start + 5, "c2", {})]),
+        })
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            self.assertRaises(SystemExit) as cm,
+            patch.object(log_mod.console, "print"),
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", S, E, 1, True, None
+            )
+
+        self.assertEqual(cm.exception.code, 0)
+        actual = [(c["start"], c["end"]) for c in fake.calls]
+        heap_order = [(S, E), (c1_start, c1_end), c1_prime, (c2_start, c2_end)]
+        fifo_order = [(S, E), (c1_start, c1_end), (c2_start, c2_end), c1_prime]
+        self.assertEqual(actual, heap_order)
+        self.assertNotEqual(actual, fifo_order)
+
+
+class TestSharedRateLimitSignalReducesConcurrency(unittest.TestCase):
+    """Drives `_AdaptiveLogScheduler` directly, never through Click/CliRunner.
+
+    Proves the rate-limit admission policy: a 429 activates the shared
+    `_RateLimitSignal`, no new units are admitted while it is active,
+    already-in-flight work is allowed to finish rather than being aborted,
+    and admission resumes once the cooldown genuinely elapses.
+
+    `test_429_signal_blocks_admission_until_cooldown_ends_event_driven`
+    below is the sole (and deterministic) proof of this policy: it drives
+    the real `_AdaptiveLogScheduler`/`_RateLimitSignal` (including a real
+    `ThreadPoolExecutor`, via `sched.run()`) with controlled fake fetch
+    functions synchronized via `threading.Event`s, and asserts directly on
+    recorded submission timestamps and the signal's own `active()` state --
+    never on a real-time sleep-and-compare window. Real-`ThreadPoolExecutor`
+    concurrency is separately covered by `TestWorkerConcurrency` in
+    test_log_cli.py.
+    """
+
+    def test_429_signal_blocks_admission_until_cooldown_ends_event_driven(self):
+        """Drives the real `_AdaptiveLogScheduler`/`_RateLimitSignal`
+        directly (via a controlled `log_mod._fetch_log_unit` fake),
+        `--workers 2`, four hand-seeded units: TRIGGER=(0,1) signals the
+        rate limit then resolves quickly; RUNNING=(1,2) runs concurrently
+        with TRIGGER and blocks on a test-controlled event, standing in for
+        already-in-flight work; LATER1=(2,3)/LATER2=(3,4) are only
+        reachable once a worker slot frees. Proves: a 429 activates the
+        signal and blocks new admission even with a free slot, already-
+        started work (RUNNING) is allowed to finish rather than being
+        aborted, and admission resumes (LATER1/LATER2 dispatched) only
+        after the cooldown has genuinely elapsed and RUNNING is released.
+        """
+        # Generous relative to ordinary thread-scheduling/GIL jitter between
+        # `trigger_done` firing and the "still active" check just after it,
+        # so the test fails only on a genuine admission-control regression,
+        # never on scheduling noise.
+        cooldown = 1.0
+        S = 1_700_000_000_000_000_000  # arbitrary ns epoch base
+        TRIGGER = (S + 0, S + 1)
+        RUNNING = (S + 1, S + 2)
+        LATER1 = (S + 2, S + 3)
+        LATER2 = (S + 3, S + 4)
+
+        trigger_started = threading.Event()
+        trigger_done = threading.Event()
+        running_started = threading.Event()
+        running_release = threading.Event()
+
+        events: list = []  # (label, time.monotonic()) in call order
+        events_lock = threading.Lock()
+
+        def record(label):
+            with events_lock:
+                events.append((label, time.monotonic()))
+
+        def fake_fetch(
+            deployment,
+            job,
+            replica,
+            job_history_name,
+            query,
+            start,
+            end,
+            limit,
+            cancelled,
+            rate_limit_signal,
+        ):
+            key = (start, end)
+            if key == TRIGGER:
+                record("trigger_start")
+                trigger_started.set()
+                # Explicit synchronization (not a timing guess): wait for
+                # RUNNING to have genuinely started before signaling the
+                # rate limit, so both units are provably admitted/in-flight
+                # concurrently under `--workers 2` before the signal ever
+                # activates -- otherwise TRIGGER (which does no I/O) could
+                # race ahead and signal before the scheduler's `_submit_ready`
+                # loop has even reached its second admission check.
+                self.assertTrue(
+                    running_started.wait(timeout=5), "RUNNING never started"
+                )
+                rate_limit_signal.signal(cooldown)
+                result = FetchUnitResult(
+                    [LogEntry((), start, "trigger", ())], False, start, start, False
+                )
+                record("trigger_end")
+                trigger_done.set()
+                return result
+            if key == RUNNING:
+                record("running_start")
+                running_started.set()
+                # Already in flight when the signal activates -- must be
+                # allowed to run to completion, not aborted.
+                finished_cleanly = running_release.wait(timeout=5)
+                record("running_end")
+                return FetchUnitResult(
+                    [LogEntry((), start, "running", ())],
+                    False,
+                    start,
+                    start,
+                    not finished_cleanly,  # failed=True only if we timed out
+                )
+            if key in (LATER1, LATER2):
+                record(f"later_start:{key}")
+                return FetchUnitResult(
+                    [LogEntry((), start, "later", ())], False, start, start, False
+                )
+            raise AssertionError(f"unexpected unit range {key}")
+
+        with (
+            patch.object(log_mod, "_fetch_log_unit", fake_fetch),
+            patch.object(log_mod.console, "print"),
+        ):
+            sched = _AdaptiveLogScheduler(
+                None, "job-1", None, None, "", TRIGGER[0], LATER2[1], 2, True, None
+            )
+            sched.pending = []
+            for key in (TRIGGER, RUNNING, LATER1, LATER2):
+                heapq.heappush(sched.pending, WorkUnit(sched._next_seq(), *key))
+
+            run_thread_exit = {}
+
+            def run_thread():
+                try:
+                    sched.run()
+                except SystemExit as e:
+                    run_thread_exit["code"] = e.code
+
+            thread = threading.Thread(target=run_thread)
+            thread.start()
+
+            self.assertTrue(trigger_started.wait(timeout=5), "TRIGGER never started")
+            self.assertTrue(running_started.wait(timeout=5), "RUNNING never started")
+
+            # TRIGGER resolves quickly on its own (no artificial delay) and
+            # frees a worker slot while RUNNING is still blocked and the
+            # signal is active. Once its future has genuinely resolved,
+            # give the scheduler's single dispatch thread a bounded, well
+            # under-cooldown margin to run its next `_submit_ready` pass
+            # (triggered by that resolution), then confirm it admitted
+            # nothing -- the signal (activated by TRIGGER, cooldown=0.2s)
+            # is still active at this point.
+            self.assertTrue(trigger_done.wait(timeout=5), "TRIGGER never finished")
+            self.assertTrue(sched.rate_limit_signal.active())
+            time.sleep(0.1)
+
+            with events_lock:
+                later_events = [
+                    label for label, _ in events if label.startswith("later_start:")
+                ]
+            self.assertEqual(
+                later_events,
+                [],
+                "LATER1/LATER2 must not be dispatched while the rate-limit"
+                f" signal is active: {events}",
+            )
+            self.assertFalse(
+                running_release.is_set(),
+                "RUNNING must still be genuinely in flight (not aborted) at this point",
+            )
+
+            # Wait out the real cooldown before releasing RUNNING, so that
+            # when RUNNING's future resolves and `_submit_ready` runs again,
+            # the signal has genuinely gone inactive.
+            cooldown_deadline = time.monotonic() + cooldown + 0.1
+            while time.monotonic() < cooldown_deadline:
+                time.sleep(0.01)
+            self.assertFalse(
+                sched.rate_limit_signal.active(),
+                "cooldown should have elapsed by now",
+            )
+            release_time = time.monotonic()
+            running_release.set()
+
+            thread.join(timeout=10)
+            self.assertFalse(thread.is_alive(), "scheduler thread never finished")
+
+        self.assertEqual(run_thread_exit.get("code"), 0)
+
+        with events_lock:
+            later_start_times = {
+                label: t for label, t in events if label.startswith("later_start:")
+            }
+        self.assertEqual(len(later_start_times), 2, events)
+        for label, t in later_start_times.items():
+            self.assertGreaterEqual(
+                t,
+                release_time,
+                f"{label} was dispatched before RUNNING was released: {events}",
+            )
+
+
+class TestJitteredBackoffNotIdenticalAcrossWorkers(unittest.TestCase):
+    """Four independent, concurrently-dispatchable leaf units (hand-seeded,
+    no bisection needed) driven through the real
+    `_AdaptiveLogScheduler.run()` with `--workers 4`; only real
+    `ThreadPoolExecutor` concurrency matters here, not the CLI layer.
+    """
+
+    def _run_with_script(self, leaves, script):
+        fake = _RecordingFakeLogAPI(script)
+        recorded = []
+
+        def recording_sleep(d, c=None):
+            recorded.append(d)
+
+        _wait_for_quiescent_threads()
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod, "_interruptible_sleep", side_effect=recording_sleep),
+            patch.object(log_mod.console, "print"),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            sched = _AdaptiveLogScheduler(
+                None, "job-1", None, None, "", 0, 4000, 4, True, None
+            )
+            sched.pending = []
+            for key in leaves:
+                heapq.heappush(sched.pending, WorkUnit(sched._next_seq(), *key))
+            sched.run()
+        self.assertEqual(cm.exception.code, 0)
+        return recorded
+
+    def test_no_retry_after_uses_jittered_backoff_differing_per_worker(self):
+        leaves = [(0, 100), (1000, 1100), (2000, 2100), (3000, 3100)]
+        script = {
+            key: [
+                LogAPIError("rate limited", 429, retry_after=None),
+                _loki_response([(key[0] + 1, "leaf", {})]),
+            ]
+            for key in leaves
+        }
+        recorded = self._run_with_script(leaves, script)
+        # One 429 backoff sleep per leaf unit, each within attempt 0's
+        # jittered range. `_interruptible_sleep` is a single process-wide
+        # module attribute, so patching it also captures the scheduler's own
+        # unrelated internal orchestration-loop waits (if any); those fall
+        # well outside this narrow jitter window and are filtered out here
+        # rather than asserting on the raw, unfiltered call list.
+        jitter_calls = [d for d in recorded if 1.0 <= d < 1.5]
+        self.assertEqual(len(jitter_calls), 4, f"all recorded calls: {recorded}")
+        self.assertGreater(
+            len(set(jitter_calls)),
+            1,
+            "expected jitter to differentiate concurrent workers' delays, got"
+            f" {jitter_calls}",
+        )
+
+    def test_control_non_429_failure_uses_identical_fixed_delay(self):
+        """Parallel control fixture: the same 4 leaves failing with a
+        non-429 exception always sleep exactly the fixed 1.0s backoff --
+        proving the jittered, non-identical values above come from the 429
+        branch specifically, not from generic retry variance.
+        """
+        leaves = [(0, 100), (1000, 1100), (2000, 2100), (3000, 3100)]
+        script = {
+            key: [RuntimeError("boom"), _loki_response([(key[0] + 1, "leaf", {})])]
+            for key in leaves
+        }
+        recorded = self._run_with_script(leaves, script)
+        fixed_backoff_calls = [d for d in recorded if d == 1.0]
+        self.assertEqual(len(fixed_backoff_calls), 4, f"all recorded calls: {recorded}")
+        # None of the jitter branch's [1.0, 1.5) values (other than 1.0
+        # itself) appear -- confirming this control never took the 429 path.
+        self.assertFalse(any(1.0 < d < 1.5 for d in recorded))
+
+
+class TestMalformedResponseNeverMisreportedAsSinkFailure(unittest.TestCase):
+    """A stream label/metadata value that isn't a hashable scalar (or a
+    non-string line) would make the resulting `LogEntry` unhashable and only
+    fail later at the scheduler's flush-time dedup (`seen.add(entry)`),
+    misreported to the user as a sink failure ("Failed to write logs")
+    instead of the actual malformed-response root cause. This end-to-end
+    message-classification distinction is the actual regression -- rejected
+    at parse time, retried like any other malformed response, and reported
+    as a normal fetch-retry failure, never a sink failure.
+    """
+
+    def _run(self, response):
+        fake = _RecordingFakeLogAPI({(0, 100): response})
+        printed = []
+
+        def fake_print(*args, **kwargs):
+            printed.append(str(args[0]) if args else "")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", return_value=None),
+            patch.object(log_mod.console, "print", side_effect=fake_print),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 100, 4, True, None
+            )
+        return cm.exception.code, len(fake.calls), "\n".join(printed)
+
+    def test_unhashable_or_malformed_line_values_retried_never_reported_as_sink_failure(
+        self,
+    ):
+        cases = {
+            "unhashable stream label": {
+                "data": {
+                    "result": [{
+                        "stream": {"pod": ["not", "hashable"]},
+                        "values": [["1", "line"]],
+                    }]
+                }
+            },
+            "unhashable metadata value": {
+                "data": {
+                    "result": [{
+                        "stream": {"pod": "p1"},
+                        "values": [["1", "line", {"k": {"nested": 1}}]],
+                    }]
+                }
+            },
+            "non-string line value": {
+                "data": {
+                    "result": [{"stream": {"pod": "p1"}, "values": [["1", 12345]]}]
+                }
+            },
+        }
+        for description, response in cases.items():
+            with self.subTest(description=description):
+                exit_code, call_count, output = self._run(response)
+                self.assertEqual(exit_code, 2)
+                self.assertEqual(call_count, 5)
+                normalized = " ".join(output.split())
+                self.assertIn("could not be fetched after 5 retries", normalized)
+                self.assertNotIn("Failed to write logs", normalized)
+
+
+class TestOversizedPageCappingIntegration(unittest.TestCase):
+    """End-to-end (not just the capping mechanic tested at the
+    `_fetch_log_unit` layer by TestFetchLogUnitOversizedPageCapping above):
+    with the real `_ADAPTIVE_PAGE_LIMIT` (10000, no monkeypatching), a
+    14000-entry oversized root page must be capped, its child re-fetched,
+    the trace diagnostic must name both the original count and the cap, and
+    the final total must still count all 14000 distinct entries once the
+    child is fetched.
+    """
+
+    def test_oversized_backend_page_is_capped_and_child_recovers_the_rest(self):
+        # A small, dedicated [S, E) span (all 14000 offsets fit inside it)
+        # chosen so branch_mid=(S+E)/2 <= T=S+9999 -- i.e. so the capped
+        # saturation takes the single-unsplit-child branch, keeping this
+        # test's expected call sequence to exactly two calls and focused on
+        # capping, not also re-proving the branch-decision math covered
+        # elsewhere.
+        S, E = 0, 16000
+        entries = [(S + i, f"e{i}", {}) for i in range(14000)]
+        T = S + 9999  # the capped set's max_ts: the 10000 smallest of 14000
+        child_entries = [(S + i, f"e{i}", {}) for i in range(9999, 14000)]
+        fake = _RecordingFakeLogAPI({
+            (S, E): _loki_response(entries),
+            (T, E): _loki_response(child_entries),
+        })
+
+        records = []
+        handler_id = logger.add(
+            lambda msg: records.append(msg.record["message"]), level="TRACE"
+        )
+        outpath = os.path.join(tmpdir, "oversized_cap_out.txt")
+        try:
+            with (
+                patch.object(log_mod, "APIClient", _make_client_class(fake)),
+                self.assertRaises(SystemExit) as cm,
+            ):
+                fetch_logs_adaptive_parallel(
+                    None, "job-1", None, None, "", S, E, 4, True, outpath
+                )
+        finally:
+            logger.remove(handler_id)
+
+        self.assertEqual(cm.exception.code, 0)
+        requested = [(c["start"], c["end"]) for c in fake.calls]
+        self.assertEqual(requested, [(S, E), (T, E)])
+        self.assertTrue(
+            any("14000" in rec and "10000" in rec for rec in records),
+            "expected a trace record naming original count 14000 and cap"
+            f" 10000, got: {records}",
+        )
+        with open(outpath, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        for i in (0, 3500, 9999, 13999):
+            self.assertEqual(sum(1 for ln in lines if ln.endswith(f"e{i}")), 1)
+        self.assertIn("total 14000 lines", lines[-1])
+
+
+class TestBranchMidTrueDivision(unittest.TestCase):
+    """Odd-sum interval boundary."""
+
+    def test_odd_sum_interval_uses_true_division_two_child_branch(self):
+        sched = _AdaptiveLogScheduler(
+            None, "job-1", None, None, "", 0, 2001, 4, True, None
+        )
+        sched.pending = []  # drop the constructor-seeded unit; test only the split
+        unit = WorkUnit(sched._next_seq(), 0, 2001)
+        result = FetchUnitResult(
+            entries=[LogEntry((), 1000, "x", ())],
+            saturated=True,
+            min_ts=0,
+            max_ts=1000,
+            failed=False,
+        )
+        sched._handle_result(unit, result)
+        ranges = sorted((u.start, u.end) for u in sched.pending)
+        # branch_mid = 2001 / 2 = 1000.5 (true division); T=1000 < 1000.5, so
+        # the two-child branch is taken: [1000, 1500) and [1500, 2001) --
+        # never the single unsplit [1000, 2001) a floor-division
+        # branch_mid == 1000 would have produced (T >= branch_mid).
+        self.assertEqual(ranges, [(1000, 1500), (1500, 2001)])
+
+
+class TestWatermarkRegressionFailFast(unittest.TestCase):
+    """A watermark regression is a handled
+    failure (test-only fault injection, since this cannot occur in
+    practice), never an uncaught `AssertionError`.
+    """
+
+    def test_forced_watermark_regression_exits_1_with_scheduling_error_message(self):
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response([(1, "a", {})])})
+        printed = []
+
+        def fake_print(*args, **kwargs):
+            printed.append(args[0] if args else "")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.console, "print", side_effect=fake_print),
+            patch.object(
+                log_mod._AdaptiveLogScheduler, "_compute_watermark", return_value=-1
+            ),
+            self.assertRaises(SystemExit) as cm,
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 100, 4, True, None
+            )
+        self.assertEqual(cm.exception.code, 1)
+        self.assertTrue(any("Internal scheduling error" in p for p in printed), printed)
+
+    def test_watermark_regression_error_is_distinct_from_sink_failure_message(self):
+        # Same fault injection, but confirm the message does NOT read like a
+        # sink-write failure (they share the fail-fast/exit-1 contract but
+        # must be distinguishable to the user).
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response([(1, "a", {})])})
+        printed = []
+
+        def fake_print(*args, **kwargs):
+            printed.append(args[0] if args else "")
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.console, "print", side_effect=fake_print),
+            patch.object(
+                log_mod._AdaptiveLogScheduler, "_compute_watermark", return_value=-1
+            ),
+            self.assertRaises(SystemExit),
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 100, 4, True, None
+            )
+        self.assertFalse(any("Failed to write logs" in p for p in printed))
+
+
+class TestSameTimestampCaseBContinuation(unittest.TestCase):
+    """Case B: a saturated page that entirely shares
+    `timestamp_ns == T`, with `T + 1 < unit.end`, must enqueue exactly one
+    child `[T + 1, unit.end)` -- not zero children (Case A's terminal
+    behavior) and not a two-child bisection of `[T, unit.end)`.
+    """
+
+    def test_handle_result_enqueues_single_t_plus_one_child(self):
+        sched = log_mod._AdaptiveLogScheduler(
+            None, "job-1", None, None, "", 0, 100000, 4, True, None
+        )
+        sched.pending = []  # drop the constructor-seeded unit
+        unit = WorkUnit(sched._next_seq(), 0, 100000)
+        # Every entry in the saturated page shares timestamp_ns == T == 500,
+        # and T + 1 (501) is far below unit.end (100000) -- Case B applies.
+        result = FetchUnitResult(
+            entries=[LogEntry((), 500, "dup", ())],
+            saturated=True,
+            min_ts=500,
+            max_ts=500,
+            failed=False,
+        )
+        progress_advance = sched._handle_result(unit, result)
+        self.assertFalse(progress_advance)
+        self.assertEqual(len(sched.pending), 1)
+        child = sched.pending[0]
+        self.assertEqual((child.start, child.end), (501, 100000))
+
+    def test_case_a_terminal_enqueues_no_children_even_when_min_ts_equals_t(self):
+        # Contrast fixture: T >= unit.end - 1 (Case A) must win even though
+        # min_ts == T would otherwise also satisfy Case B's condition --
+        # Case A is checked first and always takes priority.
+        sched = log_mod._AdaptiveLogScheduler(
+            None, "job-1", None, None, "", 0, 501, 4, True, None
+        )
+        sched.pending = []
+        unit = WorkUnit(sched._next_seq(), 0, 501)
+        result = FetchUnitResult(
+            entries=[LogEntry((), 500, "dup", ())],
+            saturated=True,
+            min_ts=500,
+            max_ts=500,  # T=500 >= unit.end(501) - 1 -> Case A
+            failed=False,
+        )
+        progress_advance = sched._handle_result(unit, result)
+        self.assertTrue(progress_advance)
+        self.assertEqual(sched.pending, [])
+
+    def test_case_a_duplicated_entries_survive_dedup_end_to_end(self):
+        """Case A (terminal, 1ns remainder): unlike
+        `test_case_a_terminal_enqueues_no_children_even_when_min_ts_equals_t`
+        above (which only checks the branching decision via a direct
+        `_handle_result` call), this drives the real end-to-end path with
+        every line duplicated in the raw response -- proving flush-time
+        dedup, not just the child-count decision, on the terminal Case A
+        path: each *distinct* line still survives exactly once despite
+        10000 raw (5000 distinct x2) entries, and no further request is
+        ever made.
+        """
+        S, E = 0, 2
+        T = E - 1  # remaining range [T, E) is exactly 1ns wide
+        entries = []
+        for i in range(5000):
+            entries.append((T, f"same-ts-{i}", {}))
+            entries.append((T, f"same-ts-{i}", {}))
+        self.assertEqual(len(entries), 10000)
+        fake = _RecordingFakeLogAPI({(S, E): _loki_response(entries)})
+        outpath = os.path.join(tmpdir, "case_a_dedup_out.txt")
+
+        records = []
+        handler_id = logger.add(
+            lambda msg: records.append(msg.record["message"]), level="TRACE"
+        )
+        try:
+            with (
+                patch.object(log_mod, "APIClient", _make_client_class(fake)),
+                self.assertRaises(SystemExit) as cm,
+            ):
+                fetch_logs_adaptive_parallel(
+                    None, "job-1", None, None, "", S, E, 4, True, outpath
+                )
+        finally:
+            logger.remove(handler_id)
+
+        self.assertEqual(cm.exception.code, 0)
+        # No children: only the one saturated request was ever made.
+        self.assertEqual(len(fake.calls), 1)
+        with open(outpath, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        for i in (0, 1, 2499, 4999):
+            self.assertEqual(sum(1 for ln in lines if ln.endswith(f"same-ts-{i}")), 1)
+        # A trace diagnostic mentioning the same-timestamp safeguard was
+        # emitted, and it must be Case A's terminal message, not Case B's
+        # "continuing scan at T+1".
+        same_ts_records = [rec for rec in records if "same-timestamp" in rec]
+        self.assertTrue(
+            same_ts_records,
+            f"expected a same-timestamp safeguard trace record, got: {records}",
+        )
+        self.assertTrue(
+            any("incomplete" in rec for rec in same_ts_records), same_ts_records
+        )
+        self.assertFalse(
+            any("continuing scan at T+1" in rec for rec in same_ts_records),
+            same_ts_records,
+        )
+
+    def test_case_b_duplicated_entries_survive_dedup_end_to_end(self):
+        """Case B, end-to-end, with every same-timestamp line duplicated in
+        the raw response: flush-time dedup survives alongside the later,
+        genuinely distinct record fetched by the `[T+1, E)` child, and the
+        Case B trace diagnostic is emitted.
+        """
+        S, E = 0, 100000
+        T = 1500
+        entries = []
+        for i in range(5000):
+            entries.append((T, f"same-ts-{i}", {}))
+            entries.append((T, f"same-ts-{i}", {}))
+        self.assertEqual(len(entries), 10000)
+        later_entry = _loki_response([(T + 2000, "later-distinct", {})])
+        fake = _RecordingFakeLogAPI({
+            (S, E): _loki_response(entries),
+            (T + 1, E): later_entry,
+        })
+        outpath = os.path.join(tmpdir, "case_b_dedup_out.txt")
+
+        records = []
+        handler_id = logger.add(
+            lambda msg: records.append(msg.record["message"]), level="TRACE"
+        )
+        try:
+            with (
+                patch.object(log_mod, "APIClient", _make_client_class(fake)),
+                self.assertRaises(SystemExit) as cm,
+            ):
+                fetch_logs_adaptive_parallel(
+                    None, "job-1", None, None, "", S, E, 4, True, outpath
+                )
+        finally:
+            logger.remove(handler_id)
+
+        self.assertEqual(cm.exception.code, 0)
+        # Exactly one child at [T+1, E) -- never [T, E), never a two-child
+        # bisection.
+        requested = {(c["start"], c["end"]) for c in fake.calls}
+        self.assertEqual(requested, {(S, E), (T + 1, E)})
+        with open(outpath, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        for i in (0, 1, 2499, 4999):
+            self.assertEqual(sum(1 for ln in lines if ln.endswith(f"same-ts-{i}")), 1)
+        self.assertEqual(sum(1 for ln in lines if ln.endswith("later-distinct")), 1)
+        same_ts_records = [rec for rec in records if "same-timestamp" in rec]
+        self.assertTrue(
+            any("continuing scan at T+1" in rec for rec in same_ts_records),
+            same_ts_records,
+        )
+
+
+class TestAdaptivePageLimitConstantUsed(unittest.TestCase):
+    """`_ADAPTIVE_PAGE_LIMIT` (10000) must be the actual page size used by
+    the adaptive path everywhere it previously hardcoded 5000: the
+    `_fetch_log_unit` default parameter and the scheduler's explicit
+    `limit=` submission.
+    """
+
+    def test_constant_value_is_10000(self):
+        self.assertEqual(log_mod._ADAPTIVE_PAGE_LIMIT, 10000)
+
+    def test_fetch_log_unit_default_limit_is_the_named_constant(self):
+        import inspect
+
+        sig = inspect.signature(_fetch_log_unit)
+        self.assertEqual(sig.parameters["limit"].default, log_mod._ADAPTIVE_PAGE_LIMIT)
+
+    def test_scheduler_submits_with_the_named_constant_as_limit(self):
+        # A page just under 10000 entries must NOT saturate (proving the
+        # scheduler's live per-request limit is 10000, not the old 5000).
+        entries = [(t, f"l{t}", {}) for t in range(9999)]
+        fake = _RecordingFakeLogAPI({(0, 100000): _loki_response(entries)})
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            self.assertRaises(SystemExit) as cm,
+            patch.object(log_mod.console, "print"),
+        ):
+            fetch_logs_adaptive_parallel(
+                None, "job-1", None, None, "", 0, 100000, 4, True, None
+            )
+        self.assertEqual(cm.exception.code, 0)
+        # No saturation -> no split -> exactly one request was ever made.
+        self.assertEqual(len(fake.calls), 1)
+        self.assertEqual(fake.calls[0]["limit"], 10000)
+
+
+class TestDeadlockAvoidanceFrontierExemption(unittest.TestCase):
+    """Regression test for the rejected blanket-gate admission-control
+    design's confirmed deadlock.
+
+    Fixture: `--workers 4`, `_ADAPTIVE_PAGE_LIMIT` patched to 4, so
+    `_max_buffered_entries == (4 + 1) * 4 == 20`. The frontier (root) unit
+    blocks until released; siblings A/B/C resolve without blocking,
+    contributing 4/4/5 entries respectively -- all four (root/A/B/C) are
+    admitted up front under 4 workers. A fourth unit D can only be popped
+    once A/B/C are already popped (heap order); once A/B/C are in the
+    buffer (`len(buffer) == 13`) with only root active, D's projected
+    resident count (`13 + 2*4 == 21`) is one OVER cap (20), so the ordinary
+    (`active >= 1`) admission path withholds it while root is active.
+
+    Once root resolves, `self.active` becomes empty with `self.pending ==
+    [D]`. Under the superseded blanket-gate design (no `len(active) >= 1`
+    exemption), this is an unrecoverable deadlock -- nothing is ever
+    dispatched again. The corrected `cap_blocks` (mandatory exemption when
+    nothing is active) must dispatch D anyway, asserted via a wall-clock-
+    bounded `join()` on a background thread running the real `run()` loop.
+    """
+
+    def test_frontier_exemption_prevents_deadlock_when_buffer_at_raw_cap(self):
+        release_root = threading.Event()
+
+        # Root is the constructor-seeded frontier unit -- wide range, held
+        # "in flight" until explicitly released by the test, at which point
+        # it resolves saturated (Case A terminal) contributing its own
+        # block of entries.
+        ROOT = (0, 5000)
+        # Wide ranges so each saturated sibling's own entries land at a
+        # timestamp *above* D's `start`, so they are never drained away by
+        # an intervening watermark advance before the decisive
+        # cap-at-capacity dispatch decision for D is made.
+        SIB_A = (20, 3000)
+        SIB_B = (30, 3100)
+        SIB_C = (100, 4000)
+        SIB_D = (1000, 1010)
+
+        def fake_fetch(
+            deployment,
+            job,
+            replica,
+            job_history_name,
+            query,
+            start,
+            end,
+            limit,
+            cancelled,
+            rate_limit_signal,
+        ):
+            key = (start, end)
+            if key == ROOT:
+                release_root.wait(timeout=10)
+                entries = [LogEntry((), 4999, f"r{i}", ()) for i in range(4)]
+                return FetchUnitResult(entries, True, 4999, 4999, False)
+            if key == SIB_A:
+                entries = [LogEntry((), 2999, f"a{i}", ()) for i in range(4)]
+                return FetchUnitResult(entries, True, 2999, 2999, False)
+            if key == SIB_B:
+                entries = [LogEntry((), 3099, f"b{i}", ()) for i in range(4)]
+                return FetchUnitResult(entries, True, 3099, 3099, False)
+            if key == SIB_C:
+                entries = [LogEntry((), 3999, f"c{i}", ()) for i in range(5)]
+                return FetchUnitResult(entries, True, 3999, 3999, False)
+            if key == SIB_D:
+                return FetchUnitResult(
+                    [LogEntry((), 1005, "d0", ())], False, 1005, 1005, False
+                )
+            raise AssertionError(f"unexpected unit range {key}")
+
+        outdir = tempfile.mkdtemp(dir=tmpdir)
+        outpath = os.path.join(outdir, "deadlock_regression.txt")
+
+        # Instrumentation: wrap the real (unpatched) `_submit_ready` to
+        # record, for every unit it admits under real `ThreadPoolExecutor`
+        # concurrency, the `active` count immediately before that unit's
+        # admission and the buffer length at the start of the call (which
+        # cannot change mid-call, since `_submit_ready` itself never
+        # releases the GIL to do I/O). This lets the assertions below
+        # distinguish ordinary (active >= 1) admissions -- which must
+        # always respect the tightened cap -- from frontier (active == 0)
+        # admissions, which are the sole permitted source of overage.
+        submission_log = []
+        real_submit_ready = _AdaptiveLogScheduler._submit_ready
+
+        def instrumented_submit_ready(self, executor):
+            before_futures = set(self.active.keys())
+            pre_active = len(self.active)
+            buffer_len_before = len(self.buffer)
+            real_submit_ready(self, executor)
+            running_active = pre_active
+            for future, unit in self.active.items():
+                if future in before_futures:
+                    continue
+                submission_log.append({
+                    "range": (unit.start, unit.end),
+                    "active_before": running_active,
+                    "buffer_len_before": buffer_len_before,
+                })
+                running_active += 1
+
+        with (
+            patch.object(log_mod, "_ADAPTIVE_PAGE_LIMIT", 4),
+            patch.object(log_mod, "_fetch_log_unit", fake_fetch),
+            patch.object(
+                _AdaptiveLogScheduler, "_submit_ready", instrumented_submit_ready
+            ),
+        ):
+            sched = _AdaptiveLogScheduler(
+                None, "job-1", None, None, "", ROOT[0], ROOT[1], 4, True, outpath
+            )
+            page_limit = log_mod._ADAPTIVE_PAGE_LIMIT
+            cap = sched._max_buffered_entries
+            self.assertEqual(cap, 20)  # (workers=4 + 1) * page_limit(4)
+            heapq.heappush(sched.pending, WorkUnit(sched._next_seq(), *SIB_A))
+            heapq.heappush(sched.pending, WorkUnit(sched._next_seq(), *SIB_B))
+            heapq.heappush(sched.pending, WorkUnit(sched._next_seq(), *SIB_C))
+            heapq.heappush(sched.pending, WorkUnit(sched._next_seq(), *SIB_D))
+
+            result_holder = {}
+
+            def run_in_thread():
+                try:
+                    sched.run()
+                except SystemExit as e:
+                    result_holder["exit_code"] = e.code
+
+            t = threading.Thread(target=run_in_thread, daemon=True)
+            t.start()
+
+            # Poll (bounded, no fixed-delay guessing) for the deterministic
+            # intermediate state: only root remains active/unresolved, D is
+            # the sole remaining pending unit, and A/B/C have all already
+            # been accounted for (in the buffer). This state is guaranteed
+            # to be reached -- see the class docstring's arithmetic -- but
+            # real-thread completion order/timing varies, so we wait for it
+            # rather than assuming a fixed delay is long enough.
+            reached_pre_release_state = False
+            for _ in range(3000):
+                if (
+                    len(sched.active) == 1
+                    and any((u.start, u.end) == ROOT for u in sched.active.values())
+                    and [(u.start, u.end) for u in sched.pending] == [SIB_D]
+                ):
+                    reached_pre_release_state = True
+                    break
+                time.sleep(0.001)
+
+            self.assertTrue(
+                reached_pre_release_state,
+                "scheduler never reached the expected pre-release state"
+                f" (active={list(sched.active.values())},"
+                f" pending={[(u.start, u.end) for u in sched.pending]})",
+            )
+            self.assertEqual(len(sched.buffer), 13)  # A(4) + B(4) + C(5)
+
+            release_root.set()
+
+            # A generous wall-clock bound: the corrected scheduler completes
+            # promptly once released; a hang under the superseded
+            # blanket-gate design would never return within this bound.
+            t.join(timeout=10)
+
+        self.assertFalse(
+            t.is_alive(),
+            "scheduler did not complete within the timeout -- this is the"
+            " frontier-exemption deadlock regression",
+        )
+        self.assertEqual(result_holder.get("exit_code"), 0)
+
+        with open(outpath, encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        # Chronological, gap-free, duplicate-free output across all four
+        # resolved units, including D (dispatched only via the frontier
+        # exemption) and every saturated sibling.
+        expected_order = (
+            ["d0"]
+            + [f"a{i}" for i in range(4)]
+            + [f"b{i}" for i in range(4)]
+            + [f"c{i}" for i in range(5)]
+            + [f"r{i}" for i in range(4)]
+        )
+        self.assertEqual(lines[:18], expected_order)
+        self.assertTrue(lines[18].startswith("Time range: UTC|"))
+        self.assertIn("total 18 lines", lines[18])
+
+        # Every ordinary (active >= 1) admission recorded under real
+        # `ThreadPoolExecutor` concurrency must respect the tightened cap:
+        # buffer + (active_before + 1) * page_limit <= cap. Any admission
+        # that ever exceeds the cap must be a frontier (active_before == 0)
+        # dispatch -- confirming the only permitted overage in this
+        # scenario is the frontier case (ROOT and D), never an ordinary
+        # submission being over-admitted.
+        self.assertTrue(submission_log, "no submissions were recorded")
+        frontier_ranges = set()
+        for entry in submission_log:
+            resident_after = (
+                entry["buffer_len_before"] + (entry["active_before"] + 1) * page_limit
+            )
+            if entry["active_before"] == 0:
+                frontier_ranges.add(entry["range"])
+                continue
+            self.assertLessEqual(
+                resident_after,
+                cap,
+                f"ordinary submission {entry['range']} was admitted despite"
+                " pushing the resident count over the cap"
+                f" (log={submission_log})",
+            )
+        # ROOT and D are the only units ever dispatched while nothing was
+        # active -- ROOT trivially (it's the very first submission, with an
+        # empty buffer), and D specifically because A/B/C had already
+        # driven the buffer to the raw cap, so only the frontier exemption
+        # let it through.
+        self.assertEqual(frontier_ranges, {ROOT, SIB_D})
+
+
+class TestAdmissionControlFrontierExemption(unittest.TestCase):
+    """The frontier (smallest-`start`) pending unit is admitted even when
+    the buffer already sits at/over cap, as long as nothing is active --
+    `len(self.active) >= 1` in `_admission_blocked` is mandatory, not an
+    optimization. Real-thread coverage of this same exemption breaking an
+    actual deadlock lives in
+    `TestDeadlockAvoidanceFrontierExemption`; this test isolates the
+    admission decision itself, deterministically.
+    """
+
+    def test_frontier_unit_admitted_despite_buffer_already_over_cap(self):
+        with patch.object(log_mod, "_ADAPTIVE_PAGE_LIMIT", 4):
+            page_limit = log_mod._ADAPTIVE_PAGE_LIMIT
+            sched = _AdaptiveLogScheduler(
+                None, "job-1", None, None, "", 0, 100000, 2, True, None
+            )
+            cap = sched._max_buffered_entries
+            self.assertEqual(cap, 12)  # (workers=2 + 1) * page_limit(4)
+
+            sched.pending = []
+            sched.active = {}
+            sched.buffer = [None] * (cap + page_limit)  # already well over cap
+            frontier_unit = WorkUnit(sched._next_seq(), 0, 100)
+            heapq.heappush(sched.pending, frontier_unit)
+
+            admitted = []
+
+            class _RecordingExecutor:
+                def submit(self, fn, *args, **kwargs):
+                    from concurrent.futures import Future
+
+                    admitted.append(args)
+                    return Future()
+
+            sched._submit_ready(_RecordingExecutor())
+
+            self.assertEqual(
+                len(admitted),
+                1,
+                "the frontier unit must be admitted even with the buffer over cap",
+            )
+            self.assertEqual(len(sched.active), 1)
+            self.assertEqual(sched.pending, [])
+
+
+class TestAdmissionControlOrdinarySubmissionOffByOne(unittest.TestCase):
+    """Regression test for `_submit_ready`'s `cap_blocks` comparison
+    operator (`>` vs `>=`).
+
+    The documented bound is "at or under the cap": an ordinary (active >= 1)
+    submission must be ADMITTED whenever its proposed post-admission
+    resident count (`len(buffer) + (len(active) + 1) * page_limit`) would
+    land exactly AT the cap, and WITHHELD only when it would EXCEED the
+    cap. A previous round used `>=` in `cap_blocks`, which wrongly withheld
+    admission when the proposed count landed exactly at the cap -- e.g.
+    with `--workers 2`, one page buffered and one worker active, admitting
+    a second worker proposes exactly `3 * page_limit == cap`, which `>=`
+    incorrectly blocked, silently serializing the scheduler to concurrency
+    1. The fixed comparison (`>`) admits that case and only withholds a
+    proposal that would actually exceed the cap.
+    """
+
+    def _make_scheduler(self, buffer_len):
+        page_limit = log_mod._ADAPTIVE_PAGE_LIMIT
+        sched = _AdaptiveLogScheduler(
+            None, "job-1", None, None, "", 0, 100000, 3, True, None
+        )
+        cap = sched._max_buffered_entries
+        self.assertEqual(cap, 16)  # (workers=3 + 1) * page_limit(4)
+
+        sched.pending = []
+        in_flight_unit = WorkUnit(sched._next_seq(), 5000, 6000)
+        sched.active = {object(): in_flight_unit}
+        sched.buffer = [None] * buffer_len
+
+        next_unit = WorkUnit(sched._next_seq(), 0, 100)
+        heapq.heappush(sched.pending, next_unit)
+        return sched, cap, page_limit
+
+    def test_proposed_count_landing_exactly_at_cap_is_admitted(self):
+        # buffer + (active + 1) * page_limit == cap exactly -- the direct
+        # regression case: this must be ADMITTED, not withheld.
+        with patch.object(log_mod, "_ADAPTIVE_PAGE_LIMIT", 4):
+            sched, cap, page_limit = self._make_scheduler(0)
+            buffer_len = cap - 2 * page_limit  # + (1+1)*page_limit == cap
+            sched.buffer = [None] * buffer_len
+            self.assertEqual(
+                len(sched.buffer) + (len(sched.active) + 1) * page_limit, cap
+            )
+
+            admitted = []
+
+            class _RecordingExecutor:
+                def submit(self, fn, *args, **kwargs):
+                    from concurrent.futures import Future
+
+                    admitted.append(args)
+                    fut = Future()
+                    return fut
+
+            sched._submit_ready(_RecordingExecutor())
+
+            self.assertEqual(
+                len(admitted), 1, "landing exactly at cap must be admitted"
+            )
+            self.assertEqual(len(sched.active), 2)
+            self.assertEqual(sched.pending, [])
+
+    def test_proposed_count_exceeding_cap_is_withheld(self):
+        # buffer + (active + 1) * page_limit == cap + 1 -- strictly over the
+        # cap. This must remain withheld (unchanged behavior).
+        with patch.object(log_mod, "_ADAPTIVE_PAGE_LIMIT", 4):
+            sched, cap, page_limit = self._make_scheduler(0)
+            buffer_len = cap - 2 * page_limit + 1
+            sched.buffer = [None] * buffer_len
+            self.assertEqual(
+                len(sched.buffer) + (len(sched.active) + 1) * page_limit, cap + 1
+            )
+
+            class _RefusingExecutor:
+                """Fails the test if a submission is admitted -- this is an
+                ordinary (active >= 1) admission decision, so admitting one
+                more unit here would push the true resident count over the
+                cap, which must remain prevented.
+                """
+
+                def submit(self, *args, **kwargs):
+                    raise AssertionError(
+                        "an ordinary submission was admitted despite pushing"
+                        " the resident count over the cap"
+                    )
+
+            sched._submit_ready(_RefusingExecutor())
+
+            self.assertEqual(len(sched.active), 1, "no new unit should be admitted")
+            self.assertEqual(
+                [(u.start, u.end) for u in sched.pending],
+                [(0, 100)],
+                "the pending unit should remain withheld",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/cli/tests/test_log_adaptive_worker.py
+++ b/leptonai/cli/tests/test_log_adaptive_worker.py
@@ -1,0 +1,1149 @@
+"""Unit tests for the single-request-cycle building blocks of adaptive log
+retrieval: `_parse_log_entries` (response parsing/validation/page-limit
+capping), `LogEntry` identity, and `_fetch_log_unit` (one HTTP
+request/response cycle, including retry/backoff and `Retry-After` handling).
+
+None of these need a `ThreadPoolExecutor` or an `_AdaptiveLogScheduler`
+fixture -- scheduler-owned state (pending/active/buffer, watermark, split
+decisions, admission, output coordination) lives in
+`test_log_adaptive_scheduler.py`; output/sink formatting lives in
+`test_log_adaptive_output.py`.
+"""
+
+import os
+import tempfile
+
+# Set cache dir to a temp dir before importing anything from leptonai, matching
+# the existing CLI test suite convention (test_job_cli.py).
+tmpdir = tempfile.mkdtemp()
+os.environ["LEPTON_CACHE_DIR"] = tmpdir
+
+import heapq
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from leptonai.api.v2.log import LogAPI, LogAPIError
+from leptonai.cli import log as log_mod
+from leptonai.cli.log import (
+    LogEntry,
+    _ADAPTIVE_RETRY_BASE_DELAY_SEC,
+    _ADAPTIVE_RETRY_MAX_ATTEMPTS,
+    _fetch_log_unit,
+    _MalformedLogResponseError,
+    _parse_log_entries,
+    _RateLimitSignal,
+)
+from leptonai.cli.tests._log_test_helpers import (
+    FakeHTTPResponse as _FakeHTTPResponse,
+    RealLogAPIHTTPClient as _RealLogAPIHTTPClient,
+    RecordingFakeLogAPI as _RecordingFakeLogAPI,
+    loki_response as _loki_response,
+    make_client_class as _make_client_class,
+)
+
+
+class TestLogEntryDedupKey(unittest.TestCase):
+    def test_identical_entries_are_equal_and_hash_equal(self):
+        a = LogEntry((("pod", "p1"),), 100, "hello", ())
+        b = LogEntry((("pod", "p1"),), 100, "hello", ())
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+
+    def test_different_stream_labels_are_not_equal(self):
+        a = LogEntry((("pod", "p1"),), 100, "hello", ())
+        b = LogEntry((("pod", "p2"),), 100, "hello", ())
+        self.assertNotEqual(a, b)
+
+    def test_different_metadata_are_not_equal(self):
+        a = LogEntry((("pod", "p1"),), 100, "hello", ())
+        b = LogEntry((("pod", "p1"),), 100, "hello", (("k", "v"),))
+        self.assertNotEqual(a, b)
+
+
+class TestFetchLogUnit(unittest.TestCase):
+    def test_calls_get_log_with_the_bounded_adaptive_fetch_timeout(self):
+        # `_fetch_log_unit` passes a specific, bounded timeout
+        # (`_ADAPTIVE_FETCH_TIMEOUT_SEC`, shorter than the client's normal
+        # 120s default) to `get_log`, so a sink failure that triggers
+        # cancellation while a worker is mid-HTTP-request bounds shutdown
+        # to a known, short duration instead of silently inheriting 120s.
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response([(1, "a", {})])})
+        with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+            _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+        self.assertEqual(len(fake.calls), 1)
+        self.assertEqual(fake.calls[0]["timeout"], log_mod._ADAPTIVE_FETCH_TIMEOUT_SEC)
+        self.assertLess(log_mod._ADAPTIVE_FETCH_TIMEOUT_SEC, 120)
+
+    def test_non_saturated_returns_all_entries_as_final(self):
+        entries = [(3, "c", {}), (1, "a", {}), (2, "b", {})]
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response(entries)})
+        with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+        self.assertFalse(result.saturated)
+        self.assertFalse(result.failed)
+        self.assertEqual(len(result.entries), 3)
+        # Sorted ascending by timestamp regardless of Loki response order.
+        self.assertEqual([e.timestamp_ns for e in result.entries], [1, 2, 3])
+        self.assertEqual(result.min_ts, 1)
+        self.assertEqual(result.max_ts, 3)
+        self.assertEqual(fake.calls[0]["direction"], "forward")
+
+    def test_saturated_when_page_hits_limit(self):
+        entries = [(i, f"line-{i}", {}) for i in range(5)]
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response(entries)})
+        with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5)
+        self.assertTrue(result.saturated)
+        self.assertEqual(len(result.entries), 5)
+
+    def test_exhausted_retries_report_failed_without_raising(self):
+        fake = _RecordingFakeLogAPI({(0, 100): RuntimeError("boom")})
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", return_value=None) as mock_sleep,
+        ):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+        self.assertTrue(result.failed)
+        self.assertEqual(result.entries, [])
+        self.assertIsNone(result.min_ts)
+        self.assertIsNone(result.max_ts)
+        self.assertEqual(len(fake.calls), 5)
+        self.assertEqual(mock_sleep.call_count, 4)
+
+    def test_transient_failure_recovers_within_retry_budget(self):
+        fake = _RecordingFakeLogAPI({
+            (0, 100): [
+                RuntimeError("e1"),
+                RuntimeError("e2"),
+                RuntimeError("e3"),
+                _loki_response([(1, "ok", {})]),
+            ]
+        })
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", return_value=None),
+        ):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+        self.assertFalse(result.failed)
+        self.assertEqual(len(result.entries), 1)
+        self.assertEqual(len(fake.calls), 4)
+
+    def test_cancelled_before_first_attempt_makes_no_request(self):
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response([(1, "a", {})])})
+        cancelled = threading.Event()
+        cancelled.set()
+        with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+            result = _fetch_log_unit(
+                None, "job-1", None, None, "", 0, 100, limit=5000, cancelled=cancelled
+            )
+        self.assertTrue(result.failed)
+        self.assertEqual(len(fake.calls), 0)
+
+
+class TestRateLimitSignal(unittest.TestCase):
+    """Shared 429 signal semantics."""
+
+    def test_inactive_by_default(self):
+        self.assertFalse(_RateLimitSignal().active())
+
+    def test_active_until_cooldown_elapses(self):
+        signal = _RateLimitSignal()
+        signal.signal(0.05)
+        self.assertTrue(signal.active())
+        time.sleep(0.08)
+        self.assertFalse(signal.active())
+
+    def test_signal_only_extends_deadline_forward_never_backward(self):
+        signal = _RateLimitSignal()
+        signal.signal(0.2)
+        signal.signal(0.05)  # shorter cooldown must not shorten the longer one
+        time.sleep(0.1)
+        self.assertTrue(signal.active())
+
+
+class TestSharedCooldownMatchesWorkersOwnDelay(unittest.TestCase):
+    """Drives `_fetch_log_unit` directly, never through Click/CliRunner.
+
+    On a no-Retry-After-header 429, `_fetch_log_unit` signals the
+    shared `_RateLimitSignal` with `cooldown = delay` -- the same jittered
+    backoff value the worker itself is about to sleep for -- instead of a
+    fixed default cooldown. Directly drives two simulated workers (via a
+    shared `_RateLimitSignal` and controlled `random.uniform`) with
+    different jittered delays and asserts the signal's active-until
+    deadline reflects the larger of the two, not a fixed constant.
+    """
+
+    def test_cooldown_reflects_the_larger_of_two_workers_own_jittered_delays(self):
+        S, E = 0, 100
+        rate_limit_signal = _RateLimitSignal()
+        cancelled = threading.Event()
+
+        fake_a = _RecordingFakeLogAPI({
+            (S, E): [
+                LogAPIError("rate limited", 429, retry_after=None),
+                _loki_response([(S + 1, "a", {})]),
+            ]
+        })
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake_a)),
+            patch.object(log_mod.random, "uniform", return_value=1.0),
+            patch.object(log_mod, "_interruptible_sleep", return_value=None),
+        ):
+            before_a = time.monotonic()
+            _fetch_log_unit(
+                "dep1",
+                None,
+                None,
+                None,
+                "",
+                S,
+                E,
+                cancelled=cancelled,
+                rate_limit_signal=rate_limit_signal,
+            )
+        # base_delay=1.0 * 2**0 * uniform(...)=1.0 -> cooldown=1.0s.
+        deadline_a = rate_limit_signal._until
+        self.assertAlmostEqual(deadline_a - before_a, 1.0, delta=0.4)
+
+        fake_b = _RecordingFakeLogAPI({
+            (S, E): [
+                LogAPIError("rate limited", 429, retry_after=None),
+                _loki_response([(S + 1, "b", {})]),
+            ]
+        })
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake_b)),
+            patch.object(log_mod.random, "uniform", return_value=1.5),
+            patch.object(log_mod, "_interruptible_sleep", return_value=None),
+        ):
+            before_b = time.monotonic()
+            _fetch_log_unit(
+                "dep1",
+                None,
+                None,
+                None,
+                "",
+                S,
+                E,
+                cancelled=cancelled,
+                rate_limit_signal=rate_limit_signal,
+            )
+        # base_delay=1.0 * 2**0 * uniform(...)=1.5 -> cooldown=1.5s, longer
+        # than worker A's -- the shared deadline must extend to match it
+        # (`_RateLimitSignal.signal` takes max(existing, new)).
+        deadline_b = rate_limit_signal._until
+        self.assertAlmostEqual(deadline_b - before_b, 1.5, delta=0.4)
+        self.assertGreater(deadline_b, deadline_a)
+        # Not a fixed 2.0s default cooldown regardless of either worker's
+        # own jittered delay.
+        self.assertLess(deadline_a - before_a, 2.0)
+        self.assertNotAlmostEqual(deadline_a - before_a, 2.0, delta=0.1)
+
+
+class TestFetchLogUnit429Backoff(unittest.TestCase):
+    """429 retry/backoff math."""
+
+    def test_retry_after_honored_and_bounded_to_60s_cap(self):
+        """Table-driven: a `Retry-After` under the 60s cap is honored
+        verbatim; one above the cap is bounded to exactly 60s."""
+        cases = [
+            ("under cap", 3.0, 3.0),
+            ("above cap", 600.0, 60.0),
+        ]
+        for description, retry_after, expected_sleep in cases:
+            with self.subTest(description=description):
+                fake = _RecordingFakeLogAPI({
+                    (0, 100): [
+                        LogAPIError("rate limited", 429, retry_after=retry_after),
+                        _loki_response([(1, "a", {})]),
+                    ]
+                })
+                sleeps = []
+                with (
+                    patch.object(log_mod, "APIClient", _make_client_class(fake)),
+                    patch.object(
+                        log_mod.time, "sleep", side_effect=lambda d: sleeps.append(d)
+                    ),
+                ):
+                    result = _fetch_log_unit(
+                        None, "job-1", None, None, "", 0, 100, limit=5000
+                    )
+                self.assertFalse(result.failed)
+                self.assertEqual(sleeps, [expected_sleep])
+
+    def test_non_429_status_uses_fixed_backoff_not_retry_after_or_jitter(self):
+        fake = _RecordingFakeLogAPI({
+            (0, 100): [
+                LogAPIError("server error", 500),
+                _loki_response([(1, "a", {})]),
+            ]
+        })
+        sleeps = []
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", side_effect=lambda d: sleeps.append(d)),
+        ):
+            _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+        self.assertEqual(sleeps, [1.0])
+
+    def test_non_429_backoff_follows_exact_exponential_schedule(self):
+        """Table-driven: the full non-429 backoff schedule across
+        `_ADAPTIVE_RETRY_MAX_ATTEMPTS - 1` consecutive failures is exactly
+        `base_delay * 2**attempt` for attempt in
+        0..`_ADAPTIVE_RETRY_MAX_ATTEMPTS - 2` (1/2/4/8s with the current
+        constants) -- the 5th (final) attempt succeeds, so no 5th sleep is
+        recorded. Expected values are derived from the named module
+        constants, not hardcoded literals, so this test cannot silently
+        drift from production if the constants ever change.
+        """
+        self.assertEqual(_ADAPTIVE_RETRY_MAX_ATTEMPTS, 5)
+        num_failures = _ADAPTIVE_RETRY_MAX_ATTEMPTS - 1
+        expected = [
+            _ADAPTIVE_RETRY_BASE_DELAY_SEC * (2**attempt)
+            for attempt in range(num_failures)
+        ]
+        script = [LogAPIError("server error", 500) for _ in range(num_failures)]
+        script.append(_loki_response([(1, "a", {})]))
+        fake = _RecordingFakeLogAPI({(0, 100): script})
+        sleeps = []
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", side_effect=lambda d: sleeps.append(d)),
+        ):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+        self.assertFalse(result.failed)
+        self.assertEqual(len(fake.calls), _ADAPTIVE_RETRY_MAX_ATTEMPTS)
+        self.assertEqual(sleeps, expected)
+
+    def test_jittered_backoff_stays_within_bounds_and_varies_across_calls(self):
+        # No Retry-After header: delay = min(60, 1.0 * 2**0 * uniform(1.0, 1.5))
+        # on attempt 0, so every observed delay must fall in [1.0, 1.5), and
+        # repeated calls must not all produce the identical delay (jitter).
+        delays = []
+        for _ in range(20):
+            fake = _RecordingFakeLogAPI({
+                (0, 100): [
+                    LogAPIError("rate limited", 429, retry_after=None),
+                    _loki_response([(1, "a", {})]),
+                ]
+            })
+            captured = []
+            with (
+                patch.object(log_mod, "APIClient", _make_client_class(fake)),
+                patch.object(
+                    log_mod.time, "sleep", side_effect=lambda d: captured.append(d)
+                ),
+            ):
+                _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+            delays.append(captured[0])
+        for d in delays:
+            self.assertGreaterEqual(d, 1.0)
+            self.assertLess(d, 1.5)
+        self.assertGreater(len(set(delays)), 1)
+
+    def test_cancelled_is_checked_before_a_429_sleep(self):
+        # A 429 sleep must not run to completion once `cancelled` becomes
+        # set, even mid-retry-loop.
+        cancelled = threading.Event()
+
+        class _FakeSetsCancelledThen429:
+            def __init__(self):
+                self.calls = 0
+
+            def get_log(self, **kwargs):
+                self.calls += 1
+                cancelled.set()
+                raise LogAPIError("rate limited", 429, retry_after=5.0)
+
+        fake = _FakeSetsCancelledThen429()
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep") as mock_sleep,
+        ):
+            result = _fetch_log_unit(
+                None, "job-1", None, None, "", 0, 100, limit=5000, cancelled=cancelled
+            )
+        self.assertTrue(result.failed)
+        mock_sleep.assert_not_called()
+        self.assertEqual(fake.calls, 1)
+
+    def test_429_signals_the_shared_rate_limit_signal(self):
+        fake = _RecordingFakeLogAPI({
+            (0, 100): [
+                LogAPIError("rate limited", 429, retry_after=None),
+                _loki_response([(1, "a", {})]),
+            ]
+        })
+        signal = _RateLimitSignal()
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", return_value=None),
+        ):
+            _fetch_log_unit(
+                None,
+                "job-1",
+                None,
+                None,
+                "",
+                0,
+                100,
+                limit=5000,
+                rate_limit_signal=signal,
+            )
+        self.assertTrue(signal.active())
+
+    def test_exhausted_429_retries_resolve_as_failed_unit_without_raising(self):
+        """Repeated 429s never abort the run, only fail the unit."""
+        fake = _RecordingFakeLogAPI({(0, 100): LogAPIError("rate limited", 429)})
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", return_value=None),
+        ):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+        self.assertTrue(result.failed)
+        self.assertEqual(len(fake.calls), 5)
+
+    def test_negative_or_zero_retry_after_header_falls_back_to_jittered_backoff(self):
+        """Table-driven guard against a negative/zero `Retry-After` header: a
+        naive `_parse_retry_after` could return the negative/zero float
+        unchanged, which would flow into `_fetch_log_unit`'s
+        `delay = min(e.retry_after, retry_after_cap)` (still negative/zero)
+        and then `_interruptible_sleep(delay, cancelled)` ->
+        `cancelled.wait(-5.0)` (or `wait(0)`, masking the bug for the zero
+        case), raising an uncaught `ValueError` inside the worker thread for
+        the negative case. Drives a real `LogAPI` against a fake HTTP
+        transport (not a synthetic, already-constructed `LogAPIError`), so
+        this exercises the actual `_parse_retry_after` parsing path
+        end-to-end for both header values.
+        """
+        # start=0 is rejected by the real LogAPI's own epoch-zero
+        # precondition (a different regression, covered elsewhere) -- use a
+        # non-zero start so that check doesn't shadow this one.
+        S, E = 1000, 1100
+        for description, header_value in (
+            ("negative Retry-After", "-5"),
+            ("zero Retry-After", "0"),
+        ):
+            with self.subTest(description=description):
+                http_client = _RealLogAPIHTTPClient()
+                retry_after_response = _FakeHTTPResponse(
+                    None, ok=False, status_code=429, text="rate limited"
+                )
+                retry_after_response.headers["Retry-After"] = header_value
+                http_client._get.side_effect = [
+                    retry_after_response,
+                    _FakeHTTPResponse({"data": {"result": []}}),
+                ]
+                real_log_api = LogAPI(http_client)
+                cancelled = threading.Event()
+
+                # No `_interruptible_sleep`/`time.sleep` mocking here --
+                # a regression would raise an uncaught `ValueError` from
+                # `cancelled.wait(-5.0)` before ever returning. Real (short,
+                # jittered ~1.0-1.5s) backoff sleep is allowed to happen.
+                with patch.object(
+                    log_mod, "APIClient", _make_client_class(real_log_api)
+                ):
+                    result = _fetch_log_unit(
+                        "dep1", None, None, None, "", S, E, cancelled=cancelled
+                    )
+
+                self.assertFalse(result.failed)
+                self.assertEqual(http_client._get.call_count, 2)
+
+
+class TestParseLogEntriesMalformedShapes(unittest.TestCase):
+    """Malformed response shapes raise, never silently
+    default to an empty page.
+    """
+
+    def test_malformed_top_level_response_shapes_raise(self):
+        """Table-driven: each case violates the response wrapper's own
+        top-level structure (as opposed to a single record's shape, tabled
+        separately below) and must raise `_MalformedLogResponseError`."""
+        malformed_responses = [
+            ("missing 'data' key", {"error": "something went wrong"}),
+            ("'data' not a dict", {"data": "not-a-dict"}),
+            ("'result' not a list", {"data": {"result": "not-a-list"}}),
+            (
+                "result entry missing 'values' key",
+                {"data": {"result": [{"stream": {"pod": "p1"}}]}},
+            ),
+            (
+                "malformed values tuple",
+                {"data": {"result": [{"stream": {}, "values": [["only-one"]]}]}},
+            ),
+            ("response not a dict", ["not", "a", "dict"]),
+        ]
+        for description, response in malformed_responses:
+            with self.subTest(description=description):
+                with self.assertRaises(_MalformedLogResponseError):
+                    _parse_log_entries(response, limit=100, start=0, end=1_000_000)
+
+    def test_legitimately_empty_page_does_not_raise(self):
+        """A well-formed empty result is not malformed."""
+        entries, examined = _parse_log_entries(
+            {"data": {"result": []}}, limit=100, start=0, end=1_000_000
+        )
+        self.assertEqual(entries, [])
+        self.assertEqual(examined, 0)
+
+    def test_out_of_range_entry_raises(self):
+        """The `[start, end)` range check now runs inside `_parse_log_entries`
+        itself, over every examined record."""
+        with self.assertRaises(_MalformedLogResponseError):
+            _parse_log_entries(
+                _loki_response([(2500, "bad", {})]), limit=100, start=1000, end=2000
+            )
+
+    def test_end_exclusive_boundary_entry_raises(self):
+        with self.assertRaises(_MalformedLogResponseError):
+            _parse_log_entries(
+                _loki_response([(2000, "edge", {})]), limit=100, start=1000, end=2000
+            )
+
+    def test_within_range_entry_is_retained(self):
+        entries, examined = _parse_log_entries(
+            _loki_response([(1500, "ok", {})]), limit=100, start=1000, end=2000
+        )
+        self.assertEqual(examined, 1)
+        self.assertEqual([e.timestamp_ns for e in entries], [1500])
+
+    def test_malformed_stream_or_value_element_shapes_raise(self):
+        """Table-driven: each case varies either the `stream` dict or a
+        `values` element (not the top-level response-wrapper shapes tabled
+        above, nor the value-tuple length/metadata-type/timestamp-type
+        forms tabled separately in
+        `test_malformed_value_tuple_shapes_and_metadata_forms_are_rejected`
+        below) and must raise `_MalformedLogResponseError`."""
+        malformed_records = [
+            (
+                # A stream label value that isn't a hashable scalar would
+                # make the resulting `LogEntry` unhashable, only failing
+                # later at the scheduler's flush-time dedup -- reject it
+                # here instead.
+                "unhashable stream label value",
+                {"stream": {"pod": ["not", "hashable"]}, "values": [["1500", "line"]]},
+            ),
+            (
+                "unhashable metadata value",
+                {
+                    "stream": {"pod": "p1"},
+                    "values": [["1500", "line", {"k": {"nested": 1}}]],
+                },
+            ),
+            (
+                "non-dict metadata element",
+                {
+                    "stream": {"pod": "p1"},
+                    "values": [["1500", "line", ["not", "a", "dict"]]],
+                },
+            ),
+            (
+                "non-string line value",
+                {"stream": {"pod": "p1"}, "values": [["1500", 12345]]},
+            ),
+            (
+                # A stream dict with a non-`str` key (mixed `str`/`int`
+                # keys) would make `sorted(stream.items())` raise a raw,
+                # undiagnosable `TypeError` instead of
+                # `_MalformedLogResponseError` -- `assertRaises`' exact-type
+                # check fails the subTest if a bare `TypeError` propagates.
+                "non-str stream key raises malformed, not a bare TypeError",
+                {"stream": {"pod": "p1", 7: "bad"}, "values": [["1500", "line"]]},
+            ),
+            (
+                "non-str metadata key raises malformed, not a bare TypeError",
+                {
+                    "stream": {"pod": "p1"},
+                    "values": [["1500", "line", {"a": 1, 2: "bad"}]],
+                },
+            ),
+        ]
+        for description, record in malformed_records:
+            with self.subTest(description=description):
+                with self.assertRaises(_MalformedLogResponseError):
+                    _parse_log_entries(
+                        {"data": {"result": [record]}},
+                        limit=100,
+                        start=1000,
+                        end=2000,
+                    )
+
+    def test_legitimate_scalar_metadata_is_unaffected(self):
+        """Control: str/int/float/bool/None metadata values are all
+        supported hashable scalars and must not be rejected."""
+        entries, examined = _parse_log_entries(
+            {
+                "data": {
+                    "result": [{
+                        "stream": {"pod": "p1"},
+                        "values": [[
+                            "1500",
+                            "line",
+                            {
+                                "str_field": "v",
+                                "int_field": 1,
+                                "float_field": 1.5,
+                                "bool_field": True,
+                                "none_field": None,
+                            },
+                        ]],
+                    }]
+                }
+            },
+            limit=100,
+            start=1000,
+            end=2000,
+        )
+        self.assertEqual(examined, 1)
+        self.assertEqual(
+            dict(entries[0].metadata),
+            {
+                "str_field": "v",
+                "int_field": 1,
+                "float_field": 1.5,
+                "bool_field": True,
+                "none_field": None,
+            },
+        )
+
+    def test_malformed_value_tuple_shapes_and_metadata_forms_are_rejected(self):
+        """Table-driven: value-tuple length bound and metadata
+        acceptance/rejection (`None`/`{}` accepted as "no metadata", any
+        other non-dict rejected even when falsy), plus timestamp type
+        rejection (`bool`/`float`). `start` (1000) is a valid/retained
+        boundary; the exclusive `end` (2000) boundary is already covered
+        by `test_end_exclusive_boundary_entry_raises` above and is not
+        repeated here."""
+        start, end = 1000, 2000
+        valid_cases = [
+            ("2-element, no metadata", [1500, "line"], ()),
+            ("3-element, None metadata", [1500, "line", None], ()),
+            ("3-element, {} metadata", [1500, "line", {}], ()),
+            (
+                "3-element, real metadata dict",
+                [1500, "line", {"k": "v"}],
+                (("k", "v"),),
+            ),
+            ("str timestamp that parses cleanly", ["1500", "line"], ()),
+            ("timestamp exactly at start boundary", [start, "line"], ()),
+        ]
+        for description, value, expected_metadata in valid_cases:
+            with self.subTest(description=description):
+                entries, examined = _parse_log_entries(
+                    {
+                        "data": {
+                            "result": [{"stream": {"pod": "p1"}, "values": [value]}]
+                        }
+                    },
+                    limit=100,
+                    start=start,
+                    end=end,
+                )
+                self.assertEqual(examined, 1)
+                self.assertEqual(entries[0].timestamp_ns, int(value[0]))
+                self.assertEqual(entries[0].line, "line")
+                self.assertEqual(entries[0].metadata, expected_metadata)
+
+        malformed_cases = [
+            ("0-element value tuple", []),
+            ("1-element value tuple", [1500]),
+            ("4-element value tuple", [1500, "line", {}, "extra"]),
+            ("5-element value tuple", [1500, "line", {}, "extra", "extra2"]),
+            ("metadata 0 (falsy, wrong type)", [1500, "line", 0]),
+            ("metadata False (falsy, wrong type)", [1500, "line", False]),
+            ("metadata empty string (falsy, wrong type)", [1500, "line", ""]),
+            ("metadata empty list (falsy, wrong type)", [1500, "line", []]),
+            ("metadata non-dict truthy string", [1500, "line", "x"]),
+            ("positive float timestamp", [1500.5, "line"]),
+        ]
+        for description, value in malformed_cases:
+            with self.subTest(description=description):
+                with self.assertRaises(_MalformedLogResponseError):
+                    _parse_log_entries(
+                        {
+                            "data": {
+                                "result": [{
+                                    "stream": {"pod": "p1"},
+                                    "values": [value],
+                                }]
+                            }
+                        },
+                        limit=100,
+                        start=start,
+                        end=end,
+                    )
+
+        # Bracket -10..10 so these values (coerced via int(): True->1,
+        # False->0, -1.0->-1) fall in-range -- otherwise the pre-existing
+        # range check would reject them too, masking the type check below.
+        in_range_start, in_range_end = -10, 10
+        type_rejected_in_range_cases = [
+            ("bool timestamp True", [True, "line"]),
+            ("bool timestamp False", [False, "line"]),
+            ("negative float timestamp", [-1.0, "line"]),
+        ]
+        for description, value in type_rejected_in_range_cases:
+            with self.subTest(description=description):
+                with self.assertRaises(_MalformedLogResponseError):
+                    _parse_log_entries(
+                        {
+                            "data": {
+                                "result": [{
+                                    "stream": {"pod": "p1"},
+                                    "values": [value],
+                                }]
+                            }
+                        },
+                        limit=100,
+                        start=in_range_start,
+                        end=in_range_end,
+                    )
+
+    def test_limit_must_be_a_positive_int_raises_value_error(self):
+        """`limit` is an internal contract between this parser and its
+        callers (always `_ADAPTIVE_PAGE_LIMIT` in production), not data
+        from the backend -- a bad value here is our own bug, so it raises
+        plain `ValueError`, distinct from `_MalformedLogResponseError`
+        (reserved for untrusted response-shape violations). Unreachable
+        from real CLI usage; defensive only."""
+        valid_response = _loki_response([(1500, "ok", {})])
+        for bad_limit in (0, -1, True, "5", 1.5):
+            with self.subTest(bad_limit=bad_limit):
+                with self.assertRaises(ValueError):
+                    _parse_log_entries(
+                        valid_response, limit=bad_limit, start=1000, end=2000
+                    )
+
+
+class TestStreamValidationRunsOncePerStreamNotPerRecord(unittest.TestCase):
+    """`_validate_hashable_scalar_values`/`_validate_str_keys` on `stream`
+    must run once per stream dict, not once per record within that stream --
+    otherwise validation cost scales with record count instead of stream
+    count."""
+
+    def test_call_count_scales_with_stream_count_not_record_count(self):
+        entries = [(1000 + i, f"l{i}", {"pod": "p1"}) for i in range(500)]
+        response = _loki_response(entries)
+        self.assertEqual(len(response["data"]["result"]), 1)  # single stream
+
+        with (
+            patch.object(
+                log_mod,
+                "_validate_hashable_scalar_values",
+                wraps=log_mod._validate_hashable_scalar_values,
+            ) as scalar_mock,
+            patch.object(
+                log_mod, "_validate_str_keys", wraps=log_mod._validate_str_keys
+            ) as keys_mock,
+        ):
+            entries_out, examined = _parse_log_entries(
+                response, limit=1000, start=1000, end=2000
+            )
+
+        self.assertEqual(examined, 500)
+        # One stream dict validated once each, not once per the 500 records.
+        stream_scalar_calls = [
+            c for c in scalar_mock.call_args_list if c.args[1] == "stream"
+        ]
+        stream_key_calls = [
+            c for c in keys_mock.call_args_list if c.args[1] == "stream"
+        ]
+        self.assertEqual(len(stream_scalar_calls), 1)
+        self.assertEqual(len(stream_key_calls), 1)
+
+    def test_invalid_stream_with_empty_values_still_raises(self):
+        """Validating `stream` before the per-record loop means a stream
+        with an invalid value is rejected even when `values` is empty --
+        the loop body never running must not let a bad `stream` dict slip
+        through."""
+        with self.assertRaises(_MalformedLogResponseError):
+            _parse_log_entries(
+                {
+                    "data": {
+                        "result": [{
+                            "stream": {"pod": ["not", "hashable"]},
+                            "values": [],
+                        }]
+                    }
+                },
+                limit=100,
+                start=1000,
+                end=2000,
+            )
+
+    def test_invalid_stream_key_with_empty_values_still_raises(self):
+        with self.assertRaises(_MalformedLogResponseError):
+            _parse_log_entries(
+                {
+                    "data": {
+                        "result": [{
+                            "stream": {"pod": "p1", 7: "bad"},
+                            "values": [],
+                        }]
+                    }
+                },
+                limit=100,
+                start=1000,
+                end=2000,
+            )
+
+
+class TestFetchLogUnitMalformedAndOutOfRange(unittest.TestCase):
+    def test_malformed_or_out_of_range_response_is_retried_then_resolves_failed(self):
+        """Table-driven: every kind of malformed/out-of-range response drives
+        the same `_fetch_log_unit` retry-then-fail path -- a wrong-shape
+        response, an out-of-range timestamp (treated as malformed, not
+        silently dropped), a timestamp exactly at the exclusive `end`
+        boundary (half-open `[start, end)`), a too-short value tuple, a
+        non-dict/falsy metadata value, and a `bool` timestamp.
+
+        The "bool timestamp" case uses its own `start`/`end` bracketing
+        `int(True) == 1` (rather than the shared `[1000, 2000)` used by the
+        other cases): `[1000, 2000)` would reject `True` via the
+        pre-existing `[start, end)` range check regardless of whether the
+        dedicated `isinstance(value[0], (bool, float))` type check exists,
+        masking which check actually drove the failure.
+        """
+        cases = {
+            "wrong shape": (0, 100, {"error": "wrong shape"}),
+            "out-of-range timestamp": (
+                1000,
+                2000,
+                _loki_response([(2500, "bad", {})]),
+            ),
+            "timestamp at exclusive end boundary": (
+                1000,
+                2000,
+                _loki_response([(2000, "edge", {})]),
+            ),
+            "bad value-tuple length": (
+                1000,
+                2000,
+                {"data": {"result": [{"stream": {}, "values": [["1500"]]}]}},
+            ),
+            "bad metadata (non-dict, falsy)": (
+                1000,
+                2000,
+                {"data": {"result": [{"stream": {}, "values": [["1500", "line", 0]]}]}},
+            ),
+            "bool timestamp": (
+                -10,
+                10,
+                {"data": {"result": [{"stream": {}, "values": [[True, "line"]]}]}},
+            ),
+        }
+        for description, (start, end, response) in cases.items():
+            with self.subTest(description=description):
+                fake = _RecordingFakeLogAPI({(start, end): response})
+                with (
+                    patch.object(log_mod, "APIClient", _make_client_class(fake)),
+                    patch.object(log_mod.time, "sleep", return_value=None),
+                ):
+                    result = _fetch_log_unit(
+                        None, "job-1", None, None, "", start, end, limit=5000
+                    )
+                self.assertTrue(result.failed)
+                self.assertEqual(len(fake.calls), 5)
+
+    def test_fetch_log_unit_bad_limit_raises_immediately_with_no_api_calls(self):
+        """Fix (`limit` precondition) at the `_fetch_log_unit` layer:
+        `limit` is validated at the top of `_fetch_log_unit`, before the
+        retry loop and before any HTTP call, mirroring
+        `_parse_log_entries`'s own precondition check. A bad `limit` is a
+        programmer/configuration bug, never legitimately caused by
+        backend data, so it must raise a plain `ValueError` immediately --
+        zero API calls, zero retries -- rather than being caught by the
+        loop's bare `except Exception` and wastefully retried the full
+        budget before resolving `failed=True`."""
+        fake = _RecordingFakeLogAPI({(1000, 2000): _loki_response([(1500, "ok", {})])})
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", return_value=None),
+        ):
+            with self.assertRaises(ValueError):
+                _fetch_log_unit(None, "job-1", None, None, "", 1000, 2000, limit=0)
+        self.assertEqual(len(fake.calls), 0)
+
+
+class TestFetchLogUnitOversizedPageCapping(unittest.TestCase):
+    def test_response_at_or_over_limit_is_capped_and_saturated(self):
+        """Table-driven: a response strictly over `limit` is capped to the
+        `limit` smallest timestamps; a response of exactly `limit` entries
+        is also saturated (not just capped on strict overflow)."""
+        cases = [
+            ("over limit", 7000, 4999, [0, 1, 2]),
+            ("exactly at limit", 5000, None, None),
+        ]
+        for description, entry_count, expected_max_ts, expected_head in cases:
+            with self.subTest(description=description):
+                entries = [(i, f"l{i}", {}) for i in range(entry_count)]
+                fake = _RecordingFakeLogAPI({(0, 100000): _loki_response(entries)})
+                with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+                    result = _fetch_log_unit(
+                        None, "job-1", None, None, "", 0, 100000, limit=5000
+                    )
+                self.assertTrue(result.saturated)
+                self.assertEqual(len(result.entries), 5000)
+                if expected_max_ts is not None:
+                    self.assertEqual(result.max_ts, expected_max_ts)
+                    self.assertEqual(
+                        [e.timestamp_ns for e in result.entries][:3], expected_head
+                    )
+
+
+class TestBoundedIncrementalPageCapping(unittest.TestCase):
+    """`_parse_log_entries` bounds retention to `limit` incrementally
+    (a bounded max-heap) as the response is examined, instead of
+    materializing and sorting the full response before capping it.
+    """
+
+    def test_unordered_interleaved_across_streams_retains_exact_smallest_limit(
+        self,
+    ):
+        # 450 entries (4.5x the 100 limit) spread across 5 streams, with
+        # timestamps assigned via a multiplicative permutation modulo 450
+        # (97 is coprime with 450, so `(i * 97) % 450` visits every
+        # timestamp exactly once, in an order matching neither within- nor
+        # across-stream examination order) -- so neither a single stream's
+        # `values` list nor `data.result`'s stream order is ever sorted.
+        limit = 100
+        total = 450
+        entries = []
+        for i in range(total):
+            ts = (i * 97) % total
+            entries.append((ts, f"l{ts}", {"pod": f"p{i % 5}"}))
+        fake = _RecordingFakeLogAPI({(0, total): _loki_response(entries)})
+        with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+            result = _fetch_log_unit(
+                None, "job-1", None, None, "", 0, total, limit=limit
+            )
+        self.assertTrue(result.saturated)
+        self.assertEqual(len(result.entries), limit)
+        # The true smallest-`limit` timestamps are exactly 0..limit-1,
+        # sorted ascending, regardless of examination order.
+        self.assertEqual([e.timestamp_ns for e in result.entries], list(range(limit)))
+
+    def test_malformed_record_in_unretained_portion_still_raises(self):
+        # limit=5 over ts 0..19 retains only 0..4; the malformed record is
+        # appended after all 20 well-formed values, so it is examined well
+        # after the retained set is already full -- it must still raise,
+        # never be silently dropped just because it wouldn't have been kept.
+        limit = 5
+        entries = [(i, f"l{i}", {}) for i in range(20)]
+        response = _loki_response(entries)
+        response["data"]["result"][0]["values"].append(["not-enough-fields"])
+        fake = _RecordingFakeLogAPI({(0, 100): response})
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", return_value=None),
+        ):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=limit)
+        self.assertTrue(result.failed)
+
+    def test_out_of_range_record_in_unretained_portion_still_raises(self):
+        # Same shape as above, but the bad record is out-of-range rather
+        # than malformed-shaped -- also examined after the retained set is
+        # already full.
+        limit = 5
+        entries = [(i, f"l{i}", {}) for i in range(20)]
+        entries.append((99999, "way-out-of-range", {}))
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response(entries)})
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", return_value=None),
+        ):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=limit)
+        self.assertTrue(result.failed)
+
+    def test_normal_under_limit_response_unchanged_behavior(self):
+        # Control case: a normal, well-under-the-limit, unordered response
+        # is unaffected by the incremental bounded-retention rewrite.
+        entries = [(3, "c", {}), (1, "a", {}), (2, "b", {})]
+        fake = _RecordingFakeLogAPI({(0, 100): _loki_response(entries)})
+        with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+        self.assertFalse(result.saturated)
+        self.assertFalse(result.failed)
+        self.assertEqual([e.timestamp_ns for e in result.entries], [1, 2, 3])
+        self.assertEqual(result.min_ts, 1)
+        self.assertEqual(result.max_ts, 3)
+
+    def test_bounded_heap_size_never_exceeds_limit_for_large_response(self):
+        # Black-box instrumentation of the bounded max-heap's own insert
+        # operations (heapq.heappush/heapreplace), not a read of the source
+        # file or an AST inspection: confirms additional retained-object
+        # count stays proportional to `limit`, not to response size, even
+        # for a response many times larger than `limit`.
+        limit = 10
+        total = 5000
+        entries = [((i * 97) % total, f"l{i}", {}) for i in range(total)]
+        fake = _RecordingFakeLogAPI({(0, total): _loki_response(entries)})
+
+        real_heappush = heapq.heappush
+        real_heapreplace = heapq.heapreplace
+        max_heap_len = {"value": 0}
+
+        def tracking_heappush(heap, item):
+            real_heappush(heap, item)
+            max_heap_len["value"] = max(max_heap_len["value"], len(heap))
+
+        def tracking_heapreplace(heap, item):
+            real_heapreplace(heap, item)
+            max_heap_len["value"] = max(max_heap_len["value"], len(heap))
+
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.heapq, "heappush", side_effect=tracking_heappush),
+            patch.object(
+                log_mod.heapq, "heapreplace", side_effect=tracking_heapreplace
+            ),
+        ):
+            result = _fetch_log_unit(
+                None, "job-1", None, None, "", 0, total, limit=limit
+            )
+        self.assertTrue(result.saturated)
+        self.assertGreater(max_heap_len["value"], 0)
+        self.assertLessEqual(max_heap_len["value"], limit)
+
+
+class TestFetchLogUnitRejectsEpochZeroBoundary(unittest.TestCase):
+    """A literal `start=0`/`end=0` unit boundary can never actually reach
+    `_fetch_log_unit` in production -- `fetch_log`'s probe call rejects an
+    epoch-0 `--start`/`--end` before the adaptive scheduler ever starts (see
+    test_log_cli.py's `TestEpochZeroStartEndToEndCli`), and bisection never
+    produces a unit boundary below the original start. This exercises the
+    defense-in-depth case anyway: if `_fetch_log_unit` were ever given such a
+    boundary, `LogAPI.get_log` rejects it with a plain `RuntimeError`, which
+    `_fetch_log_unit`'s existing non-429 retry path treats like any other
+    failure -- retried with fixed backoff, then reported as a failed unit
+    once retries are exhausted, not an unhandled crash.
+    """
+
+    def test_zero_boundary_exhausts_retries_and_is_reported_failed(self):
+        fake = _RecordingFakeLogAPI({
+            (0, 100): RuntimeError(
+                "start=0/end=0 cannot be distinguished from an omitted"
+                " start/end by the /logs API"
+            )
+        })
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod, "_interruptible_sleep", return_value=None),
+        ):
+            result = _fetch_log_unit(None, "job-1", None, None, "", 0, 100, limit=5000)
+        self.assertTrue(result.failed)
+        self.assertEqual(len(fake.calls), 5)
+
+
+class TestInterruptibleBackoffSleep(unittest.TestCase):
+    """Backoff/retry sleeps use `cancelled.wait(delay)`,
+    which wakes promptly once `cancelled` is set instead of always blocking
+    for the full configured delay. Verified with real wall-clock timing.
+    """
+
+    def test_cancellation_during_non_429_backoff_wakes_promptly(self):
+        # attempt=0 non-429 failure -> fixed backoff delay = 1.0s. A
+        # background timer sets `cancelled` well before that elapses.
+        fake = _RecordingFakeLogAPI({(0, 100): RuntimeError("boom")})
+        cancelled = threading.Event()
+        timer = threading.Timer(0.05, cancelled.set)
+        timer.start()
+        try:
+            start = time.perf_counter()
+            with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+                result = _fetch_log_unit(
+                    None,
+                    "job-1",
+                    None,
+                    None,
+                    "",
+                    0,
+                    100,
+                    limit=5000,
+                    cancelled=cancelled,
+                )
+            elapsed = time.perf_counter() - start
+        finally:
+            timer.cancel()
+        self.assertTrue(result.failed)
+        # Woke well before the full 1.0s fixed-backoff delay would have
+        # elapsed on its own.
+        self.assertLess(elapsed, 0.3)
+
+    def test_cancellation_during_retry_after_bounded_sleep_wakes_promptly(self):
+        # A 429 with retry_after=10.0 would otherwise sleep a full 10s.
+        fake = _RecordingFakeLogAPI(
+            {(0, 100): LogAPIError("rate limited", 429, retry_after=10.0)}
+        )
+        cancelled = threading.Event()
+        timer = threading.Timer(0.05, cancelled.set)
+        timer.start()
+        try:
+            start = time.perf_counter()
+            with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+                result = _fetch_log_unit(
+                    None,
+                    "job-1",
+                    None,
+                    None,
+                    "",
+                    0,
+                    100,
+                    limit=5000,
+                    cancelled=cancelled,
+                )
+            elapsed = time.perf_counter() - start
+        finally:
+            timer.cancel()
+        self.assertTrue(result.failed)
+        # Woke well before the full (capped) 10s Retry-After delay.
+        self.assertLess(elapsed, 2.0)
+
+    def test_no_cancelled_event_falls_back_to_time_sleep(self):
+        # cancelled=None falls back to plain time.sleep.
+        fake = _RecordingFakeLogAPI(
+            {
+                (0, 100): [
+                    RuntimeError("e1"),
+                    _loki_response([(1, "ok", {})]),
+                ]
+            }
+        )
+        with (
+            patch.object(log_mod, "APIClient", _make_client_class(fake)),
+            patch.object(log_mod.time, "sleep", return_value=None) as mock_sleep,
+        ):
+            result = _fetch_log_unit(
+                None, "job-1", None, None, "", 0, 100, limit=5000, cancelled=None
+            )
+        self.assertFalse(result.failed)
+        mock_sleep.assert_called_once_with(1.0)
+
+    def test_control_backoff_sleep_not_shortened_without_cancellation(self):
+        """Control: proves the interruptible-wait mechanism doesn't shorten the delay when
+        cancellation never happens -- the full ~1.0s fixed backoff still
+        elapses before attempt 2 fires."""
+        fake = _RecordingFakeLogAPI(
+            {(0, 100): [RuntimeError("boom"), _loki_response([(1, "ok", {})])]}
+        )
+        cancelled = threading.Event()
+
+        with patch.object(log_mod, "APIClient", _make_client_class(fake)):
+            start = time.perf_counter()
+            result = _fetch_log_unit(
+                None, "job-1", None, None, "", 0, 100, limit=5000, cancelled=cancelled
+            )
+            elapsed = time.perf_counter() - start
+
+        self.assertFalse(result.failed)
+        self.assertGreaterEqual(
+            elapsed,
+            0.95,
+            "expected the full ~1.0s fixed backoff to elapse when"
+            f" cancellation never happens, got {elapsed}s",
+        )
+        self.assertEqual(len(fake.calls), 2)

--- a/leptonai/cli/tests/test_log_cli.py
+++ b/leptonai/cli/tests/test_log_cli.py
@@ -1,0 +1,667 @@
+"""Independent scenario/CLI-level tests for adaptive parallel log retrieval.
+
+These tests drive `lep log get` end-to-end through `click.testing.CliRunner`,
+exactly as a user would invoke it, with only `APIClient` replaced by a fake
+that records every `client.log.get_log(...)` call and serves scripted Loki
+`query_range`-shaped responses. They are not written from reading
+`leptonai/cli/log.py`'s implementation logic.
+
+Two small, pre-existing (and unmodified by this feature) helpers are used
+directly to build fixtures/expected strings, the same way production code
+uses them: `_preprocess_time` (parses `--start`/`--end` strings to ns epoch)
+and `_epoch_to_time_str` (formats ns epoch back to the display string). Using
+them is no different from a test calling `json.dumps` to build a fixture --
+it does not encode any assertion about the adaptive scheduler's behavior.
+"""
+
+import os
+import tempfile
+
+# Set cache dir to a temp dir before importing anything from leptonai, matching
+# the existing CLI test suite convention (test_job_cli.py).
+tmpdir = tempfile.mkdtemp()
+os.environ["LEPTON_CACHE_DIR"] = tmpdir
+
+import glob
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from leptonai.api.v2.log import LogAPI
+from leptonai.cli import cli as cli_mod
+from leptonai.cli import lep as cli
+from leptonai.cli import log as log_mod
+from leptonai.cli.log import _epoch_to_time_str, _preprocess_time
+from leptonai.cli.tests._log_test_helpers import (
+    InFlightTracker as _InFlightTracker,
+    RealLogAPIHTTPClient as _RealLogAPIHTTPClient,
+    loki_response as _loki_response,
+    make_client_class as _make_client_class,
+    pad_entries as _pad_entries,
+)
+
+# Captured before any test patches `log_mod.time.sleep` -- see
+# `_log_test_helpers` for why a real reference must be kept separately.
+_REAL_SLEEP = time.sleep
+
+
+class _FakeLogAPI:
+    """Fake `client.log`. Records every `get_log` call (including the
+    one-record probe). Non-probe (limit != 1) calls are matched by
+    (start, end) against `script`: a scripted response dict, an Exception
+    (raised), or a list of either (consumed in call-index order, last one
+    repeats)."""
+
+    def __init__(self, script, probe_response=None, delay_fn=None, inflight=None):
+        self.script = script
+        self.probe_response = (
+            probe_response
+            if probe_response is not None
+            else _loki_response([(1, "probe", {})])
+        )
+        self.calls = []
+        self._counts = {}
+        self.lock = threading.Lock()
+        self.delay_fn = delay_fn
+        self.inflight = inflight
+
+    def get_log(self, **kwargs):
+        if self.inflight is not None:
+            self.inflight.enter()
+        try:
+            with self.lock:
+                self.calls.append(dict(kwargs))
+            if kwargs.get("limit") == 1:
+                return self.probe_response
+            key = (kwargs.get("start"), kwargs.get("end"))
+            with self.lock:
+                self._counts[key] = self._counts.get(key, 0) + 1
+                n = self._counts[key]
+            if self.delay_fn is not None:
+                time.sleep(self.delay_fn(key))
+            outcome = self.script.get(key)
+            if isinstance(outcome, list):
+                outcome = outcome[min(n - 1, len(outcome) - 1)]
+            if isinstance(outcome, Exception):
+                raise outcome
+            if outcome is None:
+                return {"data": {"result": []}}
+            return outcome
+        finally:
+            if self.inflight is not None:
+                self.inflight.leave()
+
+    def unit_calls(self):
+        """Calls made by the adaptive scheduler (always direction='forward'),
+        excluding the one-record probe and any LEGACY-path calls."""
+        return [c for c in self.calls if c.get("direction") == "forward"]
+
+
+def _invoke(args, fake_log_api, input=None):
+    runner = CliRunner()
+    client_cls = _make_client_class(fake_log_api)
+    # `lep`'s group callback calls check_lepton_version(), which makes a
+    # real network call to pypi.org and prints a "newer version available"
+    # banner to stdout when the installed version is behind -- a side
+    # effect unrelated to the adaptive scheduler that would otherwise leak
+    # non-deterministically into `result.output` (first invocation in a
+    # fresh process vs. later ones once its own cache file is warm). Not a
+    # bug in check_lepton_version itself; just needs to be inert here so
+    # every CLI-level assertion in this file only reflects `log get`'s own
+    # output.
+    with (
+        patch.object(log_mod, "APIClient", client_cls),
+        patch.object(cli_mod, "check_lepton_version", return_value=None),
+    ):
+        result = runner.invoke(cli, args, input=input)
+    return result, client_cls.last_instance
+
+
+START_STR = "2024-01-01 00:00:00.000000"
+END_STR = "2024-01-01 00:00:00.004000"
+UNIX_START = _preprocess_time(START_STR, epoch=True)
+UNIX_END = _preprocess_time(END_STR, epoch=True)
+# --start/--end only support microsecond precision, so the parsed ns delta is
+# 1000x the "004000" numeral in the string above.
+assert UNIX_END - UNIX_START == 4_000_000
+
+TREE_START_STR = "2024-01-01 00:00:00.000000"
+TREE_END_STR = "2024-01-01 00:00:00.016000"
+TREE_S = _preprocess_time(TREE_START_STR, epoch=True)
+TREE_E = _preprocess_time(TREE_END_STR, epoch=True)
+assert TREE_E - TREE_S == 16_000_000
+
+
+def _base_args(*extra, start=START_STR, end=END_STR, target=("-e", "dep1")):
+    return ["log", "get", *target, "--start", start, "--end", end, *extra]
+
+
+def _build_tree_script():
+    """3-leaf, 2-level bisecting tree over [TREE_S, TREE_E):
+
+    root=[S, E) branch_mid=S+8000, saturates at T1=S+3000 (<mid) -> two
+    children C1=[S+3000, S+9500), C2=[S+9500, E).
+    C1 branch_mid=S+6250, saturates at T2=S+4000 (<mid) -> two children
+    D1=[S+4000, S+6750), D2=[S+6750, S+9500).
+    C2 terminates without further splitting.
+    Leaves: D1, D2, C2 -- three leaf units at different recursion depths.
+    """
+    S, E = TREE_S, TREE_E
+    root_page = _pad_entries(10000, S + 0, S + 3_000_000, "r")
+    c1_page = _pad_entries(10000, S + 3_000_000, S + 4_000_000, "c1")
+    d1_resp = _loki_response([(S + 4_500_000, "d1a", {}), (S + 4_600_000, "d1b", {})])
+    d2_resp = _loki_response([(S + 7_000_000, "d2a", {})])
+    c2_resp = _loki_response([(S + 12_000_000, "c2a", {})])
+    script = {
+        (S, E): _loki_response(root_page),
+        (S + 3_000_000, S + 9_500_000): _loki_response(c1_page),
+        (S + 4_000_000, S + 6_750_000): d1_resp,
+        (S + 6_750_000, S + 9_500_000): d2_resp,
+        (S + 9_500_000, E): c2_resp,
+    }
+    return script
+
+
+# ---------------------------------------------------------------------------
+# under-limit single unit
+# ---------------------------------------------------------------------------
+
+
+class TestUnderLimitSingleUnit(unittest.TestCase):
+    def test_single_request_chronological_output(self):
+        entries = [
+            (UNIX_START + 3, "c", {}),
+            (UNIX_START + 1, "a", {}),
+            (UNIX_START + 2, "b", {}),
+        ]
+        fake = _FakeLogAPI({(UNIX_START, UNIX_END): _loki_response(entries)})
+
+        result, _ = _invoke(_base_args(), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(len(fake.unit_calls()), 1)
+        self.assertEqual(fake.unit_calls()[0]["direction"], "forward")
+        # Chronological order regardless of Loki response order.
+        idx_a = result.output.index('"a"')
+        idx_b = result.output.index('"b"')
+        idx_c = result.output.index('"c"')
+        self.assertTrue(idx_a < idx_b < idx_c)
+        self.assertIn("👆Time range: UTC|", result.output)
+        self.assertIn("total 3 lines", result.output)
+
+    def test_nonempty_fetch_makes_exactly_one_http_call(self):
+        """A nonempty, non-saturating adaptive fetch makes exactly one HTTP
+        request total: the root unit's own fetch.
+        """
+        fake = _FakeLogAPI(
+            {(UNIX_START, UNIX_END): _loki_response([(UNIX_START + 1, "a", {})])}
+        )
+
+        result, _ = _invoke(_base_args(), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(len(fake.calls), 1)
+
+
+# ---------------------------------------------------------------------------
+# empty interval
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyInterval(unittest.TestCase):
+    def test_empty_result_prints_no_logs_found_and_exits_zero(self):
+        """The adaptive (no-`--limit`) path dispatches straight into the
+        scheduler: the scheduler's own root fetch for `[S, E)` resolves
+        empty (zero entries, zero failed units), and `run()` prints "No logs
+        found" instead of the normal zero-line summary.
+        """
+        S, E = UNIX_START, UNIX_END
+        fake = _FakeLogAPI({(S, E): {"data": {"result": []}}})
+
+        result, _ = _invoke(_base_args(), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("No logs found in the specified time range.", result.output)
+        self.assertNotIn("Total:", result.output)
+        # Exactly one HTTP call: the root fetch. No separate probe request.
+        self.assertEqual(len(fake.calls), 1)
+        self.assertEqual(len(fake.unit_calls()), 1)
+
+    def test_empty_result_with_path_leaves_no_file_on_disk(self):
+        """`--path` naming an *already-existing* directory: `resolve_save_path`
+        treats it as directory-mode (auto-generated filename inside it), a
+        different resolution branch than a direct file path or a
+        not-yet-existing directory. A genuinely empty, fully-successful
+        adaptive run must still never create a file inside it, proving file
+        opening is deferred independently of whether directory creation
+        itself was needed.
+        """
+        S, E = UNIX_START, UNIX_END
+        fake = _FakeLogAPI({(S, E): {"data": {"result": []}}})
+        outdir = tempfile.mkdtemp(dir=tmpdir)
+
+        result, _ = _invoke(_base_args("--path", outdir), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("No logs found in the specified time range.", result.output)
+        self.assertEqual(glob.glob(os.path.join(outdir, "*.txt")), [])
+
+    def test_empty_result_with_path_targeting_nonexistent_directory_never_creates_it(
+        self,
+    ):
+        """The stronger version of the test above: the target directory
+        doesn't exist at all yet. A genuinely empty adaptive result must
+        never create it -- proving path resolution (which creates the
+        directory via `os.makedirs`) is deferred, not just file opening.
+        """
+        S, E = UNIX_START, UNIX_END
+        fake = _FakeLogAPI({(S, E): {"data": {"result": []}}})
+        outdir = os.path.join(tmpdir, "never-created-empty-run-dir")
+        self.assertFalse(os.path.exists(outdir))
+
+        result, _ = _invoke(_base_args("--path", outdir), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("No logs found in the specified time range.", result.output)
+        self.assertFalse(
+            os.path.exists(outdir),
+            "an empty adaptive result must never create the --path directory",
+        )
+
+    def test_empty_result_with_path_targeting_existing_file_preserves_content(self):
+        """Critical data-preservation test: `--path` naming an existing file
+        with real prior content. Since path resolution and file opening are
+        deferred to the first actual write need, a genuinely empty result
+        never opens (and thus never truncates) a pre-existing file at all.
+        """
+        S, E = UNIX_START, UNIX_END
+        fake = _FakeLogAPI({(S, E): {"data": {"result": []}}})
+        outpath = os.path.join(tempfile.mkdtemp(dir=tmpdir), "pre-existing.txt")
+        original_content = "these are pre-existing, precious log lines\n" * 3
+        with open(outpath, "w", encoding="utf-8") as f:
+            f.write(original_content)
+
+        result, _ = _invoke(_base_args("--path", outpath), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("No logs found in the specified time range.", result.output)
+        with open(outpath, encoding="utf-8") as f:
+            self.assertEqual(
+                f.read(),
+                original_content,
+                "a pre-existing file at --path must be byte-for-byte"
+                " unchanged after an empty adaptive result",
+            )
+
+
+# ---------------------------------------------------------------------------
+# API failures and retries
+# ---------------------------------------------------------------------------
+
+
+class TestApiFailuresAndRetries(unittest.TestCase):
+    """Proves the CLI's own human-readable warning text (naming the failed
+    range and "missing from the output") on a partial-result exit."""
+
+    def test_permanent_failure_on_one_unit_surfaces_as_warning_exit_2(self):
+        S, E = UNIX_START, UNIX_END
+        T = S + 1_000_000  # < branch_mid -> two children
+        split_mid = T + (E - T) // 2
+        page = _pad_entries(10000, S, T, "p")
+        fake = _FakeLogAPI({
+            (S, E): _loki_response(page),
+            (T, split_mid): RuntimeError("permanent"),
+            (split_mid, E): _loki_response([(split_mid + 5, "ok-sibling", {})]),
+        })
+
+        with patch.object(log_mod, "_interruptible_sleep", return_value=None):
+            result, _ = _invoke(_base_args(), fake)
+
+        self.assertEqual(result.exit_code, 2, result.output)
+        # The permanently-failing unit was retried the full budget.
+        failing_calls = [
+            c for c in fake.unit_calls() if (c["start"], c["end"]) == (T, split_mid)
+        ]
+        self.assertEqual(len(failing_calls), 5)
+        # Sibling data is still emitted.
+        self.assertIn('"ok-sibling"', result.output)
+        # A warning names the failed range. Normalize whitespace first since
+        # the rich console line-wraps long sentences.
+        normalized = " ".join(result.output.split())
+        self.assertIn("could not be fetched after 5 retries", normalized)
+        self.assertIn("missing from the output", normalized)
+        self.assertIn(_epoch_to_time_str(T), normalized)
+        self.assertIn(_epoch_to_time_str(split_mid), normalized)
+        # It's still a real summary, not a claim of full success.
+        self.assertIn("👆Time range: UTC|", normalized)
+
+
+# ---------------------------------------------------------------------------
+# worker concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerConcurrency(unittest.TestCase):
+    def test_workers_1_never_exceeds_one_in_flight(self):
+        script = _build_tree_script()
+        tracker = _InFlightTracker()
+        fake = _FakeLogAPI(script, delay_fn=lambda key: 0.005, inflight=tracker)
+
+        result, _ = _invoke(
+            _base_args("--workers", "1", start=TREE_START_STR, end=TREE_END_STR),
+            fake,
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(len(fake.unit_calls()), 5)
+        self.assertLessEqual(tracker.max_seen, 1)
+
+    def test_default_workers_is_32(self):
+        fake = _FakeLogAPI(
+            {(UNIX_START, UNIX_END): _loki_response([(UNIX_START + 1, "a", {})])}
+        )
+        captured = {}
+        real_executor_cls = log_mod.ThreadPoolExecutor
+
+        def spy_executor(*args, **kwargs):
+            captured.update(kwargs)
+            return real_executor_cls(*args, **kwargs)
+
+        with patch.object(log_mod, "ThreadPoolExecutor", new=spy_executor):
+            result, _ = _invoke(_base_args(), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(captured.get("max_workers"), 32)
+
+
+# ---------------------------------------------------------------------------
+# --path output format + progress bar contrast
+# ---------------------------------------------------------------------------
+
+
+class TestPathOutputAndProgressBar(unittest.TestCase):
+    def test_path_output_file_content_matches_format_exactly(self):
+        S, E = UNIX_START, UNIX_END
+        entries = [(S + 1, "hello", {}), (S + 2, "world", {})]
+        fake = _FakeLogAPI({(S, E): _loki_response(entries)})
+        outdir = tempfile.mkdtemp(dir=tmpdir)
+
+        real_progress_cls = log_mod.Progress
+        progress_calls = []
+
+        def spy_progress(*args, **kwargs):
+            progress_calls.append((args, kwargs))
+            return real_progress_cls(*args, **kwargs)
+
+        with patch.object(log_mod, "Progress", new=spy_progress):
+            result, _ = _invoke(_base_args("--path", outdir), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertTrue(progress_calls, "Progress must be instantiated for --path")
+
+        files = glob.glob(os.path.join(outdir, "*.txt"))
+        self.assertEqual(len(files), 1)
+        with open(files[0], encoding="utf-8") as f:
+            content = f.read()
+        lines = content.splitlines(keepends=True)
+        self.assertEqual(len(lines), 3)
+        # File sink writes safe_load_json(line) directly (no json.dumps),
+        # unlike the stdout sink -- plain strings appear unquoted.
+        self.assertRegex(
+            lines[0],
+            r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}\｜hello\n$",
+        )
+        self.assertRegex(
+            lines[1],
+            r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}\｜world\n$",
+        )
+        self.assertRegex(
+            lines[2],
+            r"^Time range: UTC\|.+ → UTC\|.+ \| total 2 lines \n$",
+        )
+        self.assertIn("Successfully saved the log to:", result.output)
+
+
+# ---------------------------------------------------------------------------
+# LEGACY --limit path regression
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyLimitPathRegression(unittest.TestCase):
+    def test_limit_never_triggers_adaptive_helpers(self):
+        S, E = UNIX_START, UNIX_END
+        fake = _FakeLogAPI({})
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("adaptive path must not run when --limit is set")
+
+        with (
+            patch.object(
+                log_mod, "fetch_logs_adaptive_parallel", side_effect=_boom
+            ) as adaptive_mock,
+            patch.object(log_mod, "_fetch_log_unit", side_effect=_boom) as unit_mock,
+        ):
+            # Fake client needs to answer the LEGACY main call too.
+            fake.script[(S, E)] = _loki_response(
+                [(S + i, f"l{i}", {}) for i in range(5)]
+            )
+            result, _ = _invoke(_base_args("--limit", "5"), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(adaptive_mock.called)
+        self.assertFalse(unit_mock.called)
+
+        # Independent signal: no call in this invocation ever used
+        # direction="forward"; all rely on the backward default.
+        for call in fake.calls:
+            self.assertNotEqual(call.get("direction"), "forward")
+
+        # LEGACY-specific summary text, byte-for-byte the same format as
+        # today.
+        self.assertIn("Time range: UTC|", result.output)
+        self.assertIn("total 5 lines", result.output)
+
+    def test_limit_with_path_never_triggers_adaptive_helpers(self):
+        S, E = UNIX_START, UNIX_END
+        fake = _FakeLogAPI(
+            {(S, E): _loki_response([(S + i, f"l{i}", {}) for i in range(3)])}
+        )
+        outdir = tempfile.mkdtemp(dir=tmpdir)
+        outpath = os.path.join(outdir, "legacy-out.txt")
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("adaptive path must not run when --limit is set")
+
+        with patch.object(
+            log_mod, "fetch_logs_adaptive_parallel", side_effect=_boom
+        ) as adaptive_mock:
+            result, _ = _invoke(_base_args("--limit", "3", "--path", outpath), fake)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertFalse(adaptive_mock.called)
+        for call in fake.calls:
+            self.assertNotEqual(call.get("direction"), "forward")
+        self.assertIn("Successfully saved the log to:", result.output)
+        with open(outpath, encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("Time range: UTC|", content)
+        self.assertIn("total 3 lines", content)
+
+    def test_repl_path_never_triggers_adaptive_helpers(self):
+        """REPL-path variant: `fetch_and_print_logs`/the REPL loop are
+        closures nested inside `log_command`, not module-level symbols, so
+        they cannot be unit-invoked directly; instead we drive them through
+        a real (non-standalone) CLI invocation with stdin faked to report
+        as an interactive tty, matching how the deprecated interactive
+        prompt actually gates itself (`while True and sys.stdin.isatty()`).
+        """
+        S, E = UNIX_START, UNIX_END
+        fake = _FakeLogAPI(
+            {(S, E): _loki_response([(S + i, f"l{i}", {}) for i in range(5)])}
+        )
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("adaptive path must not run when --limit is set")
+
+        client_cls = _make_client_class(fake)
+        runner = CliRunner()
+        with (
+            patch.object(log_mod, "APIClient", client_cls),
+            patch.object(
+                log_mod, "fetch_logs_adaptive_parallel", side_effect=_boom
+            ) as adaptive_mock,
+            patch.object(cli_mod, "check_lepton_version", return_value=None),
+        ):
+            with runner.isolation(input="next 5\nquit\n") as outstreams:
+                with patch("sys.stdin.isatty", return_value=True):
+                    exc = None
+                    try:
+                        cli.main(
+                            _base_args("--limit", "5"),
+                            standalone_mode=False,
+                        )
+                    except SystemExit as e:
+                        exc = e
+                output = outstreams[0].getvalue().decode("utf-8", "replace")
+
+        self.assertIsNone(exc, f"unexpected SystemExit: {exc}")
+        self.assertFalse(adaptive_mock.called)
+        self.assertIn("Enter a command", output)
+        self.assertIn("Exiting log viewer.", output)
+        for call in fake.calls:
+            self.assertNotEqual(call.get("direction"), "forward")
+
+
+# ---------------------------------------------------------------------------
+# LogAPI.get_log rejects start=0/end=0 (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidAdaptiveBoundsRejectedFastCli(unittest.TestCase):
+    """The adaptive (no-`--limit`) path must reject a non-positive
+    `start`/`end` immediately at the CLI boundary, before ever dispatching a
+    request -- not by letting the root work unit run the full
+    retry-then-mark-failed gauntlet (5 attempts, real exponential backoff up
+    to ~15s total) only to discover the precondition violation the slow way
+    and report it as a generic partial failure (exit code 2).
+    """
+
+    def test_invalid_bounds_rejected_with_zero_dispatch(self):
+        epoch_zero_start = "1970-01-01 00:00:00.000000"
+        epoch_end = "1970-01-01 00:00:01.000000"
+        self.assertEqual(_preprocess_time(epoch_zero_start, epoch=True), 0)
+
+        cases = {
+            "zero_start": _base_args(start=epoch_zero_start, end=epoch_end),
+            # end=0 is only reachable past the pre-existing `end <= start`
+            # inverted-range check (which fires first) when start is itself
+            # negative -- so this necessarily also exercises a negative start.
+            "zero_end": _base_args(start="-1000", end="0"),
+            "negative_start": _base_args(start="-5", end="1000000000"),
+        }
+
+        for name, args in cases.items():
+            with self.subTest(name):
+                fake = _FakeLogAPI({})
+                result, _ = _invoke(args, fake)
+
+                self.assertEqual(result.exit_code, 1, result.output)
+                self.assertEqual(fake.calls, [], "no request should ever be dispatched")
+                self.assertNotIn("Traceback", result.output)
+
+
+class TestEndAfterStartAndNegativeTimestampEndToEndCli(unittest.TestCase):
+    """Drives `lep log get` through the full CLI, proving `end <= start` is
+    rejected end-to-end and not an unhandled traceback. The negative/zero
+    `start`/`end` cases (previously here too) now have their own dedicated
+    fast-fail coverage in `TestInvalidAdaptiveBoundsRejectedFastCli` above.
+    """
+
+    def test_end_before_start_is_rejected_with_clear_error(self):
+        # Both non-zero, non-negative, but inverted. `fetch_log`'s own
+        # `unix_end <= unix_start` guard is the first thing to catch this.
+        later = "2024-01-01 00:00:02.000000"
+        earlier = "2024-01-01 00:00:01.000000"
+
+        real_log_api = LogAPI(_RealLogAPIHTTPClient())
+        result, _ = _invoke(_base_args(start=later, end=earlier), real_log_api)
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertIn("End time must be greater than start time", result.output)
+        self.assertNotIn("Traceback", result.output)
+
+    def test_ordinary_ascending_range_is_not_rejected(self):
+        """Control case: a legitimate range must not trip either new check."""
+        fake = _FakeLogAPI(
+            {(UNIX_START, UNIX_END): _loki_response([(UNIX_START + 1, "a", {})])}
+        )
+        result, _ = _invoke(_base_args(), fake)
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("Failed to query logs", result.output)
+
+
+# ---------------------------------------------------------------------------
+# no success-implying text on a partial result, either mode
+# ---------------------------------------------------------------------------
+
+
+class TestPartialResultNoSuccessText(unittest.TestCase):
+    """When `failed_units` is non-empty (and there is no sink failure),
+    `--path` mode may not print any success-implying leading text and must
+    instead print the "Partial result" wording in both the console output
+    and the saved file's own footer."""
+
+    def _fixture(self, fail):
+        S, E = UNIX_START, UNIX_END
+        T = S + 1_000_000  # < branch_mid -> two children
+        split_mid = T + (E - T) // 2
+        page = _pad_entries(10000, S, T, "p")
+        script = {
+            (S, E): _loki_response(page),
+            (split_mid, E): _loki_response([(split_mid + 5, "ok-sibling", {})]),
+        }
+        script[(T, split_mid)] = (
+            RuntimeError("permanent")
+            if fail
+            else _loki_response([(T + 5, "child-ok", {})])
+        )
+        return _FakeLogAPI(script)
+
+    def test_path_mode_partial_result_suppresses_success_text(self):
+        fake = self._fixture(fail=True)
+        outdir = tempfile.mkdtemp(dir=tmpdir)
+
+        with patch.object(log_mod, "_interruptible_sleep", return_value=None):
+            result, _ = _invoke(_base_args("--path", outdir), fake)
+
+        self.assertEqual(result.exit_code, 2, result.output)
+        self.assertNotIn("Successfully saved the log to:", result.output)
+        self.assertIn("Partial result", result.output)
+        self.assertIn("saved incomplete log to:", result.output)
+        normalized = " ".join(result.output.split())
+        self.assertIn("could not be fetched after 5 retries", normalized)
+        self.assertIn("Total:", result.output)
+
+        files = glob.glob(os.path.join(outdir, "*.txt"))
+        self.assertEqual(len(files), 1)
+        with open(files[0], encoding="utf-8") as f:
+            content = f.read()
+        # The footer/file content itself never claims success either. The
+        # file sink writes the line unquoted (no json.dumps), unlike stdout.
+        self.assertNotIn("Successfully saved the log to:", content)
+        self.assertIn("ok-sibling", content)
+        # The partial marker is additive across both the console output and
+        # the saved file's own footer in this single real run -- not a
+        # replacement for the console gating asserted above.
+        self.assertIn("PARTIAL RESULT:", content)
+        self.assertIn(
+            "time range(s) could not be fetched and are missing from this file:",
+            content,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replace the fixed-time-slot fan-out in the no-`--limit` `lep log get` path with an adaptive bisection scheduler: units are dispatched from a min-heap by smallest start time, a saturated page splits into one or two children depending on where saturation fell within the fetched interval, and output streams chronologically (to file or stdout) via a commit watermark instead of buffering the full result. Adds 429/ Retry-After-aware backoff with a shared rate-limit signal across workers. The legacy `--limit` path is unchanged.