### PR TITLE
feat(cli): add `lep dynamo` for Dynamo graph deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ lep dynamo create -n my-dynamo --framework vllm \
   -svc frontend --resource-shape cpu.small --node-group my-node-group \
   -svc worker --resource-shape gpu.h100-80gb --replicas 2 -e MODEL=Qwen/Qwen3-0.6B
 lep dynamo status -n my-dynamo
-lep dynamo log -n my-dynamo -s worker --tail 200
+lep dynamo replica log -n my-dynamo -s worker --tail 200
 lep dynamo update -n my-dynamo -svc worker --replicas 4
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 The LeptonAI Python library lets you operate the [NVIDIA DGX Cloud Lepton](https://docs.nvidia.com/dgx-cloud/lepton) platform from Python and the command line. Key features include:
 
-- A `lep` command-line tool to create and manage endpoints, batch jobs, dev pods, Ray and Slurm clusters, fine-tuning jobs, storage, secrets, and more.
+- A `lep` command-line tool to create and manage endpoints, Dynamo graph deployments, batch jobs, dev pods, Ray and Slurm clusters, fine-tuning jobs, storage, secrets, and more.
 - A `Client` to call your deployed endpoints like native Python functions.
 - Pythonic configuration specs that are readily shipped to the cloud.
 - Skills that let agents operate the Lepton platform for you.
@@ -78,6 +78,19 @@ lep job create -n my-job --container-image my-registry/my-trainer:latest --comma
 
 # Launch an interactive dev pod
 lep pod create -n my-pod --resource-shape gpu.a10
+```
+
+Dynamo graph deployments (multi-service LLM inference with a vLLM, SGLang, or
+TensorRT-LLM backend) have their own command group. Each `-svc` block configures
+one service; the frontend is required and workers inherit its node group:
+
+```shell
+lep dynamo create -n my-dynamo --framework vllm \
+  -svc frontend --resource-shape cpu.small --node-group my-node-group \
+  -svc worker --resource-shape gpu.h100-80gb --replicas 2 -e MODEL=Qwen/Qwen3-0.6B
+lep dynamo status -n my-dynamo
+lep dynamo log -n my-dynamo -s worker --tail 200
+lep dynamo update -n my-dynamo -svc worker --replicas 4
 ```
 
 Run `lep --help`, or `lep <command> --help` for any subcommand, to explore everything. See the [CLI references](https://docs.nvidia.com/dgx-cloud/lepton/reference/cli/get-started/) for the full guide.

--- a/docs/dynamo-cli-plan.md
+++ b/docs/dynamo-cli-plan.md
@@ -1,0 +1,454 @@
+# Plan: Dynamo Graph Deployment support in `lep`
+
+Status: implemented (2026-09-08). Phases 1-4 landed in `leptonai/api/v2/{dynamo,dynamo_spec,dynamo_patch}.py`,
+`leptonai/api/v2/types/dynamo.py`, `leptonai/cli/dynamo.py`, plus `lep log get --dynamo`.
+Deviations from the plan are listed in section 7 at the end.
+
+Source material used to derive the scope:
+
+- GUI interaction specs in `lep-fe/interaction-specs/apps/dashboard/specs/`:
+  12 pages (`deployment-dynamo-*.md`, `deployment-create-dynamo.md`,
+  `deployment-edit-dynamo.md`) and 6 components (`dynamo-*.md`,
+  `llm-engine-selector.md`).
+- Dashboard form logic that the specs delegate to:
+  `apps/dashboard/src/generated/forms/dynamo/{helpers,submit,contract}.ts`
+  (default images/commands/workdirs, submit payload shape, edit merge-patch rules).
+- Backend contract: `lep-fe/docs/api-server/httpapi/dynamo/{spec,contract,design}.md`,
+  `lep-fe/api-server/httpapi/dynamo/handler.go`, `.../metrics/handler_metrics.go`,
+  `.../log/handler_log.go`, and the CRD types in
+  `deployment-operator/api/v1alpha1/leptondynamographdeployment_types.go`.
+- Existing CLI patterns to mirror: `leptonai/cli/raycluster.py` (multi-group
+  create, `-f` spec file, `get -p`), `leptonai/cli/deployment.py` (`status`,
+  `log`), `leptonai/api/v2/raycluster.py` (API layer), `leptonai/api/v2/types/*`.
+
+## 1. What the GUI can do that the CLI cannot
+
+| GUI surface (spec) | Backend call | Proposed CLI command |
+|---|---|---|
+| Dynamo list, search / status / creator filter (`deployment-dynamo-list.md`) | `GET /dynamographdeployments` (no server-side filters; client-side) | `lep dynamo list [-n SUBSTR]... [--state S]... [--created-by U]...` |
+| Create form (`deployment-create-dynamo.md`, `dynamo-config.md`, `dynamo-service.md`) | `POST /dynamographdeployments` | `lep dynamo create` |
+| Edit overlay, JSON Merge Patch (`deployment-edit-dynamo.md`) | `PATCH /dynamographdeployments/:id[?dryrun=true]` | `lep dynamo update` |
+| Detail summary card (`deployment-dynamo-detail.md`, `dynamo-deployment-card.md`) | `GET /:id`, `GET /:id/services`, `GET /:id/monitoring/status` | `lep dynamo status -n X`, `lep dynamo get -n X [-p PATH]` |
+| Delete with confirm | `DELETE /:id` | `lep dynamo remove -n X` |
+| Services tab, per-service card + run command (`deployment-dynamo-detail-services.md`, `dynamo-service-item.md`) | `GET /:id/services`, `GET /:id/services/:svc` | `lep dynamo services -n X` (table), `lep dynamo service -n X -s SVC` (detail) |
+| Restart service with confirm | `PUT /:id/services/:svc/restart` | `lep dynamo restart -n X -s SVC` |
+| Replicas tab, status filter, node column (`deployment-dynamo-detail-replicas.md`) | `GET /:id/services/:svc/replicas`, `GET /:id/replicas[?service=]` | `lep dynamo replicas -n X [-s SVC] [--state R]...` |
+| Delete replica | `DELETE /:id/replicas/:rid` (or service-scoped) | `lep dynamo remove-replica -n X -r RID` |
+| Logs overlay, per-replica logs (`deployment-dynamo-detail-logs.md`, `...-replicas-detail-logs.md`) | `GET /:id/replicas/:rid/log?tail=&timestamps=`; shared `GET /logs?dynamo_graph_deployment=&dynamo_service=&replica=` | `lep dynamo log -n X [-s SVC] [-r RID] [--tail N] [--timestamps]`; `lep log get --dynamo X` for historical windows |
+| Deployment metrics (`deployment-dynamo-detail-metrics.md`) | `GET /:id/monitoring/{GPUUtilAvg,...}?window=H` | `lep dynamo metrics -n X [--window H]` (phase 4, optional) |
+| Replica metrics (`...-replicas-detail-metrics*.md`) | `GET /:id/replicas/:rid/monitoring/{metric}` | `lep dynamo metrics -n X -r RID` (phase 4, optional) |
+| Not in GUI, cheap | `GET /:id/history` | `lep dynamo history -n X` (phase 4, optional) |
+
+Explicitly out of scope: the LLM-engine switcher, node-group preference
+storage, permission-based button disabling, and every layout/skeleton rule.
+Those are browser concerns. The server remains the authority for RBAC; the CLI
+just surfaces 403 via the existing `click_group` error handler.
+
+## 2. Backend facts that shape the CLI design
+
+These were verified against the handler source, not only the docs.
+
+- Resource path is `/dynamographdeployments` with ID `dgdid`; the CLI can
+  address a deployment by `metadata.id` (same as name for user-created ones).
+- List has no query params; `q` / `status` / `created_by` filtering is
+  client-side. Response is a bare array.
+- `spec.services` is a map keyed by service name. Service names the GUI uses:
+  `frontend`, `worker`, `prefill-worker`, `decode-worker`. `component_type`
+  is only `frontend` or `worker`.
+- Server static validation on create: name rules, at least one frontend,
+  `min_replicas >= 1` (`max_replicas` is forced equal to `min_replicas`),
+  `multinode.node_count >= 2` and worker only, `backend_framework` in
+  `vllm|sglang|trtllm`, image must be
+  `nvcr.io/nvidia/ai-dynamo/{vllm|sglang|tensorrtllm}-runtime:<version>` with
+  the version in `SupportedDynamoVersions` (today only `1.3.1`),
+  `ingress_timeout_seconds` in 300..3600.
+- `dynamo_namespace` must be empty. `validation.go` rejects any non-empty
+  value for Dynamo 1.3.1. The `spec.md` sentence about name rules is stale.
+  The CLI must not expose this field.
+- `ingress_enabled` is a plain Go bool with `omitempty`; the server does not
+  default it to true. The GUI always sends `true` by default. The CLI should
+  too.
+- Update is RFC 7396 merge patch against the user spec. Removing a service is
+  `{"spec":{"services":{"<name>":null}}}`. Multinode presence is immutable per
+  service; `node_count` inside an existing multinode block may change.
+  `?dryrun=true` validates without persisting.
+- Replica log endpoints are one-shot JSON (`{"logs": "...", ...}`), default
+  `tail=100`, optional `timestamps=true`. They do not stream. The handler
+  reads `tail`; the OpenAPI yaml documents the parameter as `lines`, which is
+  wrong, so do not generate the client from the yaml. The shared
+  `/logs` route accepts `dynamo_graph_deployment=<id>` plus `dynamo_service=`
+  and `replica=` for historical windows.
+- States: deployment `Ready | Starting | Updating | Not Ready | Deleting`;
+  service `Ready | Starting | Updating | Scaling | Restarting | Not Ready`;
+  monitoring `overall_health` is `healthy | degraded | unhealthy`.
+- Replica objects are `httpapi.Replica` with `status.readiness_issue.reason`,
+  `status.node{name,id,node_group_id}`, `status.container_status`,
+  `status.last_termination`. The readiness reason set is wider than the CLI's
+  current `ReplicaReadinessReason` enum (adds `WaitingForCapacity`,
+  `Migrating`, `UserCodeError`, `DeploymentConfigError`, `Failed`,
+  `Preempting`, `Completed`, `Terminated`, `NodeNotReady`).
+- Metrics routes exist at deployment level (`window` in hours: 1,2,3,6,12,24)
+  and replica level (no window). Response is a list of
+  `{metric:{name,device?}, values:[[ts_seconds, "value"|null], ...]}`.
+
+## 3. Defaults registry to port from the dashboard
+
+`forms/dynamo/helpers.ts` is the single source of the GUI defaults. Port it
+verbatim into `leptonai/api/v2/types/dynamo.py` (or a sibling
+`dynamo_defaults.py`) so `lep dynamo create` can fill in what the GUI computes:
+
+- `DYNAMO_VERSION = "1.3.1"`, `WORKER_ROLE_LABEL_KEY = "lepton.ai/dynamo-worker-role"`.
+- Images per framework: `nvcr.io/nvidia/ai-dynamo/{vllm,sglang,tensorrtllm}-runtime:<version>`.
+- Working dir: frontend `/workspace`; workers `/workspace/examples/backends/vllm`,
+  `/workspace/examples/backends/sglang`, `/workspace/` (trtllm).
+- Default commands per `(version, serving_mode, service_name, framework)`
+  exactly as in `SERVICE_COMMAND["1.3.1"]`, including the multinode rewrite
+  for SGLang (`--tp 1` becomes `--tp <gpu*nodes>`; disaggregated also swaps the
+  bootstrap port and appends `--mem-fraction-static 0.82`).
+- Rules: vLLM only supports aggregated; multinode only for SGLang non-frontend
+  services; prefill/decode workers get the role label automatically; workers
+  inherit the frontend node group; command strings are sent as
+  `["/bin/sh", "-c", "<string>"]` (the dashboard's `toShellCommandArgv`).
+
+Keep the registry data-only and unit-tested so a version bump is a one-line change.
+
+## 4. Deliverables by layer
+
+### 4.1 Types: `leptonai/api/v2/types/dynamo.py` (new)
+
+Pydantic models mirroring the CRD and handler response types. Field names must
+match JSON exactly; follow `types/raycluster.py` conventions (`Optional`
+everywhere, `_missing_` on enums, `Field(alias=...)` for `id`/`from`).
+
+- `DynamoBackendFramework` enum (`vllm`, `sglang`, `trtllm`).
+- `DynamoComponentType` enum (`frontend`, `worker`).
+- `DynamoMultinodeSpec { node_count }`.
+- `DynamoMainContainerSpec { image, working_dir, command: List[str] }`.
+- `DynamoExtraPodSpec { main_container, image_pull_secrets, node_selector, termination_grace_period_seconds }`.
+- `DynamoExtraPodMetadata { annotations, labels }`.
+- `LeptonDynamoServiceSpec`: `component_type`, `envs`, `env_from_secret`,
+  `mounts`, `multinode`, `extra_pod_metadata`, `extra_pod_spec`, plus the
+  inlined resource requirement fields (`resource_shape`, `cpu`, `memory`,
+  `ephemeral_storage_in_gb`, `accelerator_*`, `shared_memory_size`,
+  `affinity`, `min_replicas`, `max_replicas`, `host_network`, `is_adaptive`).
+  Reuse `EnvVar`, `Mount`, `LeptonResourceAffinity` from existing modules.
+- `LeptonDynamoGraphDeploymentUserSpec`: `display_name`, `dynamo_version`,
+  `backend_framework`, `ingress_enabled`, `envs`, `services: Dict[str, LeptonDynamoServiceSpec]`,
+  `load_balance_config`, `routing_policy`, `auth_config`,
+  `ingress_timeout_seconds`. Include `dynamo_namespace` for round-tripping
+  server responses but never set it from the CLI.
+- `LeptonDynamoGraphDeploymentState`, `LeptonDynamoServiceState` enums.
+- `LeptonDynamoServiceStatus { state, ready_replicas, desired_replicas, last_ready_replicas }`.
+- `LeptonDynamoGraphDeploymentStatus { state, conditions, observed_generation, services, endpoint: DeploymentEndpoint, default_lepton_ingress }`.
+- `LeptonDynamoGraphDeployment { metadata: Metadata, spec, status }`.
+- Response models: `DynamoServiceInfo`, `DynamoServicesResponse`,
+  `DynamoServiceResponse` (+ `DynamoServiceStatus`, `DynamoServiceCondition`,
+  `DynamoServiceReplicaStatus`), `DynamoReplica` (+ `DynamoReplicaStatus`,
+  `DynamoReplicaNode`, `DynamoReplicaReadinessIssue`),
+  `DynamoServiceReplicasResponse`, `DynamoReplicaLogResponse`,
+  `DynamoReplicaDeleteResponse`, `DynamoServiceRestartResponse`,
+  `DynamoMonitoringStatusResponse`, `DynamoHistoryItem`.
+- Extend `types/readiness.py::ReplicaReadinessReason` with the missing
+  members listed in section 2. This also fixes endpoint replicas showing
+  `Unknown` for those reasons.
+- Register the module in `types/__init__.py`.
+
+Decision: define a dedicated `DynamoReplica` rather than reusing
+`types/replica.py::Replica`, because the Dynamo `Node` carries
+`node_group_id` and the status carries readiness and container info the flat
+type lacks. If we later enrich `Replica`, the two can converge.
+
+### 4.2 API layer: `leptonai/api/v2/dynamo.py` (new) and client wiring
+
+`class DynamoGraphDeploymentAPI(APIResourse)` with one method per route:
+
+```text
+list_all() -> List[LeptonDynamoGraphDeployment]
+get(name_or_obj) -> LeptonDynamoGraphDeployment
+create(spec) -> LeptonDynamoGraphDeployment            # returns created object (201 body)
+update(name_or_obj, patch: dict, dryrun=False) -> LeptonDynamoGraphDeployment
+delete(name_or_obj) -> bool
+list_services(name) -> DynamoServicesResponse
+get_service(name, service) -> DynamoServiceResponse
+restart_service(name, service) -> DynamoServiceRestartResponse
+list_replicas(name, service=None) -> List[DynamoReplica]         # flat route, ?service=
+list_service_replicas(name, service) -> DynamoServiceReplicasResponse
+get_replica_log(name, replica, service=None, tail=None, timestamps=False) -> DynamoReplicaLogResponse
+delete_replica(name, replica, service=None) -> DynamoReplicaDeleteResponse
+get_monitoring_status(name) -> DynamoMonitoringStatusResponse
+get_history(name) -> List[DynamoHistoryItem]
+get_metric(name, metric, window=None) -> list                     # phase 4
+get_replica_metric(name, replica, metric) -> list                 # phase 4
+```
+
+Notes:
+
+- `update` takes a raw merge-patch `dict`, not a full model, because the
+  patch semantics (nulls remove keys) do not survive `safe_json`, which drops
+  `None`. Provide a helper `build_merge_patch(original_spec, desired_spec)`
+  in a pure module (`leptonai/api/v2/dynamo_patch.py`) that diffs two dicts
+  and emits `null` for removed keys, mirroring the dashboard's edit transform.
+- Register in `client.py` as `self.dynamo = DynamoGraphDeploymentAPI(self)`.
+  Dynamo is a separate resource and is not affected by the
+  `enable_new_deployment_api` switch, so no property indirection is needed.
+- Extend `LogAPI.get_log` / `get_log_time_series` with `name_or_dynamo` and
+  `dynamo_service` so `lep log get` can target Dynamo deployments via the
+  shared `/logs` route (`dynamo_graph_deployment=` query key).
+- Add `client.dynamo` to the module docstring in `api/v2/__init__.py`.
+
+### 4.3 CLI: `leptonai/cli/dynamo.py` (new), registered in `cli.py`
+
+Top-level group `lep dynamo` created with `click_group()` so abbreviations and
+the shared error handler apply. Note that `lep dyn` is ambiguous: the
+subsequence matcher in `click_group` also matches the hidden `deployment`
+alias (d-y-n appear in order in "deployment"). `lep dyna` is the shortest
+unambiguous form; document `lep dynamo` in examples.
+
+Commands, in the order to implement:
+
+1. `list` — table: Name/ID (`make_name_id_cell`), State (`colorize_state`),
+   Framework, Serving mode (derived: any `prefill-worker`/`decode-worker`
+   means disaggregated), Ingress, Services as one line per service
+   `name: replicas x shape (ready/desired)`, Node groups (union of service
+   affinities), Created at, Created by. Filters `-n` (substring, repeatable),
+   `--state` (repeatable, matches `status.state`), `--created-by`
+   (repeatable). Sorted by `created_at` descending like the GUI.
+2. `get -n X [-d] [-p PATH]` — print sanitized JSON; `-p` saves `spec` only
+   as `dynamo-spec-<name>.json`, reusable by `create -f`. Same shape as
+   `raycluster get`.
+3. `status -n X [-d]` — the summary card plus detail tabs in text: state,
+   framework, version, ingress and external endpoint (only when `Ready`, as
+   the GUI does), node groups, global env names (values hidden, secrets marked),
+   a service table from `/services` (component type, ready/desired, total
+   pods, multinode node_count, shape, min_replicas), the monitoring
+   `overall_health` line, and a replica table from `/replicas` (id, service,
+   readiness reason colored, node, created at). `-d` dumps the full object.
+4. `services -n X` and `service -n X -s SVC` — table and single-service
+   detail (spec, status phase/health/state/uptime, conditions, last replica
+   error events, and the run command rendered as a shell line).
+5. `replicas -n X [-s SVC] [--state REASON]...` — per-service or flat list.
+   Status filter uses the GUI's readiness-reason groups verbatim.
+6. `log -n X [-s SVC] [-r RID] [--tail N] [--timestamps] [-p PATH]` — one-shot
+   pod log. Selection rule mirrors `lep endpoint log`: if `-r` is missing,
+   choose the first replica of `-s` (default service `frontend`), print which
+   one was chosen. Print a hint that this endpoint does not stream and that
+   `lep log get --dynamo X` covers historical windows.
+7. `restart -n X -s SVC [-y]` — confirm prompt like the GUI dialog unless
+   `-y`; print `deleted_pods`. Refuse client-side when the service is
+   deleting or `min_replicas <= 0` (same disable rule as the GUI).
+8. `remove -n X [-y]` and `remove-replica -n X -r RID [-s SVC] [-y]` —
+   confirm prompts; surface the 400 "already being deleted" message plainly.
+9. `create` — see 4.4.
+10. `update` — see 4.5.
+11. Phase 4: `metrics`, `history`, `lep log get --dynamo`.
+
+Every command takes `--name/-n` as the deployment identifier, matching the
+rest of the CLI. Destructive commands accept `-y/--yes` so the agent skill and
+scripts can run them non-interactively.
+
+### 4.4 `lep dynamo create` design
+
+Two input paths that can be combined, exactly like `raycluster create`:
+
+- `-f/--file spec.json`: a `LeptonDynamoGraphDeploymentUserSpec` JSON (the
+  file `get -p` writes). CLI flags override or add on top.
+- Flags only.
+
+Global flags:
+
+```text
+-n/--name                    required, validated locally (<=36 chars, lowercase
+                             alnum/'-', starts with a letter, ends alnum,
+                             not ending in "by-lepton")
+--framework                  vllm|sglang|trtllm, default vllm
+--serving-mode               aggregated|disaggregated, default aggregated
+--dynamo-version             default 1.3.1 (drives image tags and command registry)
+--ingress-enabled/--no-ingress   default enabled
+--ingress-timeout            300..3600 seconds, optional
+--display-name               optional
+-e/--env NAME=VALUE, -s/--secret NAME[=SECRET]   global envs (reuse make_env_vars_from_strings)
+--image-pull-secrets         repeatable, applied to each service's extra_pod_spec
+--visibility                 public|private (metadata.visibility, as raycluster does)
+```
+
+Per-service blocks using a repeatable marker, parsed by a generalized copy of
+`WorkerGroupCommand` (extract the block parser into `cli/util.py` so both
+raycluster and dynamo share it):
+
+```text
+-svc/--service TYPE   TYPE in frontend|worker|prefill-worker|decode-worker
+  --resource-shape S           required for every new service
+  --node-group NG              only meaningful on frontend; workers inherit it
+  --replicas N                 default 1, >= 1
+  --node-count N               >= 2, sglang workers only; emits multinode
+  --image IMG                  default derived from framework+version
+  --working-dir DIR            default derived
+  --command "..."              default derived; sent as /bin/sh -c argv
+  -e/--env, -s/--secret        per-service envs
+  --mount FROM:MOUNT:VOLUME    reuse make_mounts_from_strings
+  --annotation K=V, --label K=V
+  --shared-memory-size MiB
+  --termination-grace-period SECONDS
+```
+
+Behavior rules copied from the GUI page and `helpers.ts`:
+
+- If no `frontend` block is given, one is synthesized with defaults. It still
+  needs `--resource-shape` and `--node-group`, so the CLI errors with a clear
+  message telling the user to add `-svc frontend --resource-shape ... --node-group ...`.
+- `worker` is only valid in aggregated mode; `prefill-worker` and
+  `decode-worker` only in disaggregated mode. Error, do not silently switch.
+- `--framework vllm --serving-mode disaggregated` is an error (GUI
+  auto-switches; a CLI should not change what the user typed).
+- `--node-count` on a frontend, or on any service when framework is not
+  sglang, is an error.
+- Worker `--node-group` that differs from the frontend's is an error; absent
+  means inherit.
+- `lepton.ai/dynamo-worker-role: prefill|decode` is added to prefill/decode
+  worker labels automatically.
+- Image: if `--image` is given, warn that the server only accepts the
+  official runtime image with a supported tag, then send it as typed.
+- Node group names are resolved to IDs with the existing
+  `_get_valid_nodegroup_ids`.
+- Optional pre-flight: validate `--resource-shape` against
+  `client.shapes.list_shapes(node_group)` and print the available shapes on
+  mismatch. Make this best-effort so a shapes API failure does not block
+  create (the GUI treats catalog failures the same way).
+- On success print the name and `lep dynamo status -n X` hint, mirroring the
+  GUI's "Endpoint created" dialog.
+
+Spec assembly lives in pure functions (`build_dynamo_spec(...)`,
+`build_service_spec(...)`) in `leptonai/api/v2/dynamo_spec.py` so they are unit
+testable without click.
+
+### 4.5 `lep dynamo update` design
+
+Merge-patch builder with three input styles, any combination allowed:
+
+- Global fields: `--display-name`, `--ingress-enabled/--no-ingress`,
+  `--ingress-timeout`, `-e/-s` (replaces the global env list, as the GUI
+  edit form does; document this).
+- Service blocks `-svc NAME` with `--replicas`, `--resource-shape`,
+  `--command`, `--working-dir`, `-e/-s`, `--mount`, `--annotation`,
+  `--label`, `--node-count` (only if the service already has multinode),
+  and `--remove` to delete the service (`null` in the patch). A block naming
+  a service that does not exist adds it and therefore requires
+  `--resource-shape` (node group inherited from the frontend).
+- `-f patch.json`: a raw merge patch applied as-is for anything the flags do
+  not cover.
+- `--dryrun`: sends `?dryrun=true` and prints the server-validated result.
+- Empty patch prints "No changes detected" and exits 0 without a request,
+  same as the GUI.
+- Client-side guard: adding or removing `multinode` on an existing service is
+  rejected before the request with the server's wording.
+
+Clearing rules from the edit spec: clearing a worker `--working-dir ""` is
+rejected by the global empty-string guard, so expose `--clear-working-dir`
+instead, which emits `working_dir: null` for workers and `/workspace` for the
+frontend.
+
+### 4.6 Tests
+
+Follow the existing layout and fixtures.
+
+- `leptonai/tests/test_dynamo_spec.py`: pure-function tests for the defaults
+  registry, `build_dynamo_spec`, worker-role labels, node-group inheritance,
+  every error rule in 4.4, and `build_merge_patch` (removed keys become
+  `null`, unchanged paths omitted, service removal).
+- `leptonai/api/v2/tests/test_dynamo_api.py`: `responses`-based tests that
+  each method hits the right path, query string (`?service=`, `?tail=`,
+  `?timestamps=true`, `?dryrun=true`), and parses the documented response
+  shapes, including the bare-array list and the `{"services": {...}}` map.
+- `leptonai/cli/tests/test_dynamo_cli.py`: `CliRunner` with a patched
+  `APIClient` (the `_FakeAPIClient` pattern in `test_deployment_cli.py`).
+  Cover: list rendering and filters, `create` payload assertions for the
+  three GUI user stories (single frontend, aggregated worker, disaggregated
+  prefill/decode), each create rejection, `update` patch assertions and
+  no-op exit, `log` replica auto-selection, confirm prompts and `-y`.
+- Run with `pytest -x leptonai` as CI does.
+
+### 4.7 Docs and agent skill
+
+- README: add `lep dynamo` to the getting-started list and the CLI feature
+  bullet.
+- `plugins/lepton-cli/skills/lepton-cli/references/workloads.md` already
+  describes Dynamo endpoints conceptually; add the command mapping and the
+  confirm-before-destroy note for `remove`, `remove-replica`, `restart`.
+- `example_usage.md`: one aggregated and one disaggregated create example.
+- The external e2e script (`lepton/sdk/release_scripts/e2e_sdk_cli_test.sh`)
+  needs a Dynamo create/status/remove case; track it as a follow-up in that
+  repo.
+
+## 5. Phasing and PR split
+
+Each phase is one reviewable PR in the style of the recent `feat(cli):` commits.
+
+| Phase | Content | Depends on |
+|---|---|---|
+| 1 | Types, defaults registry, API layer, client wiring, readiness enum extension, API and spec unit tests | none |
+| 2 | Read and lifecycle commands: `list`, `get`, `status`, `services`, `service`, `replicas`, `log`, `restart`, `remove`, `remove-replica`; CLI tests | 1 |
+| 3 | `create` and `update`, shared block parser extracted from raycluster, spec-file round trip, CLI tests | 1, 2 |
+| 4 | `metrics`, `history`, `lep log get --dynamo`, README and skill docs, e2e follow-up | 2 |
+
+Phase 1 plus 2 already gives operators everything the GUI detail pages offer.
+Phase 3 is the largest and is where the GUI rules matter most. Phase 4 is
+optional polish; the CLI has no metrics commands for endpoints today either,
+so `metrics` can be dropped if it does not earn its keep.
+
+## 6. Decisions taken and open questions
+
+Decisions made in this plan:
+
+- Top-level `lep dynamo` group rather than nesting under `lep endpoint`. The
+  API resource, spec shape, and lifecycle differ enough that sharing option
+  parsers with `endpoint create` would be forced. This also matches the
+  `raycluster` precedent.
+- No `dynamo_namespace` flag. The server rejects non-empty values.
+- `ingress_enabled` defaults to true to match the GUI.
+- Service names are restricted to the four GUI names in `create`. The API
+  accepts arbitrary keys, but the default command registry only knows these
+  four. An `--allow-custom-service-name` escape hatch can be added later.
+
+Questions to confirm before phase 3:
+
+1. Should `create` allow `--image` at all, given the server only accepts the
+   official runtime image for the chosen framework and version? Proposed:
+   allow with a warning, so future versions do not need a CLI release.
+2. Is the shared `/logs` route for Dynamo gated to enterprise workspaces the
+   way the GUI's Logs tab is? If yes, `lep dynamo log` (one-shot pod log)
+   stays the default and `lep log get --dynamo` documents the tier
+   requirement.
+3. Does `update` need to support `load_balance_config`, `routing_policy`, or
+   `auth_config`? The GUI edit form does not expose them. Proposed: reachable
+   only through `-f patch.json` in v1.
+4. Should `list` also appear as a tab-like hint in `lep endpoint list` output
+   ("N Dynamo endpoints exist, see `lep dynamo list`")? Cheap, but touches an
+   unrelated command. Proposed: skip.
+
+Answer to the open questions from user:
+
+1. Yes, allow `--image` with a warning, so future versions do not need a CLI release.
+2. Yes, the external e2e script needs a Dynamo create/status/remove case; track it as a follow-up in that repo.
+3. No, `update` does not need to support `load_balance_config`, `routing_policy`, or `auth_config`.
+4. No, `list` does not need to appear as a tab-like hint in `lep endpoint list` output. Skip.
+
+## 7. Implementation notes (post-plan)
+
+- The repeatable `-svc` block parser is a new generic factory,
+  `make_block_option_command` in `leptonai/cli/util.py`, instead of a refactor
+  of raycluster's `WorkerGroupCommand`. Raycluster is untouched; the two can be
+  unified later.
+- `lep dynamo get` prints JSON only (no `-d`), because the raycluster-style
+  double print was redundant. `status -d` and `service -d` dump the full object.
+- `lep dynamo create` gained `--dry-run` (prints the payload without a request)
+  and `--visibility`. Node groups are accepted by name or id.
+- `lep dynamo update` re-syncs worker node groups to the frontend after
+  applying blocks, and rejects `--node-group` on workers, matching the
+  dashboard's "workers inherit the frontend node group" rule.
+- Per the review answers: `--image` is allowed with a warning;
+  `load_balance_config` / `routing_policy` / `auth_config` are reachable only via
+  `update -f patch.json`; no hint was added to `lep endpoint list`; the e2e
+  script case is tracked in the `lepton` repo.
+- The shared `/logs` route tier gating was not confirmed; `lep dynamo log` uses
+  the one-shot pod-log endpoint by default and `lep log get --dynamo`
+  documents that historical logs may need an enterprise tier.

--- a/docs/dynamo-cli-plan.md
+++ b/docs/dynamo-cli-plan.md
@@ -30,13 +30,13 @@ Source material used to derive the scope:
 | Edit overlay, JSON Merge Patch (`deployment-edit-dynamo.md`) | `PATCH /dynamographdeployments/:id[?dryrun=true]` | `lep dynamo update` |
 | Detail summary card (`deployment-dynamo-detail.md`, `dynamo-deployment-card.md`) | `GET /:id`, `GET /:id/services`, `GET /:id/monitoring/status` | `lep dynamo status -n X`, `lep dynamo get -n X [-p PATH]` |
 | Delete with confirm | `DELETE /:id` | `lep dynamo remove -n X` |
-| Services tab, per-service card + run command (`deployment-dynamo-detail-services.md`, `dynamo-service-item.md`) | `GET /:id/services`, `GET /:id/services/:svc` | `lep dynamo services -n X` (table), `lep dynamo service -n X -s SVC` (detail) |
-| Restart service with confirm | `PUT /:id/services/:svc/restart` | `lep dynamo restart -n X -s SVC` |
-| Replicas tab, status filter, node column (`deployment-dynamo-detail-replicas.md`) | `GET /:id/services/:svc/replicas`, `GET /:id/replicas[?service=]` | `lep dynamo replicas -n X [-s SVC] [--state R]...` |
-| Delete replica | `DELETE /:id/replicas/:rid` (or service-scoped) | `lep dynamo remove-replica -n X -r RID` |
-| Logs overlay, per-replica logs (`deployment-dynamo-detail-logs.md`, `...-replicas-detail-logs.md`) | `GET /:id/replicas/:rid/log?tail=&timestamps=`; shared `GET /logs?dynamo_graph_deployment=&dynamo_service=&replica=` | `lep dynamo log -n X [-s SVC] [-r RID] [--tail N] [--timestamps]`; `lep log get --dynamo X` for historical windows |
+| Services tab, per-service card + run command (`deployment-dynamo-detail-services.md`, `dynamo-service-item.md`) | `GET /:id/services`, `GET /:id/services/:svc` | `lep dynamo service list -n X` (table), `lep dynamo service get -n X -s SVC` (detail) |
+| Restart service with confirm | `PUT /:id/services/:svc/restart` | `lep dynamo service restart -n X -s SVC` |
+| Replicas tab, status filter, node column (`deployment-dynamo-detail-replicas.md`) | `GET /:id/services/:svc/replicas`, `GET /:id/replicas[?service=]` | `lep dynamo replica list -n X [-s SVC] [--state R]...` |
+| Delete replica | `DELETE /:id/replicas/:rid` (or service-scoped) | `lep dynamo replica remove -n X -r RID` |
+| Logs overlay, per-replica logs (`deployment-dynamo-detail-logs.md`, `...-replicas-detail-logs.md`) | `GET /:id/replicas/:rid/log?tail=&timestamps=`; shared `GET /logs?dynamo_graph_deployment=&dynamo_service=&replica=` | `lep dynamo replica log -n X [-s SVC] [-r RID] [--tail N] [--timestamps]`; `lep log get --dynamo X` for historical windows |
 | Deployment metrics (`deployment-dynamo-detail-metrics.md`) | `GET /:id/monitoring/{GPUUtilAvg,...}?window=H` | `lep dynamo metrics -n X [--window H]` (phase 4, optional) |
-| Replica metrics (`...-replicas-detail-metrics*.md`) | `GET /:id/replicas/:rid/monitoring/{metric}` | `lep dynamo metrics -n X -r RID` (phase 4, optional) |
+| Replica metrics (`...-replicas-detail-metrics*.md`) | `GET /:id/replicas/:rid/monitoring/{metric}` | `lep dynamo replica metrics -n X -r RID` (phase 4, optional) |
 | Not in GUI, cheap | `GET /:id/history` | `lep dynamo history -n X` (phase 4, optional) |
 
 Explicitly out of scope: the LLM-engine switcher, node-group preference
@@ -223,24 +223,25 @@ Commands, in the order to implement:
    pods, multinode node_count, shape, min_replicas), the monitoring
    `overall_health` line, and a replica table from `/replicas` (id, service,
    readiness reason colored, node, created at). `-d` dumps the full object.
-4. `services -n X` and `service -n X -s SVC` — table and single-service
+4. `service list -n X` and `service get -n X -s SVC` — table and single-service
    detail (spec, status phase/health/state/uptime, conditions, last replica
    error events, and the run command rendered as a shell line).
-5. `replicas -n X [-s SVC] [--state REASON]...` — per-service or flat list.
+5. `replica list -n X [-s SVC] [--state REASON]...` — per-service or flat list.
    Status filter uses the GUI's readiness-reason groups verbatim.
-6. `log -n X [-s SVC] [-r RID] [--tail N] [--timestamps] [-p PATH]` — one-shot
+6. `replica log -n X [-s SVC] [-r RID] [--tail N] [--timestamps] [-p PATH]` — one-shot
    pod log. Selection rule mirrors `lep endpoint log`: if `-r` is missing,
    choose the first replica of `-s` (default service `frontend`), print which
    one was chosen. Print a hint that this endpoint does not stream and that
    `lep log get --dynamo X` covers historical windows.
-7. `restart -n X -s SVC [-y]` — confirm prompt like the GUI dialog unless
+7. `service restart -n X -s SVC [-y]` — confirm prompt like the GUI dialog unless
    `-y`; print `deleted_pods`. Refuse client-side when the service is
    deleting or `min_replicas <= 0` (same disable rule as the GUI).
-8. `remove -n X [-y]` and `remove-replica -n X -r RID [-s SVC] [-y]` —
+8. `remove -n X [-y]` and `replica remove -n X -r RID [-s SVC] [-y]` —
    confirm prompts; surface the 400 "already being deleted" message plainly.
 9. `create` — see 4.4.
 10. `update` — see 4.5.
-11. Phase 4: `metrics`, `history`, `lep log get --dynamo`.
+11. Phase 4: deployment-level `metrics`, `replica metrics`, `history`, and
+    `lep log get --dynamo`.
 
 Every command takes `--name/-n` as the deployment identifier, matching the
 rest of the CLI. Destructive commands accept `-y/--yes` so the agent skill and
@@ -364,7 +365,7 @@ Follow the existing layout and fixtures.
   Cover: list rendering and filters, `create` payload assertions for the
   three GUI user stories (single frontend, aggregated worker, disaggregated
   prefill/decode), each create rejection, `update` patch assertions and
-  no-op exit, `log` replica auto-selection, confirm prompts and `-y`.
+  no-op exit, `replica log` auto-selection, confirm prompts and `-y`.
 - Run with `pytest -x leptonai` as CI does.
 
 ### 4.7 Docs and agent skill
@@ -373,7 +374,7 @@ Follow the existing layout and fixtures.
   bullet.
 - `plugins/lepton-cli/skills/lepton-cli/references/workloads.md` already
   describes Dynamo endpoints conceptually; add the command mapping and the
-  confirm-before-destroy note for `remove`, `remove-replica`, `restart`.
+  confirm-before-destroy note for `remove`, `replica remove`, `service restart`.
 - `example_usage.md`: one aggregated and one disaggregated create example.
 - The external e2e script (`lepton/sdk/release_scripts/e2e_sdk_cli_test.sh`)
   needs a Dynamo create/status/remove case; track it as a follow-up in that
@@ -386,7 +387,7 @@ Each phase is one reviewable PR in the style of the recent `feat(cli):` commits.
 | Phase | Content | Depends on |
 |---|---|---|
 | 1 | Types, defaults registry, API layer, client wiring, readiness enum extension, API and spec unit tests | none |
-| 2 | Read and lifecycle commands: `list`, `get`, `status`, `services`, `service`, `replicas`, `log`, `restart`, `remove`, `remove-replica`; CLI tests | 1 |
+| 2 | Read and lifecycle commands: `list`, `get`, `status`, `service list/get/restart`, `replica list/log/remove`, `remove`; CLI tests | 1 |
 | 3 | `create` and `update`, shared block parser extracted from raycluster, spec-file round trip, CLI tests | 1, 2 |
 | 4 | `metrics`, `history`, `lep log get --dynamo`, README and skill docs, e2e follow-up | 2 |
 
@@ -415,7 +416,7 @@ Questions to confirm before phase 3:
    official runtime image for the chosen framework and version? Proposed:
    allow with a warning, so future versions do not need a CLI release.
 2. Is the shared `/logs` route for Dynamo gated to enterprise workspaces the
-   way the GUI's Logs tab is? If yes, `lep dynamo log` (one-shot pod log)
+   way the GUI's Logs tab is? If yes, `lep dynamo replica log` (one-shot pod log)
    stays the default and `lep log get --dynamo` documents the tier
    requirement.
 3. Does `update` need to support `load_balance_config`, `routing_policy`, or
@@ -439,7 +440,8 @@ Answer to the open questions from user:
   of raycluster's `WorkerGroupCommand`. Raycluster is untouched; the two can be
   unified later.
 - `lep dynamo get` prints JSON only (no `-d`), because the raycluster-style
-  double print was redundant. `status -d` and `service -d` dump the full object.
+  double print was redundant. `status -d` and `service get -d` dump the full
+  object.
 - `lep dynamo create` gained `--dry-run` (prints the payload without a request)
   and `--visibility`. Node groups are accepted by name or id.
 - `lep dynamo update` re-syncs worker node groups to the frontend after
@@ -449,6 +451,6 @@ Answer to the open questions from user:
   `load_balance_config` / `routing_policy` / `auth_config` are reachable only via
   `update -f patch.json`; no hint was added to `lep endpoint list`; the e2e
   script case is tracked in the `lepton` repo.
-- The shared `/logs` route tier gating was not confirmed; `lep dynamo log` uses
-  the one-shot pod-log endpoint by default and `lep log get --dynamo`
+- The shared `/logs` route tier gating was not confirmed; `lep dynamo replica
+  log` uses the one-shot pod-log endpoint by default and `lep log get --dynamo`
   documents that historical logs may need an enterprise tier.

--- a/example_usage.md
+++ b/example_usage.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 - [Ingress Canary Deployments](#ingress-canary-deployments)
 - [IP Whitelist](#ip-whitelist-usage-examples)
+- [Dynamo Graph Deployments](#dynamo-graph-deployments)
 
 ---
 
@@ -276,3 +277,78 @@ not make the endpoint token-free.
 5. **IP Whitelist**: Stored in `auth_config.ip_allowlist` field
 6. **Unauthenticated Access**: Requires the explicit `--allow-unauthenticated-access` opt-out and displays a warning
 7. **Flexible Input**: IP whitelist accepts both individual values and comma-separated lists
+
+---
+
+# Dynamo Graph Deployments
+
+A Dynamo deployment is a multi-service inference graph served by NVIDIA Dynamo.
+Every `-svc` block configures one service. The frontend is required; workers
+inherit the frontend's node group, and prefill/decode workers are only valid in
+disaggregated mode (which vLLM does not support). Image, working directory, and
+run command default to the official Dynamo runtime for the chosen framework.
+
+### 1. Aggregated serving (frontend + worker, vLLM)
+
+```bash
+lep dynamo create -n qwen-agg --framework vllm \
+  -e HF_HUB_ENABLE_HF_TRANSFER=1 -s HF_TOKEN \
+  -svc frontend --resource-shape cpu.small --node-group my-node-group \
+  -svc worker --resource-shape gpu.h100-80gb --replicas 2 \
+    --command "python3 -m dynamo.vllm --model Qwen/Qwen3-8B"
+
+lep dynamo status -n qwen-agg          # summary, services, health, replicas
+lep dynamo log -n qwen-agg -s worker   # last 100 lines of the first ready worker replica
+```
+
+### 2. Disaggregated serving (frontend + prefill + decode, SGLang, multinode)
+
+```bash
+lep dynamo create -n qwen-disagg --framework sglang --serving-mode disaggregated \
+  -svc frontend --resource-shape cpu.small --node-group my-node-group \
+  -svc prefill-worker --resource-shape gpu.h100-80gb:8 --node-count 2 \
+  -svc decode-worker --resource-shape gpu.h100-80gb:8 --replicas 2
+
+lep dynamo services -n qwen-disagg
+lep dynamo service -n qwen-disagg -s prefill-worker
+```
+
+### 3. Preview, export and re-create from a spec file
+
+```bash
+# Print the request payload without creating anything
+lep dynamo create -n preview --dry-run \
+  -svc frontend --resource-shape cpu.small --node-group my-node-group
+
+# Export the spec of an existing deployment, then re-create it with overrides
+lep dynamo get -n qwen-agg -p ./qwen-agg.json
+lep dynamo create -n qwen-agg-copy -f ./qwen-agg.json -svc worker --replicas 4
+```
+
+### 4. Update (JSON Merge Patch)
+
+```bash
+# Scale a service; service changes ask for confirmation (pass -y to skip)
+lep dynamo update -n qwen-agg -svc worker --replicas 4
+
+# Change the run command and validate server side without persisting
+lep dynamo update -n qwen-agg --dryrun \
+  -svc worker --command "python3 -m dynamo.vllm --model Qwen/Qwen3-32B"
+
+# Remove a service, disable ingress, replace the shared env list
+lep dynamo update -n qwen-agg -svc worker --remove --no-ingress -e MODEL=x -y
+
+# Anything the flags do not cover: a raw merge patch file
+lep dynamo update -n qwen-agg -f ./patch.json
+```
+
+### 5. Operate replicas
+
+```bash
+lep dynamo replicas -n qwen-agg --state ready
+lep dynamo restart -n qwen-agg -s worker
+lep dynamo remove-replica -n qwen-agg -r <replica-id> -s worker
+lep dynamo metrics -n qwen-agg --window 6
+lep log get --dynamo qwen-agg --dynamo-service worker --start "today 09:00" --end now
+lep dynamo remove -n qwen-agg
+```

--- a/example_usage.md
+++ b/example_usage.md
@@ -298,7 +298,7 @@ lep dynamo create -n qwen-agg --framework vllm \
     --command "python3 -m dynamo.vllm --model Qwen/Qwen3-8B"
 
 lep dynamo status -n qwen-agg          # summary, services, health, replicas
-lep dynamo log -n qwen-agg -s worker   # last 100 lines of the first ready worker replica
+lep dynamo replica log -n qwen-agg -s worker  # last 100 lines of the first ready worker replica
 ```
 
 ### 2. Disaggregated serving (frontend + prefill + decode, SGLang, multinode)
@@ -309,8 +309,8 @@ lep dynamo create -n qwen-disagg --framework sglang --serving-mode disaggregated
   -svc prefill-worker --resource-shape gpu.h100-80gb:8 --node-count 2 \
   -svc decode-worker --resource-shape gpu.h100-80gb:8 --replicas 2
 
-lep dynamo services -n qwen-disagg
-lep dynamo service -n qwen-disagg -s prefill-worker
+lep dynamo service list -n qwen-disagg
+lep dynamo service get -n qwen-disagg -s prefill-worker
 ```
 
 ### 3. Preview, export and re-create from a spec file
@@ -345,10 +345,11 @@ lep dynamo update -n qwen-agg -f ./patch.json
 ### 5. Operate replicas
 
 ```bash
-lep dynamo replicas -n qwen-agg --state ready
-lep dynamo restart -n qwen-agg -s worker
-lep dynamo remove-replica -n qwen-agg -r <replica-id> -s worker
+lep dynamo replica list -n qwen-agg --state ready
+lep dynamo service restart -n qwen-agg -s worker
+lep dynamo replica remove -n qwen-agg -r <replica-id> -s worker
 lep dynamo metrics -n qwen-agg --window 6
+lep dynamo replica metrics -n qwen-agg -r <replica-id>
 lep log get --dynamo qwen-agg --dynamo-service worker --start "today 09:00" --end now
 lep dynamo remove -n qwen-agg
 ```

--- a/leptonai/api/v2/__init__.py
+++ b/leptonai/api/v2/__init__.py
@@ -12,7 +12,8 @@ the platform. Typical usage::
 
 Resource groups (``client.deployment``, ``client.job``, ``client.pod``,
 ``client.secret``, ``client.ingress``, ``client.log``,
-``client.raycluster``, ``client.nodegroup``, ``client.template``) each expose
+``client.raycluster``, ``client.dynamo``, ``client.nodegroup``,
+``client.template``) each expose
 the operations for that resource. Data types live under
 :mod:`leptonai.api.v2.types`.
 

--- a/leptonai/api/v2/client.py
+++ b/leptonai/api/v2/client.py
@@ -31,6 +31,7 @@ from .resource_shape import ResourceShapeAPI
 from .template import TemplateAPI
 from .finetune import FineTuneAPI
 from .raycluster import RayClusterAPI
+from .dynamo import DynamoGraphDeploymentAPI
 
 
 from .utils import (
@@ -335,6 +336,9 @@ class APIClient(object):
         self.finetune = FineTuneAPI(self)
         self.shapes = ResourceShapeAPI(self)
         self.raycluster = RayClusterAPI(self)
+        # Dynamo graph deployments live under /dynamographdeployments and are
+        # independent of the enable_new_deployment_api switch below.
+        self.dynamo = DynamoGraphDeploymentAPI(self)
 
         # Deployment ("endpoint") and pod ("devpod") each have two backing
         # implementations: the legacy /deployments-based API and the new

--- a/leptonai/api/v2/dynamo.py
+++ b/leptonai/api/v2/dynamo.py
@@ -1,0 +1,244 @@
+"""
+DynamoGraphDeploymentAPI: the ``/dynamographdeployments`` resource.
+
+Route coverage (verified against api-server/httpapi/dynamo/handler.go and
+api-server/httpapi/metrics/handler_metrics.go):
+
+- list / create / get / delete / update (RFC 7396 merge patch, ``?dryrun=true``)
+- ``/:dgdid/services``, ``/:dgdid/services/:service``,
+  ``/:dgdid/services/:service/replicas``,
+  ``/:dgdid/services/:service/replicas/:rid/log``,
+  ``/:dgdid/services/:service/replicas/:rid`` (DELETE),
+  ``/:dgdid/services/:service/restart`` (PUT)
+- flat ``/:dgdid/replicas[?service=]``, ``/:dgdid/replicas/:rid/log``,
+  ``/:dgdid/replicas/:rid`` (DELETE)
+- ``/:dgdid/history``, ``/:dgdid/monitoring/status``
+- ``/:dgdid/monitoring/:metric[?window=H]`` and
+  ``/:dgdid/replicas/:rid/monitoring/:metric``
+
+Replica logs are one-shot JSON payloads (the handler reads the ``tail`` query
+parameter, default 100 lines); they do not stream. Historical logs for a Dynamo
+deployment go through :class:`leptonai.api.v2.log.LogAPI` with
+``name_or_dynamo=``.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from .api_resource import APIResourse
+from .types.dynamo import (
+    DynamoHistoryItem,
+    DynamoMonitoringStatusResponse,
+    DynamoReplica,
+    DynamoReplicaDeleteResponse,
+    DynamoReplicaLogResponse,
+    DynamoServiceReplicasResponse,
+    DynamoServiceResponse,
+    DynamoServiceRestartResponse,
+    DynamoServicesResponse,
+    LeptonDynamoGraphDeployment,
+)
+
+
+class DynamoGraphDeploymentAPI(APIResourse):
+    _BASE = "/dynamographdeployments"
+
+    def _to_name(
+        self, name_or_deployment: Union[str, LeptonDynamoGraphDeployment]
+    ) -> str:
+        if isinstance(name_or_deployment, str):
+            return name_or_deployment
+        metadata = name_or_deployment.metadata
+        if metadata is None or not (metadata.id_ or metadata.name):
+            raise ValueError(
+                "LeptonDynamoGraphDeployment.metadata.id (or name) is required to"
+                " address the deployment."
+            )
+        return metadata.id_ or metadata.name  # type: ignore[return-value]
+
+    def _path(self, name_or_deployment, *segments: str) -> str:
+        parts = [self._BASE, self._to_name(name_or_deployment), *segments]
+        return "/".join(parts)
+
+    # ------------------------------------------------------------------ CRUD
+
+    def list_all(self) -> List[LeptonDynamoGraphDeployment]:
+        response = self._get(self._BASE)
+        return self.ensure_list(response, LeptonDynamoGraphDeployment)
+
+    def create(self, spec: LeptonDynamoGraphDeployment) -> LeptonDynamoGraphDeployment:
+        """Create a deployment and return the created (sanitized) resource."""
+        response = self._post(self._BASE, json=self.safe_json(spec))
+        return self.ensure_type(response, LeptonDynamoGraphDeployment)
+
+    def get(
+        self, name_or_deployment: Union[str, LeptonDynamoGraphDeployment]
+    ) -> LeptonDynamoGraphDeployment:
+        response = self._get(self._path(name_or_deployment))
+        return self.ensure_type(response, LeptonDynamoGraphDeployment)
+
+    def update(
+        self,
+        name_or_deployment: Union[str, LeptonDynamoGraphDeployment],
+        patch: Dict[str, Any],
+        dryrun: bool = False,
+    ) -> LeptonDynamoGraphDeployment:
+        """
+        Apply an RFC 7396 JSON Merge Patch to the deployment.
+
+        ``patch`` is sent as-is: ``{"spec": {"services": {"worker": None}}}``
+        removes the ``worker`` service, and nested keys set to ``None`` are
+        deleted server side. Use :func:`leptonai.api.v2.dynamo_patch.build_merge_patch`
+        to derive a patch from two spec dicts. With ``dryrun=True`` the server
+        validates the patched spec without persisting it.
+        """
+        if not isinstance(patch, dict):
+            raise ValueError("The update patch must be a JSON object (dict).")
+        params = {"dryrun": "true"} if dryrun else None
+        response = self._patch(
+            self._path(name_or_deployment), json=patch, params=params
+        )
+        return self.ensure_type(response, LeptonDynamoGraphDeployment)
+
+    def delete(
+        self, name_or_deployment: Union[str, LeptonDynamoGraphDeployment]
+    ) -> bool:
+        response = self._delete(self._path(name_or_deployment))
+        return self.ensure_ok(response)
+
+    # -------------------------------------------------------------- services
+
+    def list_services(
+        self, name_or_deployment: Union[str, LeptonDynamoGraphDeployment]
+    ) -> DynamoServicesResponse:
+        response = self._get(self._path(name_or_deployment, "services"))
+        return self.ensure_type(response, DynamoServicesResponse)
+
+    def get_service(
+        self,
+        name_or_deployment: Union[str, LeptonDynamoGraphDeployment],
+        service: str,
+    ) -> DynamoServiceResponse:
+        response = self._get(self._path(name_or_deployment, "services", service))
+        return self.ensure_type(response, DynamoServiceResponse)
+
+    def restart_service(
+        self,
+        name_or_deployment: Union[str, LeptonDynamoGraphDeployment],
+        service: str,
+    ) -> DynamoServiceRestartResponse:
+        """Restart a service by deleting all of its pods."""
+        response = self._put(
+            self._path(name_or_deployment, "services", service, "restart")
+        )
+        return self.ensure_type(response, DynamoServiceRestartResponse)
+
+    # -------------------------------------------------------------- replicas
+
+    def list_replicas(
+        self,
+        name_or_deployment: Union[str, LeptonDynamoGraphDeployment],
+        service: Optional[str] = None,
+    ) -> List[DynamoReplica]:
+        """List replicas across all services, optionally filtered by service."""
+        params = {"service": service} if service else None
+        response = self._get(self._path(name_or_deployment, "replicas"), params=params)
+        return self.ensure_list(response, DynamoReplica)
+
+    def list_service_replicas(
+        self,
+        name_or_deployment: Union[str, LeptonDynamoGraphDeployment],
+        service: str,
+    ) -> DynamoServiceReplicasResponse:
+        response = self._get(
+            self._path(name_or_deployment, "services", service, "replicas")
+        )
+        return self.ensure_type(response, DynamoServiceReplicasResponse)
+
+    def get_replica_log(
+        self,
+        name_or_deployment: Union[str, LeptonDynamoGraphDeployment],
+        replica: str,
+        service: Optional[str] = None,
+        tail: Optional[int] = None,
+        timestamps: bool = False,
+    ) -> DynamoReplicaLogResponse:
+        """
+        Fetch the current log of one replica (pod). This is a one-shot payload,
+        not a stream. ``tail`` defaults to 100 lines server side. When
+        ``service`` is given the service-scoped route is used, which also
+        verifies that the pod belongs to that service.
+        """
+        if service:
+            path = self._path(
+                name_or_deployment, "services", service, "replicas", replica, "log"
+            )
+        else:
+            path = self._path(name_or_deployment, "replicas", replica, "log")
+        params: Dict[str, Any] = {}
+        if tail is not None:
+            if tail <= 0:
+                raise ValueError("tail must be a positive integer.")
+            params["tail"] = tail
+        if timestamps:
+            params["timestamps"] = "true"
+        response = self._get(path, params=params or None)
+        return self.ensure_type(response, DynamoReplicaLogResponse)
+
+    def delete_replica(
+        self,
+        name_or_deployment: Union[str, LeptonDynamoGraphDeployment],
+        replica: str,
+        service: Optional[str] = None,
+    ) -> DynamoReplicaDeleteResponse:
+        """Delete one replica (pod); the operator launches a replacement."""
+        if service:
+            path = self._path(
+                name_or_deployment, "services", service, "replicas", replica
+            )
+        else:
+            path = self._path(name_or_deployment, "replicas", replica)
+        response = self._delete(path)
+        return self.ensure_type(response, DynamoReplicaDeleteResponse)
+
+    # ------------------------------------------------------------ monitoring
+
+    def get_monitoring_status(
+        self, name_or_deployment: Union[str, LeptonDynamoGraphDeployment]
+    ) -> DynamoMonitoringStatusResponse:
+        response = self._get(self._path(name_or_deployment, "monitoring", "status"))
+        return self.ensure_type(response, DynamoMonitoringStatusResponse)
+
+    def get_history(
+        self, name_or_deployment: Union[str, LeptonDynamoGraphDeployment]
+    ) -> List[DynamoHistoryItem]:
+        response = self._get(self._path(name_or_deployment, "history"))
+        return self.ensure_list(response, DynamoHistoryItem)
+
+    def get_metric(
+        self,
+        name_or_deployment: Union[str, LeptonDynamoGraphDeployment],
+        metric: str,
+        window: Optional[int] = None,
+    ) -> Any:
+        """
+        Deployment-level metric series (e.g. ``GPUUtilAvg``). ``window`` is a
+        plain integer number of hours (the dashboard offers 1, 2, 3, 6, 12, 24).
+        Returns the decoded JSON list of ``{"metric": {...}, "values": [...]}``.
+        """
+        params = {"window": window} if window is not None else None
+        response = self._get(
+            self._path(name_or_deployment, "monitoring", metric), params=params
+        )
+        return self.ensure_json(response)
+
+    def get_replica_metric(
+        self,
+        name_or_deployment: Union[str, LeptonDynamoGraphDeployment],
+        replica: str,
+        metric: str,
+    ) -> Any:
+        """Replica-level metric series (e.g. ``GPUUtil``). No window parameter."""
+        response = self._get(
+            self._path(name_or_deployment, "replicas", replica, "monitoring", metric)
+        )
+        return self.ensure_json(response)

--- a/leptonai/api/v2/dynamo_patch.py
+++ b/leptonai/api/v2/dynamo_patch.py
@@ -1,0 +1,89 @@
+"""
+RFC 7396 (JSON Merge Patch) helpers used by `lep dynamo update`.
+
+The Dynamo update route applies a merge patch to the current user spec:
+``null`` deletes a key, nested objects merge recursively, and arrays are
+replaced whole. :func:`build_merge_patch` derives such a patch from two plain
+dicts (the current spec and the desired spec), emitting only changed paths,
+exactly like the dashboard's edit overlay.
+"""
+
+from copy import deepcopy
+from typing import Any, Dict
+
+from pydantic import BaseModel
+
+
+def spec_to_dict(spec: BaseModel) -> Dict[str, Any]:
+    """JSON-ready dict of a spec, aliases honored and ``None`` fields dropped."""
+    return spec.model_dump(mode="json", exclude_none=True, by_alias=True)
+
+
+def build_merge_patch(original: Any, desired: Any) -> Dict[str, Any]:
+    """
+    Return the merge patch that turns ``original`` into ``desired``.
+
+    - keys present in ``original`` but absent from ``desired`` become ``None``
+    - keys absent from ``original`` are added with their desired value
+    - nested dicts recurse; unchanged paths are omitted
+    - lists and scalars are compared by equality and replaced whole
+
+    Returns ``{}`` when nothing changed. Both arguments should come from
+    :func:`spec_to_dict` (or the same serialization) so ``None`` never appears
+    as a value in ``desired`` unless it means "delete".
+    """
+    if not isinstance(original, dict) or not isinstance(desired, dict):
+        raise ValueError("build_merge_patch expects two dicts at the top level.")
+    return _diff_dict(original, desired)
+
+
+def _diff_dict(original: Dict[str, Any], desired: Dict[str, Any]) -> Dict[str, Any]:
+    patch: Dict[str, Any] = {}
+    for key in original:
+        if key not in desired or desired[key] is None:
+            patch[key] = None
+    for key, value in desired.items():
+        if value is None:
+            # Deleting a key that does not exist is a no-op.
+            continue
+        if key not in original:
+            patch[key] = deepcopy(value)
+            continue
+        current = original[key]
+        if isinstance(current, dict) and isinstance(value, dict):
+            sub = _diff_dict(current, value)
+            if sub:
+                patch[key] = sub
+        elif current != value:
+            patch[key] = deepcopy(value)
+    return patch
+
+
+def deep_merge_patch(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Combine two merge patches; ``override`` wins on conflicts. A ``None`` in
+    ``override`` (delete) replaces whatever ``base`` had for that key.
+    """
+    result = deepcopy(base)
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge_patch(result[key], value)
+        else:
+            result[key] = deepcopy(value)
+    return result
+
+
+def apply_merge_patch(target: Any, patch: Any) -> Any:
+    """
+    Apply an RFC 7396 merge patch to ``target`` and return the result (a new
+    object). Used to preview what the server will store.
+    """
+    if not isinstance(patch, dict):
+        return deepcopy(patch)
+    result = dict(target) if isinstance(target, dict) else {}
+    for key, value in patch.items():
+        if value is None:
+            result.pop(key, None)
+        else:
+            result[key] = apply_merge_patch(result.get(key), value)
+    return result

--- a/leptonai/api/v2/dynamo_spec.py
+++ b/leptonai/api/v2/dynamo_spec.py
@@ -1,0 +1,696 @@
+"""
+Pure helpers that turn CLI-style inputs into a Dynamo graph deployment spec.
+
+Everything here is side-effect free (no API calls) so it can be unit tested
+without click. The defaults registry is ported from the dashboard
+(``lep-fe/interaction-specs/apps/dashboard/src/generated/forms/dynamo/helpers.ts``)
+so `lep dynamo create` fills in exactly what the web console would:
+
+- container image ``nvcr.io/nvidia/ai-dynamo/<framework>-runtime:<version>``
+- working directory per framework (frontend always ``/workspace``)
+- default run command per (version, serving mode, service, framework)
+- the ``lepton.ai/dynamo-worker-role`` label on prefill/decode workers
+- worker node groups inherited from the frontend service
+- commands sent as ``["/bin/sh", "-c", "<command>"]``
+"""
+
+import re
+import shlex
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+from .spec_utils import make_env_vars_from_strings, make_mounts_from_strings
+from .types.affinity import LeptonResourceAffinity
+from .types.dynamo import (
+    DYNAMO_FRONTEND_SERVICE,
+    DYNAMO_SERVICE_NAMES,
+    DYNAMO_WORKER_ROLE_BY_SERVICE,
+    DYNAMO_WORKER_ROLE_LABEL_KEY,
+    DynamoExtraPodMetadata,
+    DynamoExtraPodSpec,
+    DynamoMainContainerSpec,
+    DynamoMultinodeSpec,
+    LeptonDynamoGraphDeploymentUserSpec,
+    LeptonDynamoServiceSpec,
+)
+
+# ---------------------------------------------------------------------------
+# Defaults registry
+# ---------------------------------------------------------------------------
+
+DYNAMO_VERSION = "1.3.1"
+SUPPORTED_DYNAMO_VERSIONS = (DYNAMO_VERSION,)
+
+DYNAMO_FRAMEWORKS = ("vllm", "sglang", "trtllm")
+DYNAMO_SERVING_MODES = ("aggregated", "disaggregated")
+DYNAMO_SERVICES_BY_MODE = {
+    "aggregated": ("frontend", "worker"),
+    "disaggregated": ("frontend", "prefill-worker", "decode-worker"),
+}
+DYNAMO_WORKER_SERVICES = tuple(
+    name for name in DYNAMO_SERVICE_NAMES if name != DYNAMO_FRONTEND_SERVICE
+)
+
+DYNAMO_SHELL_INTERPRETER = "/bin/sh"
+DYNAMO_FRONTEND_WORKDIR = "/workspace"
+DYNAMO_NAME_MAX_LENGTH = 36
+DYNAMO_INGRESS_TIMEOUT_MIN = 300
+DYNAMO_INGRESS_TIMEOUT_MAX = 3600
+
+DYNAMO_RUNTIME_IMAGES = {
+    "vllm": "nvcr.io/nvidia/ai-dynamo/vllm-runtime",
+    "sglang": "nvcr.io/nvidia/ai-dynamo/sglang-runtime",
+    "trtllm": "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime",
+}
+
+# Ported verbatim from the dashboard's SERVICE_COMMAND registry.
+# https://github.com/ai-dynamo/dynamo/tree/v1.3.1/examples/backends
+_DYNAMO_SERVICE_COMMANDS = {
+    "1.3.1": {
+        "workdir": {
+            "vllm": "/workspace/examples/backends/vllm",
+            "sglang": "/workspace/examples/backends/sglang",
+            "trtllm": "/workspace/",
+        },
+        "aggregated": {
+            "frontend": {
+                "vllm": "python3 -m dynamo.frontend",
+                "sglang": "python3 -m dynamo.frontend",
+                "trtllm": "python3 -m dynamo.frontend",
+            },
+            "worker": {
+                "vllm": "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B",
+                "sglang": (
+                    "python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B"
+                    " --served-model-name Qwen/Qwen3-0.6B --page-size 16 --tp 1"
+                    " --trust-remote-code --skip-tokenizer-init"
+                ),
+                "trtllm": (
+                    "python3 -m dynamo.trtllm --model-path Qwen/Qwen3-0.6B"
+                    " --served-model-name Qwen/Qwen3-0.6B --extra-engine-args"
+                    " ./examples/backends/trtllm/engine_configs/qwen3/agg.yaml"
+                ),
+            },
+        },
+        "disaggregated": {
+            "frontend": {
+                "vllm": "python3 -m dynamo.frontend",
+                "sglang": "python3 -m dynamo.frontend",
+                "trtllm": "python3 -m dynamo.frontend",
+            },
+            "prefill-worker": {
+                "vllm": (
+                    "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B"
+                    " --disaggregation-mode prefill --kv-transfer-config"
+                    ' \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\''
+                ),
+                "sglang": (
+                    "python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B"
+                    " --served-model-name Qwen/Qwen3-0.6B --page-size 16 --tp 1"
+                    " --trust-remote-code --skip-tokenizer-init"
+                    " --disaggregation-mode prefill"
+                    " --disaggregation-transfer-backend nixl"
+                    " --disaggregation-bootstrap-port 12345 --host 0.0.0.0"
+                ),
+                "trtllm": (
+                    "python3 -m dynamo.trtllm --model-path Qwen/Qwen3-0.6B"
+                    " --served-model-name Qwen/Qwen3-0.6B --extra-engine-args"
+                    " ./examples/backends/trtllm/engine_configs/qwen3/prefill.yaml"
+                    " --disaggregation-mode prefill"
+                ),
+            },
+            "decode-worker": {
+                "vllm": (
+                    "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B"
+                    " --disaggregation-mode decode --kv-transfer-config"
+                    ' \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\''
+                ),
+                "sglang": (
+                    "python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B"
+                    " --served-model-name Qwen/Qwen3-0.6B --page-size 16 --tp 1"
+                    " --trust-remote-code --skip-tokenizer-init"
+                    " --disaggregation-mode decode"
+                    " --disaggregation-transfer-backend nixl"
+                    " --disaggregation-bootstrap-port 12345 --host 0.0.0.0"
+                ),
+                "trtllm": (
+                    "python3 -m dynamo.trtllm --model-path Qwen/Qwen3-0.6B"
+                    " --served-model-name Qwen/Qwen3-0.6B --extra-engine-args"
+                    " ./examples/backends/trtllm/engine_configs/qwen3/decode.yaml"
+                    " --disaggregation-mode decode"
+                ),
+            },
+        },
+    },
+}
+
+
+def _command_registry(dynamo_version: Optional[str]) -> dict:
+    # Unknown versions fall back to the newest known registry, as the dashboard does.
+    return _DYNAMO_SERVICE_COMMANDS.get(
+        dynamo_version or DYNAMO_VERSION, _DYNAMO_SERVICE_COMMANDS[DYNAMO_VERSION]
+    )
+
+
+def validate_framework(framework: Optional[str]) -> str:
+    if framework not in DYNAMO_FRAMEWORKS:
+        raise ValueError(
+            f"Unsupported backend framework {framework!r}. Expected one of:"
+            f" {', '.join(DYNAMO_FRAMEWORKS)}."
+        )
+    return framework
+
+
+def validate_serving_mode(serving_mode: Optional[str]) -> str:
+    if serving_mode not in DYNAMO_SERVING_MODES:
+        raise ValueError(
+            f"Unsupported serving mode {serving_mode!r}. Expected one of:"
+            f" {', '.join(DYNAMO_SERVING_MODES)}."
+        )
+    return serving_mode
+
+
+def validate_framework_and_mode(framework: str, serving_mode: str) -> None:
+    validate_framework(framework)
+    validate_serving_mode(serving_mode)
+    if framework == "vllm" and serving_mode == "disaggregated":
+        raise ValueError(
+            "Disaggregated mode is not supported for vLLM currently. Use"
+            " `--serving-mode aggregated` or pick sglang/trtllm."
+        )
+
+
+def get_default_image(framework: str, dynamo_version: Optional[str] = None) -> str:
+    validate_framework(framework)
+    return f"{DYNAMO_RUNTIME_IMAGES[framework]}:{dynamo_version or DYNAMO_VERSION}"
+
+
+def get_default_working_dir(
+    framework: str, service_name: str, dynamo_version: Optional[str] = None
+) -> str:
+    if service_name == DYNAMO_FRONTEND_SERVICE:
+        return DYNAMO_FRONTEND_WORKDIR
+    validate_framework(framework)
+    return _command_registry(dynamo_version)["workdir"][framework]
+
+
+def get_default_command(
+    framework: str,
+    service_name: str,
+    serving_mode: str,
+    dynamo_version: Optional[str] = None,
+    node_count: Optional[int] = None,
+    gpu_count: Optional[int] = None,
+) -> str:
+    """
+    Default run command for a service, mirroring the dashboard. Returns "" for
+    service names outside the registry. For SGLang multinode workers the
+    tensor-parallel size is rewritten to ``gpu_count * node_count``.
+    """
+    registry = _command_registry(dynamo_version)
+    base = registry.get(serving_mode, {}).get(service_name, {}).get(framework, "")
+    if (
+        node_count
+        and node_count > 1
+        and service_name != DYNAMO_FRONTEND_SERVICE
+        and framework == "sglang"
+    ):
+        tp = (gpu_count or 1) * node_count
+        if serving_mode == "disaggregated":
+            return (
+                base.replace("--tp 1", f"--tp-size {tp}").replace(
+                    "--disaggregation-bootstrap-port 12345",
+                    "--disaggregation-bootstrap-port 30001",
+                )
+                + " --mem-fraction-static 0.82"
+            )
+        return base.replace("--tp 1", f"--tp {tp}")
+    return base
+
+
+def shell_command_argv(command: Optional[str]) -> Optional[List[str]]:
+    """``"python3 -m x"`` -> ``["/bin/sh", "-c", "python3 -m x"]``; blank -> None."""
+    if command is None or not command.strip():
+        return None
+    normalized = command.replace("\r\n", "\n").replace("\r", "\n")
+    return [DYNAMO_SHELL_INTERPRETER, "-c", normalized]
+
+
+def command_display_string(argv: Optional[Sequence[str]]) -> str:
+    """Inverse of :func:`shell_command_argv` for display purposes."""
+    if not argv:
+        return ""
+    if (
+        len(argv) == 3
+        and argv[1] == "-c"
+        and argv[0]
+        in (
+            "/bin/sh",
+            "/bin/bash",
+            "sh",
+            "bash",
+        )
+    ):
+        return argv[2]
+    return shlex.join(argv)
+
+
+def component_type_for_service(service_name: str) -> str:
+    return "frontend" if service_name == DYNAMO_FRONTEND_SERVICE else "worker"
+
+
+def serving_mode_from_services(service_names: Sequence[str]) -> str:
+    """The dashboard's rule: any prefill/decode worker means disaggregated."""
+    for name in service_names:
+        if "prefill-worker" in name or "decode-worker" in name:
+            return "disaggregated"
+    return "aggregated"
+
+
+def sort_service_names(service_names: Sequence[str]) -> List[str]:
+    """``frontend`` first, then alphabetical (the dashboard's tab order)."""
+    return sorted(
+        set(service_names),
+        key=lambda name: (name != DYNAMO_FRONTEND_SERVICE, name),
+    )
+
+
+_NAME_PATTERN = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
+
+
+def validate_dynamo_name(name: Optional[str]) -> str:
+    """Name rules from the dashboard create form (same as the server's)."""
+    if not name:
+        raise ValueError("Name is required")
+    if len(name) > DYNAMO_NAME_MAX_LENGTH:
+        raise ValueError(f"Name cannot exceed {DYNAMO_NAME_MAX_LENGTH} characters.")
+    if not _NAME_PATTERN.match(name):
+        raise ValueError(
+            "Name must consist of lower case alphanumeric characters or '-', and"
+            " must start with an alphabetical character and end with an"
+            " alphanumeric character."
+        )
+    if name.endswith("by-lepton"):
+        raise ValueError("Name cannot end with 'by-lepton'")
+    return name
+
+
+def validate_service_name(service_name: str) -> str:
+    if service_name not in DYNAMO_SERVICE_NAMES:
+        raise ValueError(
+            f"Unknown Dynamo service {service_name!r}. Expected one of:"
+            f" {', '.join(DYNAMO_SERVICE_NAMES)}."
+        )
+    return service_name
+
+
+def validate_service_name_for_mode(service_name: str, serving_mode: str) -> str:
+    validate_service_name(service_name)
+    allowed = DYNAMO_SERVICES_BY_MODE[validate_serving_mode(serving_mode)]
+    if service_name not in allowed:
+        raise ValueError(
+            f"Service {service_name!r} is not available in {serving_mode} mode;"
+            f" {serving_mode} mode allows: {', '.join(allowed)}."
+        )
+    return service_name
+
+
+def validate_ingress_timeout(seconds: Optional[int]) -> Optional[int]:
+    if seconds is None:
+        return None
+    if not (DYNAMO_INGRESS_TIMEOUT_MIN <= seconds <= DYNAMO_INGRESS_TIMEOUT_MAX):
+        raise ValueError(
+            "ingress_timeout_seconds must be between"
+            f" {DYNAMO_INGRESS_TIMEOUT_MIN} and {DYNAMO_INGRESS_TIMEOUT_MAX}, got"
+            f" {seconds}."
+        )
+    return seconds
+
+
+def parse_key_value_pairs(items: Sequence[str], kind: str) -> Dict[str, str]:
+    """Parse ``KEY=VALUE`` strings; both sides are required (dashboard rule)."""
+    result: Dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"Invalid {kind} {item!r}: expected KEY=VALUE.")
+        key, value = item.split("=", 1)
+        key, value = key.strip(), value.strip()
+        if not key:
+            raise ValueError(f"Please input {kind} key ({item!r}).")
+        if not value:
+            raise ValueError(f"Please input {kind} value ({item!r}).")
+        result[key] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Spec builders
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DynamoServiceInput:
+    """
+    What the CLI collects for one ``-svc/--service`` block. ``None`` means
+    "not given": the value is derived from the defaults registry for a new
+    service, or left untouched when overriding a service loaded from a file.
+    """
+
+    name: str
+    resource_shape: Optional[str] = None
+    # Dedicated node group IDs (already resolved from names).
+    node_groups: Optional[List[str]] = None
+    replicas: Optional[int] = None
+    node_count: Optional[int] = None
+    image: Optional[str] = None
+    working_dir: Optional[str] = None
+    command: Optional[str] = None
+    envs: List[str] = field(default_factory=list)
+    secrets: List[str] = field(default_factory=list)
+    mounts: List[str] = field(default_factory=list)
+    annotations: List[str] = field(default_factory=list)
+    labels: List[str] = field(default_factory=list)
+    shared_memory_size: Optional[int] = None
+    termination_grace_period_seconds: Optional[int] = None
+    # GPUs per replica of the chosen shape; only used to derive the default
+    # tensor-parallel size of SGLang multinode commands.
+    gpu_count: Optional[int] = None
+
+
+def _set_node_groups(spec: LeptonDynamoServiceSpec, node_groups: List[str]) -> None:
+    if spec.affinity is None:
+        spec.affinity = LeptonResourceAffinity()
+    spec.affinity.allowed_dedicated_node_groups = list(node_groups)
+
+
+def build_service_spec(
+    svc: DynamoServiceInput,
+    *,
+    framework: str,
+    serving_mode: str,
+    dynamo_version: Optional[str] = None,
+    frontend_node_groups: Optional[Sequence[str]] = None,
+    image_pull_secrets: Optional[Sequence[str]] = None,
+    base: Optional[LeptonDynamoServiceSpec] = None,
+    framework_changed: bool = False,
+    fill_defaults: bool = True,
+) -> LeptonDynamoServiceSpec:
+    """
+    Build one service spec from CLI input, optionally on top of ``base`` (a
+    service loaded from a spec file). Raises ``ValueError`` for every rule the
+    dashboard enforces client side.
+
+    With ``fill_defaults=False`` (used by `lep dynamo update`) only explicitly
+    given inputs are applied on top of ``base``; missing image, working dir,
+    command, replica count and pod metadata are left untouched so the derived
+    merge patch contains nothing the user did not ask for.
+    """
+    name = svc.name
+    known = name in DYNAMO_SERVICE_NAMES
+    if known or base is None:
+        validate_service_name_for_mode(name, serving_mode)
+    is_frontend = name == DYNAMO_FRONTEND_SERVICE
+
+    spec = base.model_copy(deep=True) if base is not None else LeptonDynamoServiceSpec()
+    is_new = base is None
+    if is_new:
+        fill_defaults = True
+
+    if known and (fill_defaults or not spec.component_type):
+        spec.component_type = component_type_for_service(name)
+    elif not spec.component_type and fill_defaults:
+        spec.component_type = "worker"
+
+    # Resource shape ---------------------------------------------------------
+    if svc.resource_shape is not None:
+        spec.resource_shape = svc.resource_shape
+    if not spec.resource_shape:
+        raise ValueError(
+            f"Service {name!r} requires --resource-shape (e.g. `-svc {name}"
+            " --resource-shape gpu.a10`)."
+        )
+
+    # Node groups ------------------------------------------------------------
+    if is_frontend:
+        if svc.node_groups is not None:
+            _set_node_groups(spec, svc.node_groups)
+    else:
+        if (
+            svc.node_groups is not None
+            and frontend_node_groups is not None
+            and list(svc.node_groups) != list(frontend_node_groups)
+        ):
+            raise ValueError(
+                "Worker node groups are automatically synchronized with the"
+                f" frontend service; drop --node-group on {name!r} or make it"
+                " match the frontend."
+            )
+        if frontend_node_groups:
+            _set_node_groups(spec, list(frontend_node_groups))
+        elif svc.node_groups is not None:
+            _set_node_groups(spec, svc.node_groups)
+
+    # Replicas ---------------------------------------------------------------
+    if svc.replicas is not None:
+        if svc.replicas < 1:
+            raise ValueError(f"Replicas must be at least 1 (service {name!r}).")
+        spec.min_replicas = svc.replicas
+        if spec.max_replicas is not None:
+            spec.max_replicas = svc.replicas
+    elif spec.min_replicas is None and fill_defaults:
+        spec.min_replicas = 1
+
+    # Multinode --------------------------------------------------------------
+    if svc.node_count is not None:
+        if is_frontend:
+            raise ValueError(
+                "--node-count is only supported for worker services, not the frontend."
+            )
+        if framework != "sglang":
+            raise ValueError(
+                "Multinode (--node-count) is only supported for SGLang workers;"
+                f" the backend framework is {framework}."
+            )
+        if svc.node_count < 2:
+            raise ValueError(f"Node count must be at least 2 (service {name!r}).")
+        spec.multinode = DynamoMultinodeSpec(node_count=svc.node_count)
+    elif framework_changed and framework != "sglang":
+        # Framework cascade from the dashboard: only SGLang supports multinode.
+        spec.multinode = None
+    node_count = spec.multinode.node_count if spec.multinode else None
+
+    # Main container ---------------------------------------------------------
+    touch_container = fill_defaults or any(
+        value is not None for value in (svc.image, svc.working_dir, svc.command)
+    )
+    if touch_container:
+        if spec.extra_pod_spec is None:
+            spec.extra_pod_spec = DynamoExtraPodSpec()
+        if spec.extra_pod_spec.main_container is None:
+            spec.extra_pod_spec.main_container = DynamoMainContainerSpec()
+        container = spec.extra_pod_spec.main_container
+
+        if svc.image is not None:
+            container.image = svc.image
+        elif fill_defaults and (is_new or framework_changed or not container.image):
+            container.image = get_default_image(framework, dynamo_version)
+
+        if svc.working_dir is not None:
+            container.working_dir = svc.working_dir
+        elif fill_defaults and (
+            is_new or framework_changed or not container.working_dir
+        ):
+            container.working_dir = get_default_working_dir(
+                framework, name, dynamo_version
+            )
+
+        if svc.command is not None:
+            container.command = shell_command_argv(svc.command)
+        elif fill_defaults and (is_new or framework_changed or not container.command):
+            default_command = get_default_command(
+                framework,
+                name,
+                serving_mode,
+                dynamo_version,
+                node_count=node_count,
+                gpu_count=svc.gpu_count,
+            )
+            container.command = shell_command_argv(default_command) or container.command
+
+    if image_pull_secrets or svc.termination_grace_period_seconds is not None:
+        if spec.extra_pod_spec is None:
+            spec.extra_pod_spec = DynamoExtraPodSpec()
+        if image_pull_secrets:
+            spec.extra_pod_spec.image_pull_secrets = list(image_pull_secrets)
+        if svc.termination_grace_period_seconds is not None:
+            if svc.termination_grace_period_seconds < 0:
+                raise ValueError("--termination-grace-period must be non-negative.")
+            spec.extra_pod_spec.termination_grace_period_seconds = (
+                svc.termination_grace_period_seconds
+            )
+
+    # Envs, mounts, resources ------------------------------------------------
+    if svc.envs or svc.secrets:
+        spec.envs = make_env_vars_from_strings(list(svc.envs), list(svc.secrets))
+    if svc.mounts:
+        spec.mounts = make_mounts_from_strings(list(svc.mounts))
+    if svc.shared_memory_size is not None:
+        if svc.shared_memory_size < 0:
+            raise ValueError("--shared-memory-size must be non-negative.")
+        spec.shared_memory_size = svc.shared_memory_size
+
+    # Pod metadata -----------------------------------------------------------
+    touch_metadata = fill_defaults or bool(svc.annotations or svc.labels)
+    if touch_metadata:
+        if spec.extra_pod_metadata is None:
+            spec.extra_pod_metadata = DynamoExtraPodMetadata()
+        if svc.annotations:
+            spec.extra_pod_metadata.annotations = parse_key_value_pairs(
+                svc.annotations, "annotation"
+            )
+        if svc.labels:
+            spec.extra_pod_metadata.labels = parse_key_value_pairs(svc.labels, "label")
+        if spec.extra_pod_metadata.annotations is None:
+            spec.extra_pod_metadata.annotations = {}
+        labels = dict(spec.extra_pod_metadata.labels or {})
+        labels.pop(DYNAMO_WORKER_ROLE_LABEL_KEY, None)
+        role = DYNAMO_WORKER_ROLE_BY_SERVICE.get(name)
+        if role:
+            labels[DYNAMO_WORKER_ROLE_LABEL_KEY] = role
+        spec.extra_pod_metadata.labels = labels
+
+    return spec
+
+
+def frontend_node_groups_of(
+    spec: LeptonDynamoGraphDeploymentUserSpec,
+) -> Optional[List[str]]:
+    frontend = (spec.services or {}).get(DYNAMO_FRONTEND_SERVICE)
+    if frontend is None or frontend.affinity is None:
+        return None
+    return frontend.affinity.allowed_dedicated_node_groups
+
+
+def build_dynamo_spec(
+    *,
+    services: Sequence[DynamoServiceInput],
+    framework: Optional[str] = None,
+    serving_mode: Optional[str] = None,
+    dynamo_version: Optional[str] = None,
+    ingress_enabled: Optional[bool] = None,
+    ingress_timeout_seconds: Optional[int] = None,
+    display_name: Optional[str] = None,
+    envs: Sequence[str] = (),
+    secrets: Sequence[str] = (),
+    image_pull_secrets: Optional[Sequence[str]] = None,
+    base: Optional[LeptonDynamoGraphDeploymentUserSpec] = None,
+) -> LeptonDynamoGraphDeploymentUserSpec:
+    """
+    Assemble a full user spec from global options plus per-service inputs,
+    optionally on top of ``base`` (a spec loaded from ``lep dynamo get -p``).
+    CLI values override file values; anything not given keeps the file value
+    or the dashboard default.
+    """
+    spec = (
+        base.model_copy(deep=True)
+        if base is not None
+        else LeptonDynamoGraphDeploymentUserSpec()
+    )
+
+    base_framework = spec.backend_framework
+    framework = framework or base_framework or "vllm"
+    framework_changed = bool(
+        base is not None and base_framework and framework != base_framework
+    )
+
+    base_services: Dict[str, LeptonDynamoServiceSpec] = dict(spec.services or {})
+    if serving_mode is None:
+        serving_mode = (
+            serving_mode_from_services(list(base_services))
+            if base_services
+            else "aggregated"
+        )
+    validate_framework_and_mode(framework, serving_mode)
+
+    if spec.dynamo_namespace:
+        raise ValueError(
+            "dynamo_namespace is unsupported for Dynamo 1.3.1 and must be empty;"
+            " remove it from the spec."
+        )
+
+    spec.backend_framework = framework
+    spec.dynamo_version = dynamo_version or spec.dynamo_version or DYNAMO_VERSION
+    if display_name is not None:
+        spec.display_name = display_name
+    if ingress_enabled is not None:
+        spec.ingress_enabled = ingress_enabled
+    elif spec.ingress_enabled is None:
+        # The dashboard enables ingress by default; the server does not.
+        spec.ingress_enabled = True
+    if ingress_timeout_seconds is not None:
+        spec.ingress_timeout_seconds = validate_ingress_timeout(ingress_timeout_seconds)
+    else:
+        validate_ingress_timeout(spec.ingress_timeout_seconds)
+    if envs or secrets:
+        spec.envs = make_env_vars_from_strings(list(envs), list(secrets))
+
+    inputs_by_name: Dict[str, DynamoServiceInput] = {}
+    for svc in services:
+        if svc.name in inputs_by_name:
+            raise ValueError(f"Service {svc.name!r} is specified more than once.")
+        inputs_by_name[svc.name] = svc
+
+    if (
+        DYNAMO_FRONTEND_SERVICE not in inputs_by_name
+        and DYNAMO_FRONTEND_SERVICE not in base_services
+    ):
+        raise ValueError(
+            "A frontend service is required. Add `-svc frontend --resource-shape"
+            " <shape> --node-group <node-group>`."
+        )
+
+    for name in inputs_by_name:
+        validate_service_name_for_mode(name, serving_mode)
+    for name in base_services:
+        if name in DYNAMO_SERVICE_NAMES:
+            validate_service_name_for_mode(name, serving_mode)
+
+    common = dict(
+        framework=framework,
+        serving_mode=serving_mode,
+        dynamo_version=spec.dynamo_version,
+        image_pull_secrets=image_pull_secrets,
+        framework_changed=framework_changed,
+    )
+
+    frontend_spec = build_service_spec(
+        inputs_by_name.get(DYNAMO_FRONTEND_SERVICE)
+        or DynamoServiceInput(name=DYNAMO_FRONTEND_SERVICE),
+        base=base_services.get(DYNAMO_FRONTEND_SERVICE),
+        **common,
+    )
+    frontend_node_groups = (
+        frontend_spec.affinity.allowed_dedicated_node_groups
+        if frontend_spec.affinity
+        else None
+    )
+    if not frontend_node_groups:
+        raise ValueError(
+            "The frontend service requires --node-group (a dedicated node group);"
+            " workers inherit it."
+        )
+
+    ordered_names = sort_service_names([*base_services.keys(), *inputs_by_name.keys()])
+    new_services: Dict[str, LeptonDynamoServiceSpec] = {}
+    for name in ordered_names:
+        if name == DYNAMO_FRONTEND_SERVICE:
+            new_services[name] = frontend_spec
+            continue
+        new_services[name] = build_service_spec(
+            inputs_by_name.get(name) or DynamoServiceInput(name=name),
+            frontend_node_groups=frontend_node_groups,
+            base=base_services.get(name),
+            **common,
+        )
+    spec.services = new_services
+    return spec

--- a/leptonai/api/v2/log.py
+++ b/leptonai/api/v2/log.py
@@ -5,9 +5,17 @@ from leptonai.api.v2.types.deployment import LeptonDeployment
 from leptonai.api.v2.types.job import LeptonJob
 from leptonai.api.v2.types.replica import Replica
 from leptonai.api.v2.types.job import LeptonJobQueryMode
+from leptonai.api.v2.types.dynamo import LeptonDynamoGraphDeployment
 
 
 class LogAPI(APIResourse):
+    @staticmethod
+    def _dynamo_id(name_or_dynamo: Union[str, LeptonDynamoGraphDeployment]) -> str:
+        if isinstance(name_or_dynamo, str):
+            return name_or_dynamo
+        metadata = name_or_dynamo.metadata
+        return (metadata.id_ or metadata.name) if metadata else ""  # type: ignore
+
     def _workload_log_param(self) -> str:
         """The query key the shared ``/logs*`` routes use for a deployment/endpoint.
 
@@ -31,6 +39,8 @@ class LogAPI(APIResourse):
         q: str = "",
         job_query_mode: str = LeptonJobQueryMode.AliveAndArchive.value,
         direction: str = "backward",
+        name_or_dynamo: Union[str, LeptonDynamoGraphDeployment] = None,
+        dynamo_service: str = None,
     ):
         """
         Call /logs/timeseries to retrieve aggregated time series for logs.
@@ -39,6 +49,9 @@ class LogAPI(APIResourse):
             name_or_deployment: Deployment name or object
             name_or_job: Job id or object
             replica: Replica id or object
+            name_or_dynamo: Dynamo graph deployment id or object (sent as
+                ``dynamo_graph_deployment=``)
+            dynamo_service: Optional Dynamo service name to narrow the scope
             start: Start timestamp (ns)
             end: End timestamp (ns)
             interval_ms: Bucket interval in milliseconds
@@ -81,6 +94,11 @@ class LogAPI(APIResourse):
                 else name_or_job.metadata.id_
             )
             query_kwargs["job"] = job_id
+        elif name_or_dynamo:
+            query_kwargs["dynamo_graph_deployment"] = self._dynamo_id(name_or_dynamo)
+
+        if dynamo_service:
+            query_kwargs["dynamo_service"] = dynamo_service
 
         if replica:
             replica_id = replica if isinstance(replica, str) else replica.metadata.id_
@@ -108,6 +126,8 @@ class LogAPI(APIResourse):
         limit: int = 5000,
         q: str = "",
         job_query_mode: str = "alive_and_archive",
+        name_or_dynamo: Union[str, LeptonDynamoGraphDeployment] = None,
+        dynamo_service: str = None,
     ) -> str:
         query_kwargs = {}
         if start and end:
@@ -143,6 +163,12 @@ class LogAPI(APIResourse):
 
         elif job_history_name:
             query_kwargs["job_history_name"] = job_history_name
+
+        elif name_or_dynamo:
+            query_kwargs["dynamo_graph_deployment"] = self._dynamo_id(name_or_dynamo)
+
+        if dynamo_service:
+            query_kwargs["dynamo_service"] = dynamo_service
 
         if replica:
             replica_id = replica if isinstance(replica, str) else replica.metadata.id_

--- a/leptonai/api/v2/tests/test_dynamo_api.py
+++ b/leptonai/api/v2/tests/test_dynamo_api.py
@@ -1,0 +1,434 @@
+"""HTTP contract tests for DynamoGraphDeploymentAPI and the Dynamo LogAPI scope."""
+
+import json
+import os
+import tempfile
+import unittest
+from urllib.parse import parse_qs, urlparse
+
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+import responses
+
+from leptonai.api.v2.api_resource import ClientError
+from leptonai.api.v2.client import APIClient
+from leptonai.api.v2.types.common import Metadata
+from leptonai.api.v2.types.dynamo import (
+    LeptonDynamoGraphDeployment,
+    LeptonDynamoGraphDeploymentState,
+    LeptonDynamoGraphDeploymentUserSpec,
+    LeptonDynamoServiceSpec,
+)
+from leptonai.api.v2.types.readiness import ReplicaReadinessReason
+
+BASE = "https://gw.example/api/v2/workspaces/ws1"
+DGD = f"{BASE}/dynamographdeployments"
+
+
+def _client():
+    return APIClient(workspace_id="ws1", auth_token="tok", url=BASE)
+
+
+def _deployment_body(name="dyn-1", state="Ready"):
+    return {
+        "metadata": {"id": name, "name": name, "created_at": 1717000000000},
+        "spec": {
+            "dynamo_version": "1.3.1",
+            "backend_framework": "vllm",
+            "ingress_enabled": True,
+            "services": {
+                "frontend": {
+                    "component_type": "frontend",
+                    "resource_shape": "cpu.small",
+                    "min_replicas": 1,
+                    "max_replicas": 1,
+                    "affinity": {"allowed_dedicated_node_groups": ["ng-1"]},
+                    "mounts": [
+                        {"path": "/d", "mount_path": "/mnt/d", "from": "node-nfs:x"}
+                    ],
+                    "extra_pod_spec": {
+                        "main_container": {
+                            "image": "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.1",
+                            "command": ["/bin/sh", "-c", "python3 -m dynamo.frontend"],
+                        }
+                    },
+                }
+            },
+        },
+        "status": {
+            "state": state,
+            "services": {
+                "frontend": {
+                    "state": "Ready",
+                    "ready_replicas": 1,
+                    "desired_replicas": 1,
+                }
+            },
+            "endpoint": {"external_endpoint": "https://dyn-1.example.com"},
+        },
+    }
+
+
+def _replica_body(rid="frontend-abc", reason="Ready"):
+    return {
+        "metadata": {"id": rid, "name": rid, "created_at": 1717000000000},
+        "id": rid,
+        "status": {
+            "readiness_issue": {
+                "reason": reason,
+                "message": "",
+                "creationTimestamp": "2024-01-01T00:00:00Z",
+            },
+            "node": {"name": "node-1", "id": "n-1", "node_group_id": "ng-1"},
+        },
+    }
+
+
+def _last_request():
+    return responses.calls[-1].request
+
+
+def _query(request):
+    return parse_qs(urlparse(request.url).query)
+
+
+class TestDynamoGraphDeploymentAPI(unittest.TestCase):
+    @responses.activate
+    def test_list_all_parses_bare_array_and_states(self):
+        responses.add(
+            responses.GET,
+            DGD,
+            json=[_deployment_body("a", "Ready"), _deployment_body("b", "Not Ready")],
+        )
+        items = _client().dynamo.list_all()
+        self.assertEqual([d.metadata.name for d in items], ["a", "b"])
+        self.assertEqual(items[0].status.state, LeptonDynamoGraphDeploymentState.Ready)
+        self.assertEqual(
+            items[1].status.state, LeptonDynamoGraphDeploymentState.NotReady
+        )
+        self.assertEqual(
+            items[0].spec.services["frontend"].mounts[0].from_, "node-nfs:x"
+        )
+        self.assertEqual(
+            items[0].status.endpoint.external_endpoint, "https://dyn-1.example.com"
+        )
+
+    @responses.activate
+    def test_unknown_state_maps_to_unknown(self):
+        responses.add(responses.GET, DGD, json=[_deployment_body("a", "Weird")])
+        items = _client().dynamo.list_all()
+        self.assertEqual(
+            items[0].status.state, LeptonDynamoGraphDeploymentState.Unknown
+        )
+
+    @responses.activate
+    def test_get_and_not_found(self):
+        responses.add(responses.GET, f"{DGD}/dyn-1", json=_deployment_body())
+        responses.add(
+            responses.GET,
+            f"{DGD}/missing",
+            json={"code": "ResourceNotFound", "message": "not found"},
+            status=404,
+        )
+        client = _client()
+        dep = client.dynamo.get("dyn-1")
+        self.assertEqual(dep.metadata.id_, "dyn-1")
+        # Objects are accepted anywhere a name is.
+        client.dynamo.get(dep)
+        self.assertTrue(_last_request().url.endswith("/dynamographdeployments/dyn-1"))
+        with self.assertRaises(ClientError):
+            client.dynamo.get("missing")
+
+    @responses.activate
+    def test_create_sends_aliased_payload_without_nones(self):
+        responses.add(responses.POST, DGD, json=_deployment_body(), status=201)
+        spec = LeptonDynamoGraphDeploymentUserSpec(
+            backend_framework="vllm",
+            ingress_enabled=True,
+            services={
+                "frontend": LeptonDynamoServiceSpec(
+                    component_type="frontend",
+                    resource_shape="cpu.small",
+                    min_replicas=1,
+                    mounts=[
+                        {"path": "/d", "mount_path": "/mnt/d", "from": "node-nfs:x"}
+                    ],
+                )
+            },
+        )
+        dep = LeptonDynamoGraphDeployment(metadata=Metadata(name="dyn-1"), spec=spec)
+        created = _client().dynamo.create(dep)
+        self.assertEqual(created.metadata.name, "dyn-1")
+
+        body = json.loads(_last_request().body)
+        self.assertEqual(body["metadata"], {"name": "dyn-1"})
+        self.assertNotIn("dynamo_namespace", body["spec"])
+        frontend = body["spec"]["services"]["frontend"]
+        self.assertEqual(frontend["min_replicas"], 1)
+        self.assertNotIn("max_replicas", frontend)
+        self.assertEqual(frontend["mounts"][0]["from"], "node-nfs:x")
+
+    @responses.activate
+    def test_update_sends_merge_patch_and_dryrun(self):
+        responses.add(responses.PATCH, f"{DGD}/dyn-1", json=_deployment_body())
+        client = _client()
+        patch = {
+            "spec": {"services": {"worker": None, "frontend": {"min_replicas": 2}}}
+        }
+
+        client.dynamo.update("dyn-1", patch)
+        request = _last_request()
+        self.assertEqual(json.loads(request.body), patch)
+        self.assertEqual(_query(request), {})
+
+        client.dynamo.update("dyn-1", patch, dryrun=True)
+        self.assertEqual(_query(_last_request()), {"dryrun": ["true"]})
+
+        with self.assertRaises(ValueError):
+            client.dynamo.update("dyn-1", ["not", "a", "dict"])  # type: ignore[arg-type]
+
+    @responses.activate
+    def test_delete(self):
+        responses.add(responses.DELETE, f"{DGD}/dyn-1", json=_deployment_body())
+        self.assertTrue(_client().dynamo.delete("dyn-1"))
+
+    @responses.activate
+    def test_services_and_service(self):
+        responses.add(
+            responses.GET,
+            f"{DGD}/dyn-1/services",
+            json={
+                "services": {
+                    "frontend": {
+                        "component_type": "frontend",
+                        "min_replicas": 1,
+                        "desired_replicas": 1,
+                        "ready_replicas": 1,
+                        "total_pods": 1,
+                        "is_multinode": False,
+                    },
+                    "worker": {
+                        "component_type": "worker",
+                        "min_replicas": 2,
+                        "desired_replicas": 2,
+                        "ready_replicas": 1,
+                        "total_pods": 4,
+                        "is_multinode": True,
+                        "node_count": 2,
+                    },
+                }
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{DGD}/dyn-1/services/worker",
+            json={
+                "name": "worker",
+                "component_type": "worker",
+                "resource_shape": "gpu.h100-8",
+                "min_replicas": 2,
+                "ready_replicas": 1,
+                "spec": {"component_type": "worker", "min_replicas": 2},
+                "status": {
+                    "state": "Starting",
+                    "phase": "Running",
+                    "health": "degraded",
+                    "replicas": {
+                        "desired": 2,
+                        "ready": 1,
+                        "running": 2,
+                        "total_pods": 4,
+                    },
+                    "conditions": [{
+                        "type": "Available",
+                        "status": "False",
+                        "reason": "Pending",
+                        "message": "m",
+                    }],
+                    "uptime": 42,
+                },
+            },
+        )
+        client = _client()
+        services = client.dynamo.list_services("dyn-1").services
+        self.assertEqual(sorted(services), ["frontend", "worker"])
+        self.assertTrue(services["worker"].is_multinode)
+        self.assertEqual(services["worker"].node_count, 2)
+
+        service = client.dynamo.get_service("dyn-1", "worker")
+        self.assertEqual(service.status.replicas.ready, 1)
+        self.assertEqual(service.status.conditions[0].type_, "Available")
+        self.assertEqual(service.status.uptime, 42)
+
+    @responses.activate
+    def test_restart_service_uses_put(self):
+        responses.add(
+            responses.PUT,
+            f"{DGD}/dyn-1/services/worker/restart",
+            json={
+                "message": "restarted",
+                "service": "worker",
+                "deleted_pods": ["p1", "p2"],
+            },
+        )
+        resp = _client().dynamo.restart_service("dyn-1", "worker")
+        self.assertEqual(resp.deleted_pods, ["p1", "p2"])
+        self.assertEqual(_last_request().method, "PUT")
+
+    @responses.activate
+    def test_replica_listing(self):
+        responses.add(
+            responses.GET,
+            f"{DGD}/dyn-1/replicas",
+            json=[_replica_body("frontend-abc"), _replica_body("worker-xyz", "Failed")],
+        )
+        responses.add(
+            responses.GET,
+            f"{DGD}/dyn-1/services/worker/replicas",
+            json={
+                "service": "worker",
+                "replicas": [_replica_body("worker-xyz", "WaitingForCapacity")],
+                "is_multinode": True,
+                "node_count": 2,
+            },
+        )
+        client = _client()
+
+        flat = client.dynamo.list_replicas("dyn-1")
+        self.assertEqual([r.metadata.id_ for r in flat], ["frontend-abc", "worker-xyz"])
+        self.assertEqual(
+            flat[0].status.readiness_issue.reason, ReplicaReadinessReason.Ready
+        )
+        self.assertEqual(
+            flat[1].status.readiness_issue.reason, ReplicaReadinessReason.Failed
+        )
+        self.assertEqual(flat[0].status.node.node_group_id, "ng-1")
+        self.assertEqual(_query(_last_request()), {})
+
+        client.dynamo.list_replicas("dyn-1", service="worker")
+        self.assertEqual(_query(_last_request()), {"service": ["worker"]})
+
+        scoped = client.dynamo.list_service_replicas("dyn-1", "worker")
+        self.assertEqual(scoped.service, "worker")
+        self.assertTrue(scoped.is_multinode)
+        self.assertEqual(
+            scoped.replicas[0].status.readiness_issue.reason,
+            ReplicaReadinessReason.WaitingForCapacity,
+        )
+
+    @responses.activate
+    def test_replica_log_paths_and_query(self):
+        payload = {
+            "deployment": "dyn-1",
+            "service": "worker",
+            "replica": "w-1",
+            "logs": "a\nb\n",
+        }
+        responses.add(responses.GET, f"{DGD}/dyn-1/replicas/w-1/log", json=payload)
+        responses.add(
+            responses.GET, f"{DGD}/dyn-1/services/worker/replicas/w-1/log", json=payload
+        )
+        client = _client()
+
+        resp = client.dynamo.get_replica_log("dyn-1", "w-1")
+        self.assertEqual(resp.logs, "a\nb\n")
+        self.assertTrue(_last_request().url.endswith("/replicas/w-1/log"))
+        self.assertEqual(_query(_last_request()), {})
+
+        client.dynamo.get_replica_log(
+            "dyn-1", "w-1", service="worker", tail=50, timestamps=True
+        )
+        request = _last_request()
+        self.assertIn("/services/worker/replicas/w-1/log", request.url)
+        self.assertEqual(_query(request), {"tail": ["50"], "timestamps": ["true"]})
+
+        with self.assertRaises(ValueError):
+            client.dynamo.get_replica_log("dyn-1", "w-1", tail=0)
+
+    @responses.activate
+    def test_delete_replica_paths(self):
+        payload = {"message": "deleted", "replica": "w-1", "service": "worker"}
+        responses.add(responses.DELETE, f"{DGD}/dyn-1/replicas/w-1", json=payload)
+        responses.add(
+            responses.DELETE, f"{DGD}/dyn-1/services/worker/replicas/w-1", json=payload
+        )
+        client = _client()
+        self.assertEqual(client.dynamo.delete_replica("dyn-1", "w-1").replica, "w-1")
+        self.assertTrue(_last_request().url.endswith("/replicas/w-1"))
+        client.dynamo.delete_replica("dyn-1", "w-1", service="worker")
+        self.assertIn("/services/worker/replicas/w-1", _last_request().url)
+
+    @responses.activate
+    def test_monitoring_status_history_and_metrics(self):
+        responses.add(
+            responses.GET,
+            f"{DGD}/dyn-1/monitoring/status",
+            json={
+                "overall_health": "degraded",
+                "total_services": 2,
+                "healthy_services": 1,
+                "services": {"frontend": "healthy", "worker": "unhealthy"},
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{DGD}/dyn-1/history",
+            json=[
+                {"timestamp": 1717000000000, "operation": "create", "description": "d"}
+            ],
+        )
+        series = [
+            {"metric": {"name": "GPUUtilAvg", "device": "0"}, "values": [[1, "0.5"]]}
+        ]
+        responses.add(responses.GET, f"{DGD}/dyn-1/monitoring/GPUUtilAvg", json=series)
+        responses.add(
+            responses.GET, f"{DGD}/dyn-1/replicas/w-1/monitoring/GPUUtil", json=series
+        )
+        client = _client()
+
+        health = client.dynamo.get_monitoring_status("dyn-1")
+        self.assertEqual(health.overall_health, "degraded")
+        self.assertEqual(health.services["worker"], "unhealthy")
+
+        history = client.dynamo.get_history("dyn-1")
+        self.assertEqual(history[0].operation, "create")
+
+        self.assertEqual(
+            client.dynamo.get_metric("dyn-1", "GPUUtilAvg", window=6), series
+        )
+        self.assertEqual(_query(_last_request()), {"window": ["6"]})
+
+        self.assertEqual(
+            client.dynamo.get_replica_metric("dyn-1", "w-1", "GPUUtil"), series
+        )
+        self.assertEqual(_query(_last_request()), {})
+
+
+class TestLogAPIDynamoScope(unittest.TestCase):
+    @responses.activate
+    def test_get_log_sends_dynamo_query_keys(self):
+        responses.add(responses.GET, f"{BASE}/logs", json={"data": {"result": []}})
+        _client().log.get_log(
+            name_or_dynamo="dyn-1",
+            dynamo_service="frontend",
+            replica="r-1",
+            start=1,
+            end=2,
+        )
+        query = _query(_last_request())
+        self.assertEqual(query["dynamo_graph_deployment"], ["dyn-1"])
+        self.assertEqual(query["dynamo_service"], ["frontend"])
+        self.assertEqual(query["replica"], ["r-1"])
+        self.assertNotIn("deployment", query)
+        self.assertNotIn("endpoint", query)
+
+    @responses.activate
+    def test_time_series_accepts_dynamo_object(self):
+        responses.add(responses.GET, f"{BASE}/logs/timeseries", json={})
+        dep = LeptonDynamoGraphDeployment(metadata=Metadata(id="dyn-9", name="dyn-9"))
+        _client().log.get_log_time_series(name_or_dynamo=dep, start=1, end=2)
+        self.assertEqual(_query(_last_request())["dynamo_graph_deployment"], ["dyn-9"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/leptonai/api/v2/types/__init__.py
+++ b/leptonai/api/v2/types/__init__.py
@@ -9,6 +9,7 @@ from . import auth
 from . import common
 from . import dedicated_node_group
 from . import deployment
+from . import dynamo
 from . import events
 from . import finetune
 from . import ingress

--- a/leptonai/api/v2/types/dynamo.py
+++ b/leptonai/api/v2/types/dynamo.py
@@ -1,0 +1,385 @@
+"""
+Types for Dynamo graph deployments: multi-service inference graphs served by
+NVIDIA Dynamo (vLLM, SGLang, or TensorRT-LLM backends).
+
+The spec models mirror the ``LeptonDynamoGraphDeployment`` CRD user spec
+(``deployment-operator/api/v1alpha1/leptondynamographdeployment_types.go``);
+the response models mirror ``api-server/httpapi/dynamo/types.go``. Field names
+match the JSON wire format exactly.
+"""
+
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from loguru import logger
+from pydantic import BaseModel, Field
+
+from .affinity import LeptonResourceAffinity
+from .auth import AuthConfig
+from .common import Metadata
+from .deployment import EnvVar, LeptonRoutingPolicy, Mount
+from .ingress import LoadBalanceConfig
+from .readiness import ReplicaReadinessReason
+
+
+class DynamoBackendFramework(str, Enum):
+    VLLM = "vllm"
+    SGLANG = "sglang"
+    TRTLLM = "trtllm"
+
+
+class DynamoServingMode(str, Enum):
+    AGGREGATED = "aggregated"
+    DISAGGREGATED = "disaggregated"
+
+
+class DynamoComponentType(str, Enum):
+    FRONTEND = "frontend"
+    WORKER = "worker"
+
+
+# Service names used by the dashboard. The API accepts arbitrary service keys,
+# but only these four have default images and commands in the CLI defaults
+# registry (see leptonai.api.v2.dynamo_spec).
+DYNAMO_FRONTEND_SERVICE = "frontend"
+DYNAMO_SERVICE_NAMES = ("frontend", "worker", "prefill-worker", "decode-worker")
+
+# Pod label the dashboard stamps on prefill/decode workers.
+DYNAMO_WORKER_ROLE_LABEL_KEY = "lepton.ai/dynamo-worker-role"
+DYNAMO_WORKER_ROLE_BY_SERVICE = {
+    "prefill-worker": "prefill",
+    "decode-worker": "decode",
+}
+
+
+# ---------------------------------------------------------------------------
+# Spec
+# ---------------------------------------------------------------------------
+
+
+class DynamoMultinodeSpec(BaseModel):
+    """Multinode configuration. ``node_count`` must be >= 2 (worker services only)."""
+
+    node_count: Optional[int] = None
+
+
+class DynamoMainContainerSpec(BaseModel):
+    image: Optional[str] = None
+    working_dir: Optional[str] = None
+    command: Optional[List[str]] = None
+
+
+class DynamoExtraPodSpec(BaseModel):
+    main_container: Optional[DynamoMainContainerSpec] = None
+    image_pull_secrets: Optional[List[str]] = None
+    node_selector: Optional[Dict[str, str]] = None
+    termination_grace_period_seconds: Optional[int] = None
+
+
+class DynamoExtraPodMetadata(BaseModel):
+    annotations: Optional[Dict[str, str]] = None
+    labels: Optional[Dict[str, str]] = None
+
+
+class LeptonDynamoServiceSpec(BaseModel):
+    """
+    One service (frontend or worker) inside a Dynamo graph deployment.
+
+    The resource requirement fields are inlined in the CRD
+    (``LeptonDeploymentResourceRequirement``), so they sit at the top level of
+    the service rather than under ``resource_requirement`` as endpoints do.
+    """
+
+    component_type: Optional[str] = None
+    envs: Optional[List[EnvVar]] = None
+    env_from_secret: Optional[str] = None
+    mounts: Optional[List[Mount]] = None
+    multinode: Optional[DynamoMultinodeSpec] = None
+
+    # Inlined LeptonDeploymentResourceRequirement.
+    resource_shape: Optional[str] = None
+    cpu: Optional[float] = None
+    memory: Optional[int] = None
+    ephemeral_storage_in_gb: Optional[int] = None
+    accelerator_type: Optional[str] = None
+    accelerator_num: Optional[float] = None
+    accelerator_fraction: Optional[float] = None
+    accelerator_memory: Optional[int] = None
+    accelerator_pass_all: Optional[bool] = None
+    shared_memory_size: Optional[int] = None
+    # Deprecated upstream; kept only so server responses round-trip.
+    resource_affinity: Optional[str] = None
+    affinity: Optional[LeptonResourceAffinity] = None
+    min_replicas: Optional[int] = None
+    # Autoscaling is not supported yet: the server forces max_replicas == min_replicas.
+    max_replicas: Optional[int] = None
+    host_network: Optional[bool] = None
+    is_adaptive: Optional[bool] = None
+
+    extra_pod_metadata: Optional[DynamoExtraPodMetadata] = None
+    extra_pod_spec: Optional[DynamoExtraPodSpec] = None
+
+
+class LeptonDynamoGraphDeploymentUserSpec(BaseModel):
+    """User-facing spec of a Dynamo graph deployment."""
+
+    display_name: Optional[str] = None
+    # Must stay empty for Dynamo 1.3.1 (the server rejects any non-empty value).
+    # Present only so that server responses round-trip through the model.
+    dynamo_namespace: Optional[str] = None
+    dynamo_version: Optional[str] = None
+    backend_framework: Optional[str] = None
+    ingress_enabled: Optional[bool] = None
+    # Global environment variables applied to every service.
+    envs: Optional[List[EnvVar]] = None
+    services: Optional[Dict[str, LeptonDynamoServiceSpec]] = None
+    load_balance_config: Optional[Union[LoadBalanceConfig, Dict[str, Any]]] = None
+    routing_policy: Optional[LeptonRoutingPolicy] = None
+    auth_config: Optional[AuthConfig] = None
+    # Valid range 300..3600; the server defaults to 300 when unset.
+    ingress_timeout_seconds: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+
+class LeptonDynamoGraphDeploymentState(str, Enum):
+    """Aggregated deployment-level state (LDGD states in the CRD)."""
+
+    Ready = "Ready"
+    Starting = "Starting"
+    Updating = "Updating"
+    NotReady = "Not Ready"
+    Deleting = "Deleting"
+    # Offered by the dashboard's status filter; kept so they never render as UNK.
+    Scaling = "Scaling"
+    Stopping = "Stopping"
+    Stopped = "Stopped"
+    # Backend represents the unknown state as an empty string ("").
+    Unknown = "UNK"
+
+    @classmethod
+    def _missing_(cls, value):
+        logger.trace(f"Unknown value: {value} for LeptonDynamoGraphDeploymentState")
+        return cls.Unknown
+
+
+class LeptonDynamoServiceState(str, Enum):
+    """Per-service state."""
+
+    Ready = "Ready"
+    Starting = "Starting"
+    Updating = "Updating"
+    Scaling = "Scaling"
+    Restarting = "Restarting"
+    NotReady = "Not Ready"
+    Unknown = "UNK"
+
+    @classmethod
+    def _missing_(cls, value):
+        logger.trace(f"Unknown value: {value} for LeptonDynamoServiceState")
+        return cls.Unknown
+
+
+class DynamoK8sCondition(BaseModel):
+    """k8s ``metav1.Condition`` as serialized in the deployment status."""
+
+    type_: Optional[str] = Field(default=None, alias="type")
+    status: Optional[str] = None
+    reason: Optional[str] = None
+    message: Optional[str] = None
+    last_transition_time: Optional[str] = Field(
+        default=None, alias="lastTransitionTime"
+    )
+    observed_generation: Optional[int] = Field(default=None, alias="observedGeneration")
+
+
+class DynamoDeploymentEndpoint(BaseModel):
+    internal_endpoint: Optional[str] = None
+    external_endpoint: Optional[str] = None
+    custom_external_endpoint: Optional[List[str]] = None
+
+
+class LeptonDynamoServiceStatus(BaseModel):
+    state: Optional[LeptonDynamoServiceState] = None
+    ready_replicas: Optional[int] = None
+    desired_replicas: Optional[int] = None
+    last_ready_replicas: Optional[int] = None
+
+
+class LeptonDynamoGraphDeploymentStatus(BaseModel):
+    state: Optional[LeptonDynamoGraphDeploymentState] = None
+    conditions: Optional[List[DynamoK8sCondition]] = None
+    observed_generation: Optional[int] = None
+    services: Optional[Dict[str, LeptonDynamoServiceStatus]] = None
+    endpoint: Optional[DynamoDeploymentEndpoint] = None
+    default_lepton_ingress: Optional[str] = None
+
+
+class LeptonDynamoGraphDeployment(BaseModel):
+    metadata: Optional[Metadata] = None
+    spec: Optional[LeptonDynamoGraphDeploymentUserSpec] = None
+    status: Optional[LeptonDynamoGraphDeploymentStatus] = None
+
+
+# ---------------------------------------------------------------------------
+# Sub-resource responses (api-server/httpapi/dynamo/types.go)
+# ---------------------------------------------------------------------------
+
+
+class DynamoServiceInfo(BaseModel):
+    """One entry of ``GET .../services``."""
+
+    component_type: Optional[str] = None
+    min_replicas: Optional[int] = None
+    max_replicas: Optional[int] = None
+    desired_replicas: Optional[int] = None
+    ready_replicas: Optional[int] = None
+    total_pods: Optional[int] = None
+    is_multinode: Optional[bool] = None
+    node_count: Optional[int] = None
+
+
+class DynamoServicesResponse(BaseModel):
+    services: Dict[str, DynamoServiceInfo] = {}
+
+
+class DynamoServiceReplicaStatus(BaseModel):
+    desired: Optional[int] = None
+    ready: Optional[int] = None
+    running: Optional[int] = None
+    total_pods: Optional[int] = None
+
+
+class DynamoServiceCondition(BaseModel):
+    type_: Optional[str] = Field(default=None, alias="type")
+    status: Optional[str] = None
+    reason: Optional[str] = None
+    message: Optional[str] = None
+    last_transition_time: Optional[int] = None
+
+
+class DynamoReplicaErrorEvent(BaseModel):
+    """``http.ReplicaErrorEvent`` surfaced in a service status."""
+
+    name: Optional[str] = None
+    reason: Optional[str] = None
+    message: Optional[str] = None
+    node_name: Optional[str] = None
+    node_group_id: Optional[str] = None
+    timestamp: Optional[int] = None
+
+
+class DynamoServiceStatus(BaseModel):
+    state: Optional[str] = None
+    phase: Optional[str] = None
+    health: Optional[str] = None
+    replicas: Optional[DynamoServiceReplicaStatus] = None
+    conditions: Optional[List[DynamoServiceCondition]] = None
+    last_replica_error_events: Optional[List[DynamoReplicaErrorEvent]] = None
+    last_updated: Optional[int] = None
+    uptime: Optional[int] = None
+
+
+class DynamoServiceResponse(BaseModel):
+    """``GET .../services/:service``."""
+
+    name: Optional[str] = None
+    component_type: Optional[str] = None
+    resource_shape: Optional[str] = None
+    min_replicas: Optional[int] = None
+    max_replicas: Optional[int] = None
+    desired_replicas: Optional[int] = None
+    ready_replicas: Optional[int] = None
+    running_replicas: Optional[int] = None
+    total_pods: Optional[int] = None
+    is_multinode: Optional[bool] = None
+    node_count: Optional[int] = None
+    spec: Optional[LeptonDynamoServiceSpec] = None
+    status: Optional[DynamoServiceStatus] = None
+
+
+class DynamoReplicaNode(BaseModel):
+    name: Optional[str] = None
+    id_: Optional[str] = Field(default=None, alias="id")
+    node_group_id: Optional[str] = None
+
+
+class DynamoReplicaDomain(BaseModel):
+    name: Optional[str] = None
+
+
+class DynamoReplicaReadinessIssue(BaseModel):
+    reason: ReplicaReadinessReason = ReplicaReadinessReason.Unknown
+    message: Optional[str] = None
+    creationTimestamp: Optional[str] = None
+
+
+class DynamoReplicaStatus(BaseModel):
+    cpu: Optional[float] = None
+    memory_in_mb: Optional[float] = None
+    ephemeral_storage_in_gb: Optional[float] = None
+    gpus: Optional[float] = None
+    public_ip: Optional[str] = None
+    local_ip: Optional[str] = None
+    node: Optional[DynamoReplicaNode] = None
+    domains: Optional[List[DynamoReplicaDomain]] = None
+    readiness_issue: Optional[DynamoReplicaReadinessIssue] = None
+    last_termination: Optional[Dict[str, Any]] = None
+    container_status: Optional[Dict[str, Any]] = None
+
+
+class DynamoReplica(BaseModel):
+    """A pod of one Dynamo service."""
+
+    metadata: Metadata
+    # Deprecated upstream; use metadata.id_ instead.
+    id_: Optional[str] = Field(default=None, alias="id")
+    status: Optional[DynamoReplicaStatus] = None
+
+
+class DynamoServiceReplicasResponse(BaseModel):
+    """``GET .../services/:service/replicas``."""
+
+    service: Optional[str] = None
+    replicas: List[DynamoReplica] = []
+    is_multinode: Optional[bool] = None
+    node_count: Optional[int] = None
+
+
+class DynamoReplicaLogResponse(BaseModel):
+    """One-shot log payload of ``GET .../replicas/:rid/log``."""
+
+    deployment: Optional[str] = None
+    service: Optional[str] = None
+    replica: Optional[str] = None
+    logs: Optional[str] = None
+
+
+class DynamoReplicaDeleteResponse(BaseModel):
+    message: Optional[str] = None
+    replica: Optional[str] = None
+    service: Optional[str] = None
+
+
+class DynamoServiceRestartResponse(BaseModel):
+    message: Optional[str] = None
+    service: Optional[str] = None
+    deleted_pods: Optional[List[str]] = None
+
+
+class DynamoMonitoringStatusResponse(BaseModel):
+    """``GET .../monitoring/status``; ``overall_health`` is healthy|degraded|unhealthy."""
+
+    overall_health: Optional[str] = None
+    total_services: Optional[int] = None
+    healthy_services: Optional[int] = None
+    services: Optional[Dict[str, str]] = None
+
+
+class DynamoHistoryItem(BaseModel):
+    timestamp: Optional[int] = None
+    operation: Optional[str] = None
+    description: Optional[str] = None

--- a/leptonai/api/v2/types/readiness.py
+++ b/leptonai/api/v2/types/readiness.py
@@ -17,6 +17,17 @@ class ReplicaReadinessReason(str, Enum):
     SystemError = "SystemError"
     RequireReadinessApproval = "RequireReadinessApproval"
     Queueing = "Queueing"
+    # Reasons emitted by the dynamo replica endpoints and the newer readiness
+    # classifier (see dashboard `deployment-dynamo-detail-replicas.md`).
+    WaitingForCapacity = "WaitingForCapacity"
+    Migrating = "Migrating"
+    UserCodeError = "UserCodeError"
+    DeploymentConfigError = "DeploymentConfigError"
+    Failed = "Failed"
+    Preempting = "Preempting"
+    Completed = "Completed"
+    Terminated = "Terminated"
+    NodeNotReady = "NodeNotReady"
     Unknown = "Unknown"
 
     @classmethod

--- a/leptonai/cli/cli.py
+++ b/leptonai/cli/cli.py
@@ -29,6 +29,7 @@ from . import log
 from . import raycluster
 from . import template
 from . import finetune
+from . import dynamo
 
 from .util import click_group
 
@@ -78,6 +79,7 @@ log.add_command(lep)
 raycluster.add_command(lep)
 template.add_command(lep)
 finetune.add_command(lep)
+dynamo.add_command(lep)
 
 
 @lep.command()

--- a/leptonai/cli/dynamo.py
+++ b/leptonai/cli/dynamo.py
@@ -1,0 +1,1764 @@
+"""
+`lep dynamo`: manage Dynamo graph deployments (multi-service LLM inference
+graphs served by NVIDIA Dynamo with a vLLM, SGLang, or TensorRT-LLM backend).
+
+The command surface mirrors the dashboard's Dynamo pages: list, create, edit
+(merge patch), detail/status, per-service detail and restart, per-service
+replicas, replica logs, replica deletion, metrics, and history.
+"""
+
+import json
+import sys
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import click
+from rich.pretty import Pretty
+from rich.table import Table
+
+from ..api.v2.api_resource import ClientError, ServerError
+from ..api.v2.client import APIClient
+from ..api.v2.dynamo_patch import (
+    apply_merge_patch,
+    build_merge_patch,
+    deep_merge_patch,
+    spec_to_dict,
+)
+from ..api.v2.dynamo_spec import (
+    DYNAMO_FRAMEWORKS,
+    DYNAMO_RUNTIME_IMAGES,
+    DYNAMO_SERVING_MODES,
+    DYNAMO_VERSION,
+    DynamoServiceInput,
+    SUPPORTED_DYNAMO_VERSIONS,
+    build_dynamo_spec,
+    build_service_spec,
+    command_display_string,
+    frontend_node_groups_of,
+    serving_mode_from_services,
+    sort_service_names,
+    validate_dynamo_name,
+    validate_ingress_timeout,
+)
+from ..api.v2.spec_utils import make_env_vars_from_strings
+from ..api.v2.types.common import LeptonVisibility, Metadata
+from ..api.v2.types.dynamo import (
+    DYNAMO_FRONTEND_SERVICE,
+    DYNAMO_SERVICE_NAMES,
+    DynamoReplica,
+    LeptonDynamoGraphDeployment,
+    LeptonDynamoGraphDeploymentUserSpec,
+    LeptonDynamoServiceSpec,
+)
+from .util import (
+    PathResolutionError,
+    check,
+    click_group,
+    colorize_state,
+    console,
+    format_timestamp_ms,
+    make_block_option_command,
+    make_name_id_cell,
+    resolve_save_path,
+)
+
+# Deployment-level metrics shown by the dashboard's Metrics tab.
+DEPLOYMENT_METRICS = (
+    "GPUUtilAvg",
+    "GPUMemoryUtilAvg",
+    "GPUMemoryUsageMax",
+    "GPUMemoryTotal",
+    "GPUTempAvg",
+)
+# Replica-level metrics shown by the dashboard's per-replica metrics view.
+REPLICA_METRICS = (
+    "CPUUtil",
+    "memoryUtil",
+    "memoryUsage",
+    "memoryTotal",
+    "GPUUtil",
+    "GPUMemoryUtil",
+    "GPUMemoryUsage",
+    "GPUMemoryTotal",
+    "GPUPowerConsumption",
+)
+METRIC_WINDOWS = ("1", "2", "3", "6", "12", "24")
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _fmt_ts(ms: Optional[int]) -> str:
+    if not ms:
+        return "-"
+    try:
+        return datetime.fromtimestamp(ms / 1000).strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return "-"
+
+
+def _state_text(state) -> str:
+    if state is None:
+        return "-"
+    return str(getattr(state, "value", state))
+
+
+def _normalize_token(value: str) -> str:
+    return "".join(ch for ch in value.lower() if ch.isalnum())
+
+
+def _colorize_health(health: Optional[str]) -> str:
+    if not health:
+        return "-"
+    lowered = health.lower()
+    if lowered == "healthy":
+        return f"[green]{health}[/]"
+    if lowered == "degraded":
+        return f"[yellow]{health}[/]"
+    return f"[red]{health}[/]"
+
+
+_READINESS_GREEN = {"Ready"}
+_READINESS_BLUE = {"InProgress", "Migrating", "RequireReadinessApproval"}
+_READINESS_AMBER = {
+    "Queueing",
+    "NoCapacity",
+    "WaitingForCapacity",
+    "Deleting",
+    "Preempting",
+}
+_READINESS_RED = {
+    "UserCodeError",
+    "SystemError",
+    "DeploymentConfigError",
+    "ConfigError",
+    "Failed",
+}
+
+
+def _replica_reason(replica: DynamoReplica) -> str:
+    issue = replica.status.readiness_issue if replica.status else None
+    if issue is None or issue.reason is None:
+        return "Terminated"
+    return _state_text(issue.reason)
+
+
+def _colorize_readiness(reason: str) -> str:
+    if reason in _READINESS_GREEN:
+        return f"[green]{reason}[/]"
+    if reason in _READINESS_BLUE:
+        return f"[blue]{reason}[/]"
+    if reason in _READINESS_AMBER:
+        return f"[yellow]{reason}[/]"
+    if reason in _READINESS_RED:
+        return f"[red]{reason}[/]"
+    return f"[bright_black]{reason}[/]"
+
+
+def _node_groups_of(spec: Optional[LeptonDynamoGraphDeploymentUserSpec]) -> List[str]:
+    seen: List[str] = []
+    for name in sort_service_names(list((spec.services if spec else None) or {})):
+        service = spec.services[name]  # type: ignore[index]
+        groups = (
+            service.affinity.allowed_dedicated_node_groups if service.affinity else None
+        ) or []
+        for group in groups:
+            if group not in seen:
+                seen.append(group)
+    return seen
+
+
+def _env_summary(envs) -> str:
+    if not envs:
+        return "-"
+    parts = []
+    for env in envs:
+        if env.value_from and env.value_from.secret_name_ref:
+            parts.append(f"{env.name} (secret: {env.value_from.secret_name_ref})")
+        else:
+            parts.append(env.name)
+    return ", ".join(parts)
+
+
+def _main_container(service: Optional[LeptonDynamoServiceSpec]):
+    if service is None or service.extra_pod_spec is None:
+        return None
+    return service.extra_pod_spec.main_container
+
+
+def _service_summary_line(
+    name: str,
+    service: LeptonDynamoServiceSpec,
+    status_services: Optional[Dict[str, Any]],
+) -> str:
+    replicas = service.min_replicas if service.min_replicas is not None else 0
+    shape = service.resource_shape or "unknown-shape"
+    line = f"{name}: {replicas} x {shape}"
+    status = (status_services or {}).get(name)
+    if status is not None and (
+        status.ready_replicas is not None or status.desired_replicas is not None
+    ):
+        line += f" ({status.ready_replicas or 0}/{status.desired_replicas or 0} ready)"
+    return line
+
+
+def _sorted_services(dep: LeptonDynamoGraphDeployment) -> List[str]:
+    return sort_service_names(list((dep.spec.services if dep.spec else None) or {}))
+
+
+def _confirm(prompt: str, yes: bool) -> None:
+    if yes:
+        return
+    if not click.confirm(prompt, default=False):
+        console.print("Aborted.")
+        sys.exit(0)
+
+
+def _load_json_file(path: str, what: str) -> Any:
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except Exception as e:
+        console.print(f"Cannot load {what} from file [red]{path}[/]: {e}")
+        sys.exit(1)
+
+
+def _load_user_spec_file(path: str) -> LeptonDynamoGraphDeploymentUserSpec:
+    """Accept either a bare user spec (`lep dynamo get -p`) or a full object."""
+    payload = _load_json_file(path, "Dynamo deployment spec")
+    if isinstance(payload, dict) and "spec" in payload and "services" not in payload:
+        payload = payload["spec"]
+    try:
+        return LeptonDynamoGraphDeploymentUserSpec.model_validate(payload)
+    except Exception as e:
+        console.print(f"Invalid Dynamo deployment spec in [red]{path}[/]: {e}")
+        sys.exit(1)
+
+
+def _resolve_node_group_ids(client: APIClient, terms: Sequence[str]) -> List[str]:
+    """Map dedicated node group names or IDs to IDs; exit on unknown values."""
+    if not terms:
+        return []
+    node_groups = client.nodegroup.list_all()
+    by_key: Dict[str, str] = {}
+    for ng in node_groups:
+        if ng.metadata is None:
+            continue
+        if ng.metadata.id_:
+            by_key[ng.metadata.id_] = ng.metadata.id_
+        if ng.metadata.name:
+            by_key.setdefault(ng.metadata.name, ng.metadata.id_ or ng.metadata.name)
+    resolved: List[str] = []
+    for term in terms:
+        if term not in by_key:
+            available = ", ".join(
+                sorted(
+                    f"{ng.metadata.name} ({ng.metadata.id_})"
+                    for ng in node_groups
+                    if ng.metadata
+                )
+            )
+            console.print(
+                f"Invalid node group: [red]{term}[/] (valid node groups: {available})"
+            )
+            sys.exit(1)
+        if by_key[term] not in resolved:
+            resolved.append(by_key[term])
+    return resolved
+
+
+def _lookup_shape_gpu_count(
+    client: APIClient, node_group_id: Optional[str], resource_shape: Optional[str]
+) -> Optional[int]:
+    """Best effort: GPUs per replica of a shape, used for multinode commands."""
+    if not resource_shape:
+        return None
+    try:
+        shapes = client.shapes.list_shapes(
+            node_group=node_group_id, purpose="deployment"
+        )
+    except Exception:
+        return None
+    for shape in shapes:
+        names = {shape.metadata.id_, shape.metadata.name, shape.spec.name}
+        if resource_shape in names and shape.spec.accelerator_num:
+            return int(shape.spec.accelerator_num)
+    return None
+
+
+def _warn_if_unofficial_image(name: str, service: LeptonDynamoServiceSpec, framework):
+    container = _main_container(service)
+    image = container.image if container else None
+    if not image or framework not in DYNAMO_RUNTIME_IMAGES:
+        return
+    prefix = DYNAMO_RUNTIME_IMAGES[framework] + ":"
+    tag = image[len(prefix) :] if image.startswith(prefix) else None
+    if tag is None or tag not in SUPPORTED_DYNAMO_VERSIONS:
+        console.print(
+            f"[yellow]Warning:[/] service {name!r} uses image {image!r}. The server"
+            f" only accepts the official runtime image for {framework}"
+            f" ({DYNAMO_RUNTIME_IMAGES[framework]}) with a supported Dynamo version"
+            f" tag ({', '.join(SUPPORTED_DYNAMO_VERSIONS)}); the request may be"
+            " rejected."
+        )
+
+
+def _parse_int(value: Optional[str], flag: str) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        raise click.UsageError(f'"{flag}" expects an integer, got {value!r}.')
+
+
+def _service_input_from_block(
+    block: Dict[str, Any],
+    client: APIClient,
+    *,
+    framework: Optional[str],
+) -> DynamoServiceInput:
+    node_groups = (
+        _resolve_node_group_ids(client, block["node_group"])
+        if block.get("node_group")
+        else None
+    )
+    svc = DynamoServiceInput(
+        name=block["key"],
+        resource_shape=block.get("resource_shape"),
+        node_groups=node_groups,
+        replicas=_parse_int(block.get("replicas"), "--replicas"),
+        node_count=_parse_int(block.get("node_count"), "--node-count"),
+        image=block.get("image"),
+        working_dir=block.get("working_dir"),
+        command=block.get("command"),
+        envs=list(block.get("env") or []),
+        secrets=list(block.get("secret") or []),
+        mounts=list(block.get("mount") or []),
+        annotations=list(block.get("annotation") or []),
+        labels=list(block.get("label") or []),
+        shared_memory_size=_parse_int(
+            block.get("shared_memory_size"), "--shared-memory-size"
+        ),
+        termination_grace_period_seconds=_parse_int(
+            block.get("termination_grace_period"), "--termination-grace-period"
+        ),
+    )
+    if svc.node_count and framework == "sglang":
+        svc.gpu_count = _lookup_shape_gpu_count(
+            client, node_groups[0] if node_groups else None, svc.resource_shape
+        )
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Group
+# ---------------------------------------------------------------------------
+
+
+@click_group()
+def dynamo():
+    """
+    Manage Dynamo graph deployments on DGX Cloud Lepton.
+
+    A Dynamo deployment is a multi-service inference graph: a frontend service
+    plus optional worker services (aggregated mode) or prefill/decode workers
+    (disaggregated mode), each with its own resource shape, replicas, image,
+    command, environment variables, and storage mounts.
+    """
+    pass
+
+
+# ---------------------------------------------------------------------------
+# list / get / status
+# ---------------------------------------------------------------------------
+
+
+def _print_dynamo_table(deployments: List[LeptonDynamoGraphDeployment]) -> None:
+    table = Table(title="Dynamo Deployments", show_lines=True, show_header=True)
+    table.add_column("Name")
+    table.add_column("State")
+    table.add_column("Framework")
+    table.add_column("Mode")
+    table.add_column("Ingress")
+    table.add_column("Services (replicas x shape)")
+    table.add_column("Node Groups")
+    table.add_column("Created At")
+    table.add_column("Created By")
+
+    for dep in deployments:
+        metadata = dep.metadata or Metadata()
+        spec = dep.spec or LeptonDynamoGraphDeploymentUserSpec()
+        status = dep.status
+        services = spec.services or {}
+        name_cell = make_name_id_cell(
+            metadata.name or metadata.id_,
+            metadata.id_ if metadata.id_ and metadata.id_ != metadata.name else None,
+        )
+        service_lines = [
+            _service_summary_line(
+                svc_name, services[svc_name], status.services if status else None
+            )
+            for svc_name in sort_service_names(list(services))
+        ]
+        table.add_row(
+            name_cell,
+            colorize_state(_state_text(status.state) if status else None),
+            spec.backend_framework or "-",
+            serving_mode_from_services(list(services)) if services else "-",
+            "Enabled" if spec.ingress_enabled else "Disabled",
+            "\n".join(service_lines) if service_lines else "-",
+            ", ".join(_node_groups_of(spec)) or "-",
+            format_timestamp_ms(metadata.created_at),
+            metadata.created_by or "-",
+        )
+
+    if not deployments:
+        console.print(
+            "No Dynamo deployments found. Use `lep dynamo create` to create one."
+        )
+        return
+    console.print(table)
+
+
+@dynamo.command(name="list")
+@click.option(
+    "--name",
+    "-n",
+    multiple=True,
+    help="Filter by name (case-insensitive substring). Can be repeated.",
+)
+@click.option(
+    "--state",
+    multiple=True,
+    help=(
+        "Filter by deployment state, e.g. Ready, 'Not Ready', Starting, Updating,"
+        " Deleting. Case-insensitive; can be repeated."
+    ),
+)
+@click.option(
+    "--created-by",
+    multiple=True,
+    help="Filter by creator username. Can be repeated.",
+)
+def list_command(name, state, created_by):
+    """
+    Lists Dynamo deployments in the current workspace, newest first.
+    """
+    client = APIClient()
+    deployments = client.dynamo.list_all()
+
+    if name:
+        needles = [n.lower() for n in name]
+        deployments = [
+            d
+            for d in deployments
+            if d.metadata
+            and any(
+                needle in (d.metadata.name or d.metadata.id_ or "").lower()
+                for needle in needles
+            )
+        ]
+    if state:
+        wanted = {_normalize_token(s) for s in state}
+        deployments = [
+            d
+            for d in deployments
+            if d.status and _normalize_token(_state_text(d.status.state)) in wanted
+        ]
+    if created_by:
+        wanted_users = set(created_by)
+        deployments = [
+            d
+            for d in deployments
+            if d.metadata and d.metadata.created_by in wanted_users
+        ]
+
+    deployments.sort(
+        key=lambda d: (d.metadata.created_at or 0) if d.metadata else 0, reverse=True
+    )
+    _print_dynamo_table(deployments)
+
+
+@dynamo.command()
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option(
+    "--path",
+    "-p",
+    type=click.Path(
+        exists=False,
+        file_okay=True,
+        dir_okay=True,
+        writable=True,
+        readable=True,
+        resolve_path=True,
+    ),
+    help=(
+        "Optional local path to save the deployment spec JSON (reusable with"
+        " `lep dynamo create -f`). Directory or full filename accepted. If a"
+        " directory is provided, the file is saved as dynamo-spec-<name>.json."
+    ),
+    required=False,
+)
+def get(name, path):
+    """
+    Prints the full Dynamo deployment as JSON and optionally saves its spec.
+    """
+    client = APIClient()
+    dep = client.dynamo.get(name)
+    console.print(
+        json.dumps(client.dynamo.safe_json(dep), indent=2),
+        markup=False,
+        highlight=False,
+    )
+
+    if path:
+        spec_json = (
+            dep.spec.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+            if dep.spec
+            else "{}"
+        )
+        try:
+            save_path = resolve_save_path(path, f"dynamo-spec-{name}.json")
+        except PathResolutionError as e:
+            console.print(f"[red]Failed to save spec: {e}[/]")
+            sys.exit(1)
+        try:
+            with open(save_path, "w") as f:
+                f.write(spec_json)
+        except Exception as e:
+            console.print(f"[red]Failed to save spec: {e}[/]")
+            sys.exit(1)
+        console.print(f"Dynamo deployment spec saved to [green]{save_path}[/].")
+
+
+def _services_table(
+    dep: LeptonDynamoGraphDeployment, infos: Optional[Dict[str, Any]]
+) -> Table:
+    table = Table(show_lines=False)
+    table.add_column("Service")
+    table.add_column("Type")
+    table.add_column("Shape")
+    table.add_column("Replicas (ready/desired)")
+    table.add_column("Pods")
+    table.add_column("Multinode")
+    table.add_column("State")
+
+    spec_services = (dep.spec.services if dep.spec else None) or {}
+    status_services = (dep.status.services if dep.status else None) or {}
+    for svc_name in _sorted_services(dep):
+        service = spec_services[svc_name]
+        info = (infos or {}).get(svc_name)
+        status = status_services.get(svc_name)
+        ready = (
+            info.ready_replicas
+            if info is not None and info.ready_replicas is not None
+            else (status.ready_replicas if status else None)
+        )
+        desired = (
+            info.desired_replicas
+            if info is not None and info.desired_replicas is not None
+            else (status.desired_replicas if status else service.min_replicas)
+        )
+        if info is not None and info.is_multinode:
+            multinode = f"{info.node_count or '?'} nodes"
+        elif service.multinode and service.multinode.node_count:
+            multinode = f"{service.multinode.node_count} nodes"
+        else:
+            multinode = "-"
+        table.add_row(
+            svc_name,
+            service.component_type or (info.component_type if info else None) or "-",
+            service.resource_shape or "-",
+            f"{ready if ready is not None else '-'}/{desired if desired is not None else '-'}",
+            (
+                str(info.total_pods)
+                if info is not None and info.total_pods is not None
+                else "-"
+            ),
+            multinode,
+            colorize_state(_state_text(status.state) if status else None),
+        )
+    return table
+
+
+def _replicas_table(rows: Iterable[Tuple[str, DynamoReplica]]) -> Tuple[Table, int]:
+    table = Table(show_lines=False)
+    table.add_column("Replica")
+    table.add_column("Service")
+    table.add_column("Status")
+    table.add_column("Node")
+    table.add_column("Created At")
+    count = 0
+    for svc_name, replica in rows:
+        reason = _replica_reason(replica)
+        node = replica.status.node if replica.status else None
+        table.add_row(
+            replica.metadata.id_ or replica.id_ or "-",
+            svc_name,
+            _colorize_readiness(reason),
+            (node.name or node.id_ or "-") if node else "-",
+            _fmt_ts(replica.metadata.created_at),
+        )
+        count += 1
+    return table, count
+
+
+def _collect_replicas(
+    client: APIClient, name: str, services: Sequence[str]
+) -> List[Tuple[str, DynamoReplica]]:
+    rows: List[Tuple[str, DynamoReplica]] = []
+    for svc_name in services:
+        resp = client.dynamo.list_service_replicas(name, svc_name)
+        for replica in resp.replicas:
+            rows.append((svc_name, replica))
+    return rows
+
+
+@dynamo.command()
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option(
+    "--detail", "-d", is_flag=True, default=False, help="Also dump the full object."
+)
+def status(name, detail):
+    """
+    Shows the status of a Dynamo deployment: summary, services, health, and replicas.
+    """
+    client = APIClient()
+    dep = client.dynamo.get(name)
+    spec = dep.spec or LeptonDynamoGraphDeploymentUserSpec()
+    metadata = dep.metadata or Metadata()
+    st = dep.status
+    state_text = _state_text(st.state) if st else None
+    services = _sorted_services(dep)
+
+    console.print(f"Time now:    {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    console.print(f"Created at:  {_fmt_ts(metadata.created_at)}")
+    console.print(f"Created by:  {metadata.created_by or '-'}")
+    if metadata.last_modified_at:
+        console.print(
+            f"Modified at: {_fmt_ts(metadata.last_modified_at)}"
+            f" by {metadata.last_modified_by or '-'}"
+        )
+    console.print(f"State:       {colorize_state(state_text)}")
+    console.print(
+        f"Framework:   {spec.backend_framework or '-'} (Dynamo"
+        f" {spec.dynamo_version or DYNAMO_VERSION})"
+    )
+    console.print(
+        f"Mode:        {serving_mode_from_services(services) if services else '-'}"
+    )
+    ingress = "Enabled" if spec.ingress_enabled else "Disabled"
+    if spec.ingress_timeout_seconds:
+        ingress += f" (timeout {spec.ingress_timeout_seconds}s)"
+    console.print(f"Ingress:     {ingress}")
+    external = st.endpoint.external_endpoint if st and st.endpoint else None
+    if external:
+        if state_text == "Ready":
+            console.print(f"Endpoint:    {external}")
+        else:
+            console.print(
+                f"Endpoint:    {external} [bright_black](unavailable until Ready)[/]"
+            )
+    console.print(f"Node groups: {', '.join(_node_groups_of(spec)) or '-'}")
+    console.print(f"Global envs: {_env_summary(spec.envs)}")
+
+    console.print("\nServices:")
+    infos = None
+    try:
+        infos = client.dynamo.list_services(name).services
+    except (ClientError, ServerError) as e:
+        console.print(f"[yellow]Live service status unavailable: {e}[/]")
+    console.print(_services_table(dep, infos))
+
+    try:
+        health = client.dynamo.get_monitoring_status(name)
+        console.print(
+            f"Health:      {_colorize_health(health.overall_health)}"
+            f" ({health.healthy_services or 0}/{health.total_services or 0} services"
+            " healthy)"
+        )
+    except (ClientError, ServerError) as e:
+        console.print(f"[yellow]Health status unavailable: {e}[/]")
+
+    console.print("\nReplicas:")
+    try:
+        rows = _collect_replicas(client, name, services)
+    except (ClientError, ServerError) as e:
+        console.print(f"[yellow]Replica list unavailable: {e}[/]")
+        rows = []
+    table, count = _replicas_table(rows)
+    if count:
+        console.print(table)
+        ready_count = sum(1 for _, r in rows if _replica_reason(r) == "Ready")
+        console.print(f"[green]{ready_count}[/] out of {count} replicas ready.")
+    else:
+        console.print("No replicas found.")
+
+    if detail:
+        console.print(
+            Pretty(dep.model_dump(mode="json", exclude_none=True, by_alias=True))
+        )
+
+
+# ---------------------------------------------------------------------------
+# services / service / restart
+# ---------------------------------------------------------------------------
+
+
+@dynamo.command()
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+def services(name):
+    """
+    Lists the services of a Dynamo deployment with their replica counts.
+    """
+    client = APIClient()
+    dep = client.dynamo.get(name)
+    infos = None
+    try:
+        infos = client.dynamo.list_services(name).services
+    except (ClientError, ServerError) as e:
+        console.print(f"[yellow]Live service status unavailable: {e}[/]")
+    if not _sorted_services(dep):
+        console.print(f"Dynamo deployment [yellow]{name}[/] has no services.")
+        return
+    console.print(_services_table(dep, infos))
+
+
+@dynamo.command()
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option("--service", "-s", help="The service name.", required=True)
+@click.option(
+    "--detail", "-d", is_flag=True, default=False, help="Also dump the raw response."
+)
+def service(name, service, detail):
+    """
+    Shows one service of a Dynamo deployment: spec, runtime status, and run command.
+    """
+    client = APIClient()
+    svc = client.dynamo.get_service(name, service)
+    spec = svc.spec or LeptonDynamoServiceSpec()
+    st = svc.status
+    container = _main_container(spec)
+
+    console.print(f"Service:      {svc.name or service}")
+    console.print(f"Type:         {svc.component_type or spec.component_type or '-'}")
+    state_line = colorize_state(st.state if st and st.state else None)
+    extras = []
+    if st and st.phase:
+        extras.append(f"phase: {st.phase}")
+    if st and st.health:
+        extras.append(f"health: {st.health}")
+    if extras:
+        state_line += f" ({', '.join(extras)})"
+    console.print(f"State:        {state_line}")
+    replicas = st.replicas if st else None
+    console.print(
+        "Replicas:     ready"
+        f" {(replicas.ready if replicas else svc.ready_replicas) or 0} / desired"
+        f" {(replicas.desired if replicas else svc.desired_replicas) or spec.min_replicas or 0} (running"
+        f" {(replicas.running if replicas else svc.running_replicas) or 0}, pods"
+        f" {(replicas.total_pods if replicas else svc.total_pods) or 0})"
+    )
+    console.print(f"Shape:        {svc.resource_shape or spec.resource_shape or '-'}")
+    groups = (
+        spec.affinity.allowed_dedicated_node_groups if spec.affinity else None
+    ) or []
+    console.print(f"Node groups:  {', '.join(groups) or '-'}")
+    if svc.is_multinode or spec.multinode:
+        node_count = svc.node_count or (
+            spec.multinode.node_count if spec.multinode else None
+        )
+        console.print(f"Multinode:    {node_count or '?'} nodes")
+    else:
+        console.print("Multinode:    single node")
+    console.print(f"Image:        {(container.image if container else None) or '-'}")
+    console.print(
+        f"Working dir:  {(container.working_dir if container else None) or '-'}"
+    )
+    command = command_display_string(container.command if container else None)
+    console.print(f"Command:      {command or '-'}", markup=False, highlight=False)
+    console.print(f"Envs:         {_env_summary(spec.envs)}")
+    if spec.mounts:
+        mounts = ", ".join(f"{m.from_} -> {m.mount_path}" for m in spec.mounts)
+        console.print(f"Mounts:       {mounts}")
+    if spec.extra_pod_metadata:
+        if spec.extra_pod_metadata.labels:
+            labels = ", ".join(
+                f"{k}={v}" for k, v in spec.extra_pod_metadata.labels.items()
+            )
+            console.print(f"Labels:       {labels}")
+        if spec.extra_pod_metadata.annotations:
+            annotations = ", ".join(
+                f"{k}={v}" for k, v in spec.extra_pod_metadata.annotations.items()
+            )
+            console.print(f"Annotations:  {annotations}")
+    if st and st.uptime:
+        console.print(f"Uptime:       {st.uptime}s")
+
+    if st and st.conditions:
+        table = Table(title="Conditions", show_lines=False)
+        table.add_column("Type")
+        table.add_column("Status")
+        table.add_column("Reason")
+        table.add_column("Message")
+        for cond in st.conditions:
+            table.add_row(
+                cond.type_ or "-",
+                cond.status or "-",
+                cond.reason or "-",
+                cond.message or "-",
+            )
+        console.print(table)
+    if st and st.last_replica_error_events:
+        table = Table(title="Recent replica errors", show_lines=False)
+        table.add_column("Replica")
+        table.add_column("Reason")
+        table.add_column("Message")
+        table.add_column("Node")
+        table.add_column("Time")
+        for event in st.last_replica_error_events:
+            table.add_row(
+                event.name or "-",
+                f"[yellow]{event.reason or '-'}[/]",
+                event.message or "-",
+                event.node_name or "-",
+                _fmt_ts(event.timestamp),
+            )
+        console.print(table)
+
+    if detail:
+        console.print(
+            Pretty(svc.model_dump(mode="json", exclude_none=True, by_alias=True))
+        )
+
+
+@dynamo.command()
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option("--service", "-s", help="The service to restart.", required=True)
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip the confirmation.")
+def restart(name, service, yes):
+    """
+    Restarts a service by deleting all of its replicas (pods); the operator
+    launches replacements.
+    """
+    client = APIClient()
+    svc = client.dynamo.get_service(name, service)
+    min_replicas = svc.min_replicas
+    if min_replicas is None and svc.spec is not None:
+        min_replicas = svc.spec.min_replicas
+    if (min_replicas or 0) <= 0:
+        console.print(
+            f"[red]Service {service!r} has no replicas (min_replicas <= 0); nothing"
+            " to restart.[/]"
+        )
+        sys.exit(1)
+    phase = (svc.status.phase or svc.status.state or "") if svc.status else ""
+    if "delet" in str(phase).lower():
+        console.print(
+            f"[red]Service {service!r} is being deleted; restart is disabled.[/]"
+        )
+        sys.exit(1)
+
+    _confirm(f"Are you sure to restart the service {service!r} of {name!r}?", yes)
+    resp = client.dynamo.restart_service(name, service)
+    console.print(
+        f"Restart request has been sent for service [green]{service}[/] of"
+        f" [green]{name}[/]."
+    )
+    if resp.message:
+        console.print(resp.message)
+    if resp.deleted_pods:
+        console.print("Deleted pods: " + ", ".join(resp.deleted_pods))
+
+
+# ---------------------------------------------------------------------------
+# replicas / log / remove-replica / remove
+# ---------------------------------------------------------------------------
+
+
+@dynamo.command()
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option(
+    "--service",
+    "-s",
+    default=None,
+    help="Only list replicas of this service. Defaults to all services.",
+)
+@click.option(
+    "--state",
+    multiple=True,
+    help=(
+        "Filter by replica readiness status, e.g. Ready, InProgress, Failed,"
+        " Terminated. Case-insensitive; can be repeated."
+    ),
+)
+def replicas(name, service, state):
+    """
+    Lists the replicas (pods) of a Dynamo deployment, per service.
+    """
+    client = APIClient()
+    dep = client.dynamo.get(name)
+    services_ = _sorted_services(dep)
+    if service:
+        if services_ and service not in services_:
+            console.print(
+                f"[red]Service {service!r} not found in {name!r}. Available services:"
+                f" {', '.join(services_)}[/]"
+            )
+            sys.exit(1)
+        services_ = [service]
+    rows = _collect_replicas(client, name, services_)
+    if state:
+        wanted = {_normalize_token(s) for s in state}
+        rows = [
+            (s, r) for s, r in rows if _normalize_token(_replica_reason(r)) in wanted
+        ]
+    table, count = _replicas_table(rows)
+    if not count:
+        console.print(f"No replicas found for [yellow]{name}[/].")
+        return
+    console.print(table)
+
+
+def _pick_replica(
+    client: APIClient, name: str, service: Optional[str]
+) -> Tuple[str, str]:
+    dep = client.dynamo.get(name)
+    services_ = _sorted_services(dep)
+    check(services_, f"Dynamo deployment [red]{name}[/] has no services.")
+    if service is None:
+        service = (
+            DYNAMO_FRONTEND_SERVICE
+            if DYNAMO_FRONTEND_SERVICE in services_
+            else services_[0]
+        )
+    elif service not in services_:
+        console.print(
+            f"[red]Service {service!r} not found in {name!r}. Available services:"
+            f" {', '.join(services_)}[/]"
+        )
+        sys.exit(1)
+    resp = client.dynamo.list_service_replicas(name, service)
+    check(
+        len(resp.replicas) > 0,
+        f"No replicas found for service [red]{service}[/] of [red]{name}[/].",
+    )
+    ordered = sorted(
+        resp.replicas,
+        key=lambda r: (_replica_reason(r) != "Ready", r.metadata.created_at or 0),
+    )
+    replica = ordered[0].metadata.id_ or ordered[0].id_ or ""
+    return service, replica
+
+
+@dynamo.command()
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option(
+    "--service",
+    "-s",
+    default=None,
+    help=(
+        "The service whose replica log to show. Defaults to `frontend` when"
+        " --replica is not given."
+    ),
+)
+@click.option(
+    "--replica",
+    "-r",
+    default=None,
+    help="The replica (pod) name. Defaults to the first ready replica of the service.",
+)
+@click.option(
+    "--tail",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Number of most recent log lines to return (server default: 100).",
+)
+@click.option(
+    "--timestamps",
+    is_flag=True,
+    default=False,
+    help="Prefix each line with its timestamp.",
+)
+@click.option(
+    "--path",
+    "-p",
+    type=click.Path(
+        exists=False,
+        file_okay=True,
+        dir_okay=True,
+        writable=True,
+        readable=True,
+        resolve_path=True,
+    ),
+    default=None,
+    help=(
+        "Save the log to a local file instead of printing it. Directory or full"
+        " filename accepted."
+    ),
+)
+def log(name, service, replica, tail, timestamps, path):
+    """
+    Gets the current log of one replica of a Dynamo deployment.
+
+    This returns a snapshot (the last N lines) rather than a stream. For
+    historical, time-scoped logs use `lep log get --dynamo <name>`.
+    """
+    client = APIClient()
+    if not replica:
+        service, replica = _pick_replica(client, name, service)
+        console.print(
+            f"Replica not specified; selected replica [green]{replica}[/] of service"
+            f" [green]{service}[/]."
+        )
+    resp = client.dynamo.get_replica_log(
+        name, replica, service=service, tail=tail, timestamps=timestamps
+    )
+    text = resp.logs or ""
+    if path:
+        try:
+            save_path = resolve_save_path(path, f"dynamo-log-{name}-{replica}.txt")
+        except PathResolutionError as e:
+            console.print(f"[red]Failed to save log: {e}[/]")
+            sys.exit(1)
+        with open(save_path, "w", encoding="utf-8") as f:
+            f.write(text)
+        console.print(f"Log saved to [green]{save_path}[/].")
+        return
+    if text:
+        console.print(
+            text, markup=False, highlight=False, end="" if text.endswith("\n") else "\n"
+        )
+    else:
+        console.print("[yellow](empty log)[/]")
+    console.print(
+        "[bright_black]Snapshot only. Use `--tail N` for more lines or"
+        f" `lep log get --dynamo {name} --replica {replica}` for historical logs.[/]"
+    )
+
+
+@dynamo.command(name="remove-replica")
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option(
+    "--replica", "-r", help="The replica (pod) name to delete.", required=True
+)
+@click.option(
+    "--service",
+    "-s",
+    default=None,
+    help="The service the replica belongs to (verified server side when given).",
+)
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip the confirmation.")
+def remove_replica(name, replica, service, yes):
+    """
+    Deletes one replica (pod). A new replica is launched to replace it, so
+    capacity is briefly one replica short of the desired count.
+    """
+    client = APIClient()
+    _confirm(
+        f"The replica {replica!r} will immediately be deleted and a new replica will"
+        " be launched. Continue?",
+        yes,
+    )
+    resp = client.dynamo.delete_replica(name, replica, service=service)
+    console.print(
+        f"Replica [green]{resp.replica or replica}[/] of service"
+        f" [green]{resp.service or service or '-'}[/] is being deleted."
+    )
+    if resp.message:
+        console.print(resp.message)
+
+
+@dynamo.command()
+@click.option(
+    "--name", "-n", help="The Dynamo deployment name to remove.", required=True
+)
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip the confirmation.")
+def remove(name, yes):
+    """
+    Removes a Dynamo deployment.
+    """
+    client = APIClient()
+    _confirm(f"Are you sure to delete the Dynamo deployment {name!r}?", yes)
+    client.dynamo.delete(name)
+    console.print(f"Deletion request has been sent for [green]{name}[/].")
+
+
+# ---------------------------------------------------------------------------
+# history / metrics
+# ---------------------------------------------------------------------------
+
+
+@dynamo.command()
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+def history(name):
+    """
+    Shows the recorded history (creation and updates) of a Dynamo deployment.
+    """
+    client = APIClient()
+    items = client.dynamo.get_history(name)
+    if not items:
+        console.print(f"No history recorded for [yellow]{name}[/].")
+        return
+    table = Table(show_lines=False)
+    table.add_column("Time")
+    table.add_column("Operation")
+    table.add_column("Description")
+    for item in items:
+        table.add_row(
+            _fmt_ts(item.timestamp), item.operation or "-", item.description or "-"
+        )
+    console.print(table)
+
+
+def _summarize_series(series: Any) -> List[Tuple[str, str, str, str, str, int, str]]:
+    """Reduce ``[{metric, values}]`` to per-series latest/min/avg/max rows."""
+    rows = []
+    if not isinstance(series, list):
+        return rows
+    for entry in series:
+        if not isinstance(entry, dict):
+            continue
+        metric = entry.get("metric") or {}
+        values = []
+        last_ts = None
+        for point in entry.get("values") or []:
+            if not isinstance(point, (list, tuple)) or len(point) != 2:
+                continue
+            ts, raw = point
+            if raw is None:
+                continue
+            try:
+                values.append(float(raw))
+                last_ts = ts
+            except (TypeError, ValueError):
+                continue
+        if not values:
+            continue
+        latest = values[-1]
+        rows.append((
+            str(metric.get("name") or "-"),
+            str(metric.get("device") or "-"),
+            f"{latest:.4g}",
+            f"{min(values):.4g}",
+            f"{sum(values) / len(values):.4g}",
+            f"{max(values):.4g}",
+            len(values),
+            _fmt_ts(int(float(last_ts) * 1000)) if last_ts is not None else "-",
+        ))
+    return rows
+
+
+@dynamo.command()
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option(
+    "--replica",
+    "-r",
+    default=None,
+    help=(
+        "Show replica-level metrics for this replica instead of deployment-level ones."
+    ),
+)
+@click.option(
+    "--metric",
+    "-m",
+    multiple=True,
+    help=(
+        "Metric name(s) to fetch. Defaults to the dashboard set:"
+        f" {', '.join(DEPLOYMENT_METRICS)} at deployment level and"
+        f" {', '.join(REPLICA_METRICS)} at replica level."
+    ),
+)
+@click.option(
+    "--window",
+    type=click.Choice(METRIC_WINDOWS),
+    default="1",
+    show_default=True,
+    help="Time window in hours (deployment-level metrics only).",
+)
+def metrics(name, replica, metric, window):
+    """
+    Prints a summary (latest, min, avg, max) of GPU and resource metrics.
+    """
+    client = APIClient()
+    names = (
+        list(metric)
+        if metric
+        else list(REPLICA_METRICS if replica else DEPLOYMENT_METRICS)
+    )
+    table = Table(
+        title=f"Metrics for {name}"
+        + (f" / {replica}" if replica else f" (last {window}h)"),
+        show_lines=False,
+    )
+    for column in (
+        "Metric",
+        "Series",
+        "Device",
+        "Latest",
+        "Min",
+        "Avg",
+        "Max",
+        "Samples",
+        "Last Seen",
+    ):
+        table.add_column(column)
+    row_count = 0
+    for metric_name in names:
+        try:
+            if replica:
+                series = client.dynamo.get_replica_metric(name, replica, metric_name)
+            else:
+                series = client.dynamo.get_metric(name, metric_name, window=int(window))
+        except ClientError as e:
+            status_code = getattr(getattr(e, "response", None), "status_code", None)
+            if status_code == 404:
+                continue  # the dashboard hides panels whose metric is unavailable
+            table.add_row(
+                metric_name,
+                "-",
+                "-",
+                f"[red]error {status_code}[/]",
+                "-",
+                "-",
+                "-",
+                "-",
+                "-",
+            )
+            row_count += 1
+            continue
+        except ServerError:
+            table.add_row(
+                metric_name, "-", "-", "[yellow]unavailable[/]", "-", "-", "-", "-", "-"
+            )
+            row_count += 1
+            continue
+        rows = _summarize_series(series)
+        if not rows:
+            table.add_row(
+                metric_name,
+                "-",
+                "-",
+                "[bright_black]no data[/]",
+                "-",
+                "-",
+                "-",
+                "0",
+                "-",
+            )
+            row_count += 1
+            continue
+        for series_name, device, latest, min_, avg, max_, samples, last_seen in rows:
+            table.add_row(
+                metric_name,
+                series_name,
+                device,
+                latest,
+                min_,
+                avg,
+                max_,
+                str(samples),
+                last_seen,
+            )
+            row_count += 1
+    if not row_count:
+        console.print(f"No metrics available for [yellow]{name}[/].")
+        return
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+_SERVICE_BLOCK_FLAGS = {
+    "--resource-shape": "resource_shape",
+    "--node-group": "node_group",
+    "--replicas": "replicas",
+    "--node-count": "node_count",
+    "--image": "image",
+    "--working-dir": "working_dir",
+    "--command": "command",
+    "--env": "env",
+    "-e": "env",
+    "--secret": "secret",
+    "-s": "secret",
+    "--mount": "mount",
+    "--annotation": "annotation",
+    "--label": "label",
+    "--shared-memory-size": "shared_memory_size",
+    "--termination-grace-period": "termination_grace_period",
+}
+_SERVICE_BLOCK_LIST_FIELDS = (
+    "node_group",
+    "env",
+    "secret",
+    "mount",
+    "annotation",
+    "label",
+)
+
+_SERVICE_BLOCK_HELP = """\
+Service blocks (-svc/--service TYPE)
+  Define services by repeating `-svc TYPE` followed by per-service flags. TYPE is
+  one of: frontend, worker (aggregated mode), prefill-worker, decode-worker
+  (disaggregated mode). Global options (--framework, --serving-mode, -e/-s for
+  shared envs, ...) must come before the first -svc block; inside a block, -e/-s
+  set per-service envs. Example:
+
+    lep dynamo create -n my-llm --framework vllm \\
+      -svc frontend --resource-shape cpu.small --node-group my-ng \\
+      -svc worker --resource-shape gpu.h100-80gb --replicas 2 \\
+        -e MODEL=Qwen/Qwen3-0.6B -s HF_TOKEN
+
+  Rules (same as the dashboard):
+    - frontend is required; workers inherit the frontend's node group.
+    - vLLM only supports aggregated mode.
+    - --node-count (multinode) is only available for SGLang workers.
+    - image, working dir and command default to the official Dynamo runtime for
+      the chosen framework/version; override them only if you know the server
+      accepts the value.
+    - prefill/decode workers get the label lepton.ai/dynamo-worker-role.
+
+  Per-service flags:
+    --resource-shape TEXT          REQUIRED for new services.
+    --node-group TEXT              Dedicated node group (name or id). Frontend only;
+                                   workers inherit it.
+    --replicas INTEGER             Replica count (default 1, >= 1).
+    --node-count INTEGER           Multinode node count (>= 2, SGLang workers only).
+    --image TEXT                   Container image (default: official runtime image).
+    --working-dir TEXT             Container working directory.
+    --command TEXT                 Run command, executed via `/bin/sh -c`.
+    --env, -e NAME=VALUE           Repeatable. Per-service environment variables.
+    --secret, -s NAME[=SECRET]     Repeatable. Secret injected as env var NAME.
+    --mount FROM_PATH:MOUNT_PATH:VOLUME
+                                   Repeatable. VOLUME is `node-local` or
+                                   `node-<type>:<storage_name>` (e.g. node-nfs:my-nfs).
+    --annotation KEY=VALUE         Repeatable. Pod annotations.
+    --label KEY=VALUE              Repeatable. Pod labels.
+    --shared-memory-size INTEGER   Shared memory (/dev/shm) in MiB.
+    --termination-grace-period INTEGER
+                                   Pod termination grace period in seconds."""
+
+ServiceBlockCommand = make_block_option_command(
+    markers=("-svc", "--service"),
+    flags=_SERVICE_BLOCK_FLAGS,
+    list_fields=_SERVICE_BLOCK_LIST_FIELDS,
+    param_name="service_blocks",
+    help_text=_SERVICE_BLOCK_HELP,
+)
+
+_UPDATE_SERVICE_BLOCK_HELP = """\
+Service blocks (-svc/--service NAME)
+  Update or add services by repeating `-svc NAME` followed by per-service flags.
+  Existing services keep every value you do not mention. A NAME that does not
+  exist yet is added (it requires --resource-shape; the node group is inherited
+  from the frontend). Example:
+
+    lep dynamo update -n my-llm -svc worker --replicas 4 --command "python3 -m dynamo.vllm --model Qwen/Qwen3-8B"
+    lep dynamo update -n my-llm -svc worker --remove
+
+  Per-service flags: the same as `lep dynamo create` (--resource-shape,
+  --node-group (frontend only), --replicas, --node-count (only if the service is
+  already multinode), --image, --working-dir, --command, -e/--env, -s/--secret,
+  --mount, --annotation, --label, --shared-memory-size,
+  --termination-grace-period) plus:
+    --remove                       Delete this service from the deployment.
+    --clear-working-dir            Reset the working dir (frontend: /workspace,
+                                   workers: image default)."""
+
+UpdateServiceBlockCommand = make_block_option_command(
+    markers=("-svc", "--service"),
+    flags={
+        **_SERVICE_BLOCK_FLAGS,
+        "--remove": "remove",
+        "--clear-working-dir": "clear_working_dir",
+    },
+    list_fields=_SERVICE_BLOCK_LIST_FIELDS,
+    bool_flags=("remove", "clear_working_dir"),
+    param_name="service_blocks",
+    help_text=_UPDATE_SERVICE_BLOCK_HELP,
+)
+
+
+@dynamo.command(cls=ServiceBlockCommand)
+@click.option(
+    "--name", "-n", type=str, help="Name of the Dynamo deployment.", required=True
+)
+@click.option(
+    "--file",
+    "-f",
+    type=click.Path(
+        exists=False, file_okay=True, dir_okay=False, readable=True, resolve_path=True
+    ),
+    help=(
+        "Load the deployment spec from this JSON file (as written by `lep dynamo get"
+        " -p`) before applying CLI overrides."
+    ),
+    required=False,
+)
+@click.option(
+    "--framework",
+    type=click.Choice(DYNAMO_FRAMEWORKS),
+    default=None,
+    help="Backend framework. Default: vllm (or the value in --file).",
+)
+@click.option(
+    "--serving-mode",
+    type=click.Choice(DYNAMO_SERVING_MODES),
+    default=None,
+    help=(
+        "aggregated (frontend + worker) or disaggregated (frontend + prefill-worker +"
+        " decode-worker). Default: aggregated (or derived from --file)."
+    ),
+)
+@click.option(
+    "--dynamo-version",
+    type=str,
+    default=None,
+    help=(
+        "Dynamo version; drives image tags and default commands. Default:"
+        f" {DYNAMO_VERSION}."
+    ),
+)
+@click.option(
+    "--ingress-enabled/--no-ingress",
+    "ingress_enabled",
+    default=None,
+    help="Create an ingress for the frontend service. Default: enabled.",
+)
+@click.option(
+    "--ingress-timeout",
+    type=int,
+    default=None,
+    help="Ingress request timeout in seconds (300-3600; server default 300).",
+)
+@click.option(
+    "--display-name", type=str, default=None, help="Human-friendly display name."
+)
+@click.option(
+    "--env",
+    "-e",
+    multiple=True,
+    help="Shared environment variables for all services, as `NAME=VALUE`. Repeatable.",
+)
+@click.option(
+    "--secret",
+    "-s",
+    multiple=True,
+    help=(
+        "Shared secrets for all services, as `NAME=SECRET_NAME` (or just"
+        " `SECRET_NAME`). Repeatable."
+    ),
+)
+@click.option(
+    "--image-pull-secrets",
+    type=str,
+    multiple=True,
+    help="Secrets to use for pulling images, applied to every service. Repeatable.",
+)
+@click.option(
+    "--visibility",
+    type=click.Choice(["public", "private"]),
+    default=None,
+    help=(
+        "Visibility of the deployment. Private deployments are only visible to the"
+        " creator and admins."
+    ),
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the request payload instead of creating the deployment.",
+)
+def create(
+    name,
+    file,
+    framework,
+    serving_mode,
+    dynamo_version,
+    ingress_enabled,
+    ingress_timeout,
+    display_name,
+    env,
+    secret,
+    image_pull_secrets,
+    visibility,
+    dry_run,
+    service_blocks,
+):
+    """
+    Creates a Dynamo deployment from CLI flags and/or a spec file.
+
+    The frontend service is required; add workers with additional -svc blocks.
+    Run `lep dynamo create --help` for the per-service flags and rules.
+    """
+    validate_dynamo_name(name)
+    client = APIClient()
+
+    base = _load_user_spec_file(file) if file else None
+    effective_framework = (
+        framework or (base.backend_framework if base else None) or "vllm"
+    )
+    inputs = [
+        _service_input_from_block(block, client, framework=effective_framework)
+        for block in service_blocks
+    ]
+
+    spec = build_dynamo_spec(
+        services=inputs,
+        framework=framework,
+        serving_mode=serving_mode,
+        dynamo_version=dynamo_version,
+        ingress_enabled=ingress_enabled,
+        ingress_timeout_seconds=ingress_timeout,
+        display_name=display_name,
+        envs=env,
+        secrets=secret,
+        image_pull_secrets=image_pull_secrets or None,
+        base=base,
+    )
+    for svc_name, svc_spec in (spec.services or {}).items():
+        _warn_if_unofficial_image(svc_name, svc_spec, spec.backend_framework)
+
+    metadata_kwargs: Dict[str, Any] = {"name": name}
+    if visibility:
+        metadata_kwargs["visibility"] = LeptonVisibility(visibility)
+    dep = LeptonDynamoGraphDeployment(metadata=Metadata(**metadata_kwargs), spec=spec)
+
+    if dry_run:
+        console.print(
+            json.dumps(client.dynamo.safe_json(dep), indent=2),
+            markup=False,
+            highlight=False,
+        )
+        return
+
+    created = client.dynamo.create(dep)
+    created_name = (created.metadata.name if created.metadata else None) or name
+    console.print(f"Dynamo deployment [green]{created_name}[/] created successfully.")
+    console.print(
+        f"Use `lep dynamo status -n {created_name}` to check its status, or"
+        f" `lep dynamo log -n {created_name}` to read replica logs."
+    )
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+def _load_patch_file(path: str) -> Dict[str, Any]:
+    payload = _load_json_file(path, "merge patch")
+    if not isinstance(payload, dict):
+        console.print(f"[red]The merge patch in {path} must be a JSON object.[/]")
+        sys.exit(1)
+    if "spec" not in payload:
+        payload = {"spec": payload}
+    return payload
+
+
+@dynamo.command(cls=UpdateServiceBlockCommand)
+@click.option(
+    "--name", "-n", help="The Dynamo deployment name to update.", required=True
+)
+@click.option("--display-name", type=str, default=None, help="New display name.")
+@click.option(
+    "--ingress-enabled/--no-ingress",
+    "ingress_enabled",
+    default=None,
+    help="Enable or disable the frontend ingress.",
+)
+@click.option(
+    "--ingress-timeout",
+    type=int,
+    default=None,
+    help="Ingress request timeout in seconds (300-3600).",
+)
+@click.option(
+    "--env",
+    "-e",
+    multiple=True,
+    help=(
+        "Replace the shared environment variables (`NAME=VALUE`). Repeatable; the"
+        " full list is replaced, not merged."
+    ),
+)
+@click.option(
+    "--secret",
+    "-s",
+    multiple=True,
+    help=(
+        "Replace the shared secrets (`NAME=SECRET_NAME`). Repeatable; used together"
+        " with --env."
+    ),
+)
+@click.option(
+    "--file",
+    "-f",
+    type=click.Path(
+        exists=False, file_okay=True, dir_okay=False, readable=True, resolve_path=True
+    ),
+    default=None,
+    help=(
+        'A raw RFC 7396 merge patch JSON ({"spec": {...}}) applied on top of the'
+        " flag-derived patch. Use it for fields the flags do not cover."
+    ),
+)
+@click.option(
+    "--dryrun",
+    "--dry-run",
+    "dryrun",
+    is_flag=True,
+    default=False,
+    help=(
+        "Ask the server to validate the patch without persisting it, and print the"
+        " patch."
+    ),
+)
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip the confirmation.")
+def update(
+    name,
+    display_name,
+    ingress_enabled,
+    ingress_timeout,
+    env,
+    secret,
+    file,
+    dryrun,
+    yes,
+    service_blocks,
+):
+    """
+    Updates a Dynamo deployment with a JSON Merge Patch built from the given
+    flags. Only the fields you mention change; service changes may restart
+    replicas and therefore ask for confirmation.
+    """
+    client = APIClient()
+    current = client.dynamo.get(name)
+    if current.spec is None:
+        console.print(f"[red]Dynamo deployment {name!r} has no spec to update.[/]")
+        sys.exit(1)
+    original = current.spec
+    desired = original.model_copy(deep=True)
+    desired.services = dict(desired.services or {})
+    framework = desired.backend_framework or "vllm"
+    serving_mode = serving_mode_from_services(list(desired.services))
+
+    if display_name is not None:
+        desired.display_name = display_name
+    if ingress_enabled is not None:
+        desired.ingress_enabled = ingress_enabled
+    if ingress_timeout is not None:
+        desired.ingress_timeout_seconds = validate_ingress_timeout(ingress_timeout)
+    if env or secret:
+        desired.envs = make_env_vars_from_strings(list(env), list(secret))
+
+    for block in service_blocks:
+        svc_name = block["key"]
+        existing = desired.services.get(svc_name)
+        if block.get("remove"):
+            if svc_name == DYNAMO_FRONTEND_SERVICE:
+                raise ValueError("The frontend service cannot be removed.")
+            if existing is None:
+                raise ValueError(
+                    f"Service {svc_name!r} does not exist in {name!r}; nothing to"
+                    " remove."
+                )
+            del desired.services[svc_name]
+            continue
+
+        svc_input = _service_input_from_block(block, client, framework=framework)
+        if existing is not None:
+            if svc_input.node_count is not None and existing.multinode is None:
+                raise ValueError(
+                    f"service {svc_name}: cannot add multinode configuration to"
+                    " existing service"
+                )
+            if (
+                svc_input.node_groups is not None
+                and svc_name != DYNAMO_FRONTEND_SERVICE
+            ):
+                raise ValueError(
+                    "Worker node groups are automatically synchronized with the"
+                    " frontend service; change the node group on the frontend instead."
+                )
+            new_spec = build_service_spec(
+                svc_input,
+                framework=framework,
+                serving_mode=serving_mode,
+                dynamo_version=desired.dynamo_version,
+                frontend_node_groups=None,
+                base=existing,
+                fill_defaults=False,
+            )
+            if block.get("clear_working_dir"):
+                container = _main_container(new_spec)
+                if container is not None:
+                    container.working_dir = (
+                        "/workspace" if svc_name == DYNAMO_FRONTEND_SERVICE else None
+                    )
+        else:
+            if svc_name not in DYNAMO_SERVICE_NAMES:
+                raise ValueError(
+                    f"Unknown Dynamo service {svc_name!r}. Expected one of:"
+                    f" {', '.join(DYNAMO_SERVICE_NAMES)}."
+                )
+            new_spec = build_service_spec(
+                svc_input,
+                framework=framework,
+                serving_mode=serving_mode,
+                dynamo_version=desired.dynamo_version,
+                frontend_node_groups=frontend_node_groups_of(desired),
+                base=None,
+            )
+        desired.services[svc_name] = new_spec
+
+    # Workers always follow the frontend node group (dashboard rule).
+    frontend_groups = frontend_node_groups_of(desired)
+    if frontend_groups:
+        for svc_name, svc_spec in desired.services.items():
+            if svc_name == DYNAMO_FRONTEND_SERVICE:
+                continue
+            if svc_spec.affinity is None:
+                continue
+            if svc_spec.affinity.allowed_dedicated_node_groups != list(frontend_groups):
+                svc_spec.affinity.allowed_dedicated_node_groups = list(frontend_groups)
+
+    spec_patch = build_merge_patch(spec_to_dict(original), spec_to_dict(desired))
+    patch: Dict[str, Any] = {"spec": spec_patch} if spec_patch else {}
+    if file:
+        patch = deep_merge_patch(patch, _load_patch_file(file))
+
+    if not patch.get("spec"):
+        console.print("No changes detected.")
+        return
+
+    if dryrun:
+        console.print("Merge patch:")
+        console.print(json.dumps(patch, indent=2), markup=False, highlight=False)
+    elif "services" in patch["spec"]:
+        _confirm(
+            "This update changes services and may restart running replicas of"
+            f" {name!r}. Continue?",
+            yes,
+        )
+
+    result = client.dynamo.update(name, patch, dryrun=dryrun)
+    if dryrun:
+        console.print(
+            "[green]The server validated the patch (dry run; nothing was persisted).[/]"
+        )
+        preview = apply_merge_patch(spec_to_dict(original), patch.get("spec", {}))
+        console.print(Pretty(preview))
+        return
+    result_name = (result.metadata.name if result.metadata else None) or name
+    console.print(f"Dynamo deployment [green]{result_name}[/] updated successfully.")
+
+
+def add_command(cli_group):
+    cli_group.add_command(dynamo)

--- a/leptonai/cli/dynamo.py
+++ b/leptonai/cli/dynamo.py
@@ -704,13 +704,19 @@ def status(name, detail):
 
 
 # ---------------------------------------------------------------------------
-# services / service / restart
+# service commands
 # ---------------------------------------------------------------------------
 
 
-@dynamo.command()
+@dynamo.group(name="service")
+def service_group():
+    """Manage services in a Dynamo deployment."""
+    pass
+
+
+@service_group.command(name="list")
 @click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
-def services(name):
+def list_services(name):
     """
     Lists the services of a Dynamo deployment with their replica counts.
     """
@@ -727,13 +733,13 @@ def services(name):
     console.print(_services_table(dep, infos))
 
 
-@dynamo.command()
+@service_group.command(name="get")
 @click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
 @click.option("--service", "-s", help="The service name.", required=True)
 @click.option(
     "--detail", "-d", is_flag=True, default=False, help="Also dump the raw response."
 )
-def service(name, service, detail):
+def get_service(name, service, detail):
     """
     Shows one service of a Dynamo deployment: spec, runtime status, and run command.
     """
@@ -835,11 +841,11 @@ def service(name, service, detail):
         )
 
 
-@dynamo.command()
+@service_group.command(name="restart")
 @click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
 @click.option("--service", "-s", help="The service to restart.", required=True)
 @click.option("--yes", "-y", is_flag=True, default=False, help="Skip the confirmation.")
-def restart(name, service, yes):
+def restart_service(name, service, yes):
     """
     Restarts a service by deleting all of its replicas (pods); the operator
     launches replacements.
@@ -875,11 +881,17 @@ def restart(name, service, yes):
 
 
 # ---------------------------------------------------------------------------
-# replicas / log / remove-replica / remove
+# replica commands / remove
 # ---------------------------------------------------------------------------
 
 
-@dynamo.command()
+@dynamo.group(name="replica")
+def replica_group():
+    """Manage replicas in a Dynamo deployment."""
+    pass
+
+
+@replica_group.command(name="list")
 @click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
 @click.option(
     "--service",
@@ -895,7 +907,7 @@ def restart(name, service, yes):
         " Terminated. Case-insensitive; can be repeated."
     ),
 )
-def replicas(name, service, state):
+def list_replicas(name, service, state):
     """
     Lists the replicas (pods) of a Dynamo deployment, per service.
     """
@@ -954,7 +966,7 @@ def _pick_replica(
     return service, replica
 
 
-@dynamo.command()
+@replica_group.command(name="log")
 @click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
 @click.option(
     "--service",
@@ -1000,7 +1012,7 @@ def _pick_replica(
         " filename accepted."
     ),
 )
-def log(name, service, replica, tail, timestamps, path):
+def replica_log(name, service, replica, tail, timestamps, path):
     """
     Gets the current log of one replica of a Dynamo deployment.
 
@@ -1040,7 +1052,7 @@ def log(name, service, replica, tail, timestamps, path):
     )
 
 
-@dynamo.command(name="remove-replica")
+@replica_group.command(name="remove")
 @click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
 @click.option(
     "--replica", "-r", help="The replica (pod) name to delete.", required=True
@@ -1152,37 +1164,8 @@ def _summarize_series(series: Any) -> List[Tuple[str, str, str, str, str, int, s
     return rows
 
 
-@dynamo.command()
-@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
-@click.option(
-    "--replica",
-    "-r",
-    default=None,
-    help=(
-        "Show replica-level metrics for this replica instead of deployment-level ones."
-    ),
-)
-@click.option(
-    "--metric",
-    "-m",
-    multiple=True,
-    help=(
-        "Metric name(s) to fetch. Defaults to the dashboard set:"
-        f" {', '.join(DEPLOYMENT_METRICS)} at deployment level and"
-        f" {', '.join(REPLICA_METRICS)} at replica level."
-    ),
-)
-@click.option(
-    "--window",
-    type=click.Choice(METRIC_WINDOWS),
-    default="1",
-    show_default=True,
-    help="Time window in hours (deployment-level metrics only).",
-)
-def metrics(name, replica, metric, window):
-    """
-    Prints a summary (latest, min, avg, max) of GPU and resource metrics.
-    """
+def _print_metrics(name, replica, metric, window):
+    """Print deployment- or replica-level metrics using the shared table format."""
     client = APIClient()
     names = (
         list(metric)
@@ -1268,6 +1251,46 @@ def metrics(name, replica, metric, window):
         console.print(f"No metrics available for [yellow]{name}[/].")
         return
     console.print(table)
+
+
+@dynamo.command(name="metrics")
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option(
+    "--metric",
+    "-m",
+    multiple=True,
+    help=(
+        "Metric name(s) to fetch. Defaults to the dashboard set:"
+        f" {', '.join(DEPLOYMENT_METRICS)}."
+    ),
+)
+@click.option(
+    "--window",
+    type=click.Choice(METRIC_WINDOWS),
+    default="1",
+    show_default=True,
+    help="Time window in hours.",
+)
+def deployment_metrics(name, metric, window):
+    """Prints deployment-level GPU and resource metrics."""
+    _print_metrics(name, replica=None, metric=metric, window=window)
+
+
+@replica_group.command(name="metrics")
+@click.option("--name", "-n", help="The Dynamo deployment name.", required=True)
+@click.option("--replica", "-r", help="The replica (pod) name.", required=True)
+@click.option(
+    "--metric",
+    "-m",
+    multiple=True,
+    help=(
+        "Metric name(s) to fetch. Defaults to the dashboard set:"
+        f" {', '.join(REPLICA_METRICS)}."
+    ),
+)
+def replica_metrics(name, replica, metric):
+    """Prints GPU and resource metrics for one replica."""
+    _print_metrics(name, replica=replica, metric=metric, window=None)
 
 
 # ---------------------------------------------------------------------------
@@ -1543,7 +1566,7 @@ def create(
     console.print(f"Dynamo deployment [green]{created_name}[/] created successfully.")
     console.print(
         f"Use `lep dynamo status -n {created_name}` to check its status, or"
-        f" `lep dynamo log -n {created_name}` to read replica logs."
+        f" `lep dynamo replica log -n {created_name}` to read replica logs."
     )
 
 

--- a/leptonai/cli/log.py
+++ b/leptonai/cli/log.py
@@ -195,6 +195,8 @@ def fetch_all_within_time_slot(
     time_start,
     time_end,
     cur_log_result,
+    dynamo=None,
+    dynamo_service=None,
 ):
     client = APIClient()
     while time_end >= time_start:
@@ -212,6 +214,8 @@ def fetch_all_within_time_slot(
                     end=time_end,
                     limit=10000,
                     q=query,
+                    name_or_dynamo=dynamo,
+                    dynamo_service=dynamo_service,
                 )
                 break
             except Exception as e:
@@ -304,6 +308,23 @@ def log():
     ),
 )
 @click.option(
+    "--dynamo",
+    "-dn",
+    type=str,
+    default=None,
+    help=(
+        "The name of a Dynamo deployment. Combine with --dynamo-service and/or"
+        " --replica to narrow the scope. Historical Dynamo logs may require an"
+        " enterprise workspace tier."
+    ),
+)
+@click.option(
+    "--dynamo-service",
+    type=str,
+    default=None,
+    help="Only logs of this Dynamo service (requires --dynamo).",
+)
+@click.option(
     "--replica",
     type=str,
     default=None,
@@ -377,6 +398,8 @@ def log_command(
     deployment,
     job,
     job_name,
+    dynamo,
+    dynamo_service,
     replica,
     job_history_name,
     start,
@@ -429,24 +452,35 @@ def log_command(
 
     # Save logs to file
     lep log get -d my-deployment --start "today 09:00" --end now --path ./logs/
+
+    # Get logs from one service of a Dynamo deployment
+    lep log get --dynamo my-dynamo --dynamo-service frontend --start "today 09:00" --end now
     """
 
     if (
         not deployment
         and not job
         and not job_name
+        and not dynamo
         and not replica
         and not job_history_name
     ):
         console.print(
-            "[red]No deployment name, job id, job name or replica id provided.[/red]"
+            "[red]No deployment name, job id, job name, dynamo deployment name or"
+            " replica id provided.[/red]"
         )
         sys.exit(1)
 
-    if sum(bool(var) for var in [deployment, job, job_name, job_history_name]) > 1:
+    if (
+        sum(bool(var) for var in [deployment, job, job_name, job_history_name, dynamo])
+        > 1
+    ):
         raise ValueError(
-            "Only one of 'deployment', 'job', or 'job_history_name' can be specified."
+            "Only one of 'deployment', 'job', 'job_history_name' or 'dynamo' can be"
+            " specified."
         )
+    if dynamo_service and not dynamo:
+        raise ValueError("--dynamo-service requires --dynamo.")
 
     client = APIClient()
 
@@ -463,6 +497,28 @@ def log_command(
         client.deployment.get(deployment)
     if job and not job_name:
         client.job.get(job)
+    if dynamo:
+        dynamo_obj = client.dynamo.get(dynamo)
+        dynamo_services = list(
+            (dynamo_obj.spec.services if dynamo_obj.spec else None) or {}
+        )
+        if dynamo_service and dynamo_services and dynamo_service not in dynamo_services:
+            console.print(
+                f"[bold red]Warning:[/bold red] No service named '{dynamo_service}'"
+                f" found for {dynamo}. Available services:"
+                f" {', '.join(dynamo_services)}."
+            )
+            sys.exit(1)
+        if replica:
+            dynamo_replicas = client.dynamo.list_replicas(
+                dynamo, service=dynamo_service
+            )
+            if replica not in [r.metadata.id_ for r in dynamo_replicas]:
+                console.print(
+                    f"[bold red]Warning:[/bold red] No replica named '{replica}' found"
+                    f" for {dynamo}."
+                )
+                sys.exit(1)
 
     if (job or deployment) and replica:
         replicas = (
@@ -506,6 +562,8 @@ def log_command(
             end=unix_end_probe,
             limit=1,
             q=query,
+            name_or_dynamo=dynamo,
+            dynamo_service=dynamo_service,
         )
         if not probe or not probe.get("data", {}).get("result"):
             console.print("[yellow]No logs found in the specified time range.[/]")
@@ -537,7 +595,7 @@ def log_command(
             # Resolve save path early before starting progress/executor
             if path:
                 default_filename = (
-                    f"log-{job or deployment or replica or job_history_name or ''}{datetime.now().strftime('%Y%m%d-%H%M%S')}.txt"
+                    f"log-{job or deployment or dynamo or replica or job_history_name or ''}{datetime.now().strftime('%Y%m%d-%H%M%S')}.txt"
                 )
                 try:
                     path = resolve_save_path(path, default_filename)
@@ -570,6 +628,8 @@ def log_command(
                             time_start,
                             time_end,
                             log_list[index],
+                            dynamo,
+                            dynamo_service,
                         )
                         futures.append(future)
                         future_to_index[future] = index
@@ -674,6 +734,8 @@ def log_command(
                     end=cur_unix_end,
                     limit=cur_limit if cur_limit < 10000 else 10000,
                     q=query,
+                    name_or_dynamo=dynamo,
+                    dynamo_service=dynamo_service,
                 )
                 lines = log_dict["data"]["result"]
 
@@ -704,7 +766,7 @@ def log_command(
     def fetch_and_print_logs(start, end, limit, path=None):
         if path and limit is not None:
             default_filename = (
-                f"log-{job or deployment or replica or job_history_name or ''}{datetime.now().strftime('%Y%m%d-%H%M%S')}.txt"
+                f"log-{job or deployment or dynamo or replica or job_history_name or ''}{datetime.now().strftime('%Y%m%d-%H%M%S')}.txt"
             )
             try:
                 path = resolve_save_path(path, default_filename)

--- a/leptonai/cli/tests/test_dynamo_cli.py
+++ b/leptonai/cli/tests/test_dynamo_cli.py
@@ -1,0 +1,1078 @@
+"""CLI tests for `lep dynamo`, driven through CliRunner with a fake API client."""
+
+import json
+import os
+import tempfile
+
+# Set cache dir to a temp dir before importing anything from leptonai
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+import pytest
+from click.testing import CliRunner
+
+from leptonai.api.v2.api_resource import ClientError
+from leptonai.api.v2.types.common import Metadata
+from leptonai.api.v2.types.dedicated_node_group import (
+    DedicatedNodeGroup,
+    DedicatedNodeGroupSpec,
+    DedicatedNodeGroupStatus,
+)
+from leptonai.api.v2.types.dynamo import (
+    DYNAMO_WORKER_ROLE_LABEL_KEY,
+    DynamoHistoryItem,
+    DynamoMonitoringStatusResponse,
+    DynamoReplica,
+    DynamoReplicaDeleteResponse,
+    DynamoReplicaLogResponse,
+    DynamoServiceReplicasResponse,
+    DynamoServiceResponse,
+    DynamoServiceRestartResponse,
+    DynamoServicesResponse,
+    LeptonDynamoGraphDeployment,
+    LeptonDynamoGraphDeploymentUserSpec,
+)
+from leptonai.api.v2.types.shape import Shape, ShapeSpec
+from leptonai.cli import lep as cli
+from leptonai.cli.dynamo import console as dynamo_console
+
+VLLM_IMAGE = "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.1"
+
+
+class _FakeResponse:
+    def __init__(self, status_code, text):
+        self.status_code = status_code
+        self.text = text
+
+
+def _not_found(what):
+    return ClientError(_FakeResponse(404, f'{{"message": "{what} not found"}}'))
+
+
+def _service_spec(component_type, shape, replicas, command, working_dir, labels=None):
+    return {
+        "component_type": component_type,
+        "resource_shape": shape,
+        "min_replicas": replicas,
+        "max_replicas": replicas,
+        "affinity": {"allowed_dedicated_node_groups": ["ng-1"]},
+        "extra_pod_spec": {
+            "main_container": {
+                "image": VLLM_IMAGE,
+                "working_dir": working_dir,
+                "command": ["/bin/sh", "-c", command],
+            }
+        },
+        "extra_pod_metadata": {"annotations": {}, "labels": labels or {}},
+    }
+
+
+def _deployment(name, services=None, state="Ready", created_by="alice"):
+    if services is None:
+        services = {
+            "frontend": _service_spec(
+                "frontend", "cpu.small", 1, "python3 -m dynamo.frontend", "/workspace"
+            ),
+            "worker": _service_spec(
+                "worker",
+                "gpu.a100-1",
+                2,
+                "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B",
+                "/workspace/examples/backends/vllm",
+            ),
+        }
+    return {
+        "metadata": {
+            "id": name,
+            "name": name,
+            "created_at": 1717000000000,
+            "created_by": created_by,
+            "visibility": "private",
+        },
+        "spec": {
+            "dynamo_version": "1.3.1",
+            "backend_framework": "vllm",
+            "ingress_enabled": True,
+            "envs": [{"name": "MODEL", "value": "Qwen/Qwen3-0.6B"}],
+            "services": services,
+        },
+        "status": {
+            "state": state,
+            "services": {
+                svc: {
+                    "state": "Ready",
+                    "ready_replicas": 1,
+                    "desired_replicas": spec["min_replicas"],
+                }
+                for svc, spec in services.items()
+            },
+            "endpoint": {
+                "external_endpoint": f"https://{name}.example.com",
+                "internal_endpoint": "http://internal",
+            },
+        },
+    }
+
+
+def _replica(rid, reason="Ready", node="node-1"):
+    return {
+        "metadata": {"id": rid, "name": rid, "created_at": 1717000000000},
+        "id": rid,
+        "status": {
+            "readiness_issue": {
+                "reason": reason,
+                "message": "",
+                "creationTimestamp": "2024-01-01T00:00:00Z",
+            },
+            "node": {"name": node, "id": "n-1", "node_group_id": "ng-1"},
+        },
+    }
+
+
+class FakeDynamoAPI:
+    def __init__(self):
+        self.deployments = {}
+        self.service_infos = {}
+        self.service_details = {}
+        self.replicas = {}
+        self.logs = {}
+        self.metrics = {}
+        self.metrics_404 = set()
+        self.history_items = []
+        self.monitoring = {
+            "overall_health": "degraded",
+            "total_services": 2,
+            "healthy_services": 1,
+            "services": {"frontend": "healthy", "worker": "unhealthy"},
+        }
+        self.calls = []
+        self.created = None
+        self.updated = None
+
+    def add_deployment(self, payload):
+        dep = LeptonDynamoGraphDeployment(**payload)
+        self.deployments[payload["metadata"]["name"]] = dep
+        return dep
+
+    def _dep(self, name):
+        if name not in self.deployments:
+            raise _not_found(name)
+        return self.deployments[name]
+
+    def safe_json(self, obj):
+        return obj.model_dump(mode="json", exclude_none=True, by_alias=True)
+
+    def list_all(self):
+        return list(self.deployments.values())
+
+    def get(self, name):
+        return self._dep(name)
+
+    def create(self, dep):
+        self.created = dep
+        return dep
+
+    def update(self, name, patch, dryrun=False):
+        self._dep(name)
+        self.updated = (name, patch, dryrun)
+        return self.deployments[name]
+
+    def delete(self, name):
+        self._dep(name)
+        self.calls.append(("delete", name))
+        return True
+
+    def list_services(self, name):
+        self._dep(name)
+        return DynamoServicesResponse(services=self.service_infos.get(name, {}))
+
+    def get_service(self, name, service):
+        self._dep(name)
+        detail = self.service_details.get((name, service))
+        if detail is None:
+            raise _not_found(service)
+        return DynamoServiceResponse(**detail)
+
+    def restart_service(self, name, service):
+        self.calls.append(("restart", name, service))
+        return DynamoServiceRestartResponse(
+            message="Restart initiated", service=service, deleted_pods=["pod-1"]
+        )
+
+    def list_service_replicas(self, name, service):
+        self._dep(name)
+        return DynamoServiceReplicasResponse(
+            service=service,
+            replicas=[
+                DynamoReplica(**r) for r in self.replicas.get((name, service), [])
+            ],
+        )
+
+    def list_replicas(self, name, service=None):
+        self._dep(name)
+        items = []
+        for (dep_name, svc), replicas in self.replicas.items():
+            if dep_name == name and (service is None or svc == service):
+                items.extend(DynamoReplica(**r) for r in replicas)
+        return items
+
+    def get_replica_log(self, name, replica, service=None, tail=None, timestamps=False):
+        self.calls.append(("log", name, replica, service, tail, timestamps))
+        return DynamoReplicaLogResponse(
+            deployment=name,
+            service=service,
+            replica=replica,
+            logs=self.logs.get(replica, ""),
+        )
+
+    def delete_replica(self, name, replica, service=None):
+        self.calls.append(("delete_replica", name, replica, service))
+        return DynamoReplicaDeleteResponse(
+            message="deleting", replica=replica, service=service
+        )
+
+    def get_monitoring_status(self, name):
+        return DynamoMonitoringStatusResponse(**self.monitoring)
+
+    def get_history(self, name):
+        return [DynamoHistoryItem(**item) for item in self.history_items]
+
+    def get_metric(self, name, metric, window=None):
+        self.calls.append(("metric", name, metric, window))
+        if metric in self.metrics_404:
+            raise _not_found(metric)
+        return self.metrics.get(metric, [])
+
+    def get_replica_metric(self, name, replica, metric):
+        self.calls.append(("replica_metric", name, replica, metric))
+        if metric in self.metrics_404:
+            raise _not_found(metric)
+        return self.metrics.get(metric, [])
+
+
+class FakeNodeGroupAPI:
+    def list_all(self):
+        return [
+            DedicatedNodeGroup(
+                metadata=Metadata(id="ng-1", name="my-ng"),
+                spec=DedicatedNodeGroupSpec(),
+                status=DedicatedNodeGroupStatus(),
+            )
+        ]
+
+
+class FakeShapesAPI:
+    def list_shapes(self, node_group=None, purpose=None):
+        return [
+            Shape(
+                metadata=Metadata(id="gpu.h100-8", name="gpu.h100-8"),
+                spec=ShapeSpec(name="gpu.h100-8", accelerator_num=8),
+            )
+        ]
+
+
+class FakeAPIClient:
+    dynamo_api = None
+
+    def __init__(self, *args, **kwargs):
+        self.dynamo = FakeAPIClient.dynamo_api
+        self.nodegroup = FakeNodeGroupAPI()
+        self.shapes = FakeShapesAPI()
+
+
+@pytest.fixture
+def fake(monkeypatch):
+    api = FakeDynamoAPI()
+    api.add_deployment(_deployment("my-dynamo"))
+    api.add_deployment(
+        _deployment(
+            "solo",
+            services={
+                "frontend": _service_spec(
+                    "frontend",
+                    "cpu.small",
+                    1,
+                    "python3 -m dynamo.frontend",
+                    "/workspace",
+                )
+            },
+            state="Starting",
+            created_by="bob",
+        )
+    )
+    api.service_infos["my-dynamo"] = {
+        "frontend": {
+            "component_type": "frontend",
+            "min_replicas": 1,
+            "desired_replicas": 1,
+            "ready_replicas": 1,
+            "total_pods": 1,
+            "is_multinode": False,
+        },
+        "worker": {
+            "component_type": "worker",
+            "min_replicas": 2,
+            "desired_replicas": 2,
+            "ready_replicas": 1,
+            "total_pods": 4,
+            "is_multinode": True,
+            "node_count": 2,
+        },
+    }
+    worker_spec = api.deployments["my-dynamo"].spec.services["worker"]
+    api.service_details[("my-dynamo", "worker")] = {
+        "name": "worker",
+        "component_type": "worker",
+        "resource_shape": "gpu.a100-1",
+        "min_replicas": 2,
+        "ready_replicas": 1,
+        "desired_replicas": 2,
+        "is_multinode": True,
+        "node_count": 2,
+        "spec": worker_spec.model_dump(mode="json", exclude_none=True, by_alias=True),
+        "status": {
+            "state": "Starting",
+            "phase": "Running",
+            "health": "degraded",
+            "replicas": {"desired": 2, "ready": 1, "running": 2, "total_pods": 4},
+            "conditions": [{
+                "type": "Available",
+                "status": "False",
+                "reason": "Pending",
+                "message": "warming up",
+            }],
+        },
+    }
+    api.service_details[("my-dynamo", "idle")] = {
+        "name": "idle",
+        "component_type": "worker",
+        "min_replicas": 0,
+        "spec": {"component_type": "worker", "min_replicas": 0},
+    }
+    api.replicas[("my-dynamo", "frontend")] = [_replica("frontend-abc")]
+    api.replicas[("my-dynamo", "worker")] = [_replica("worker-xyz", "InProgress")]
+    api.logs["frontend-abc"] = "line1\nline2\n"
+    api.logs["worker-xyz"] = "worker log\n"
+    api.history_items = [
+        {"timestamp": 1717000000000, "operation": "create", "description": "created"}
+    ]
+    api.metrics = {
+        "GPUUtilAvg": [{
+            "metric": {"name": "GPUUtilAvg", "device": "0"},
+            "values": [[1717000000, "0.25"], [1717000060, "0.75"]],
+        }],
+        "GPUUtil": [{
+            "metric": {"name": "GPUUtil"},
+            "values": [[1717000000, "0.5"], [1717000060, None]],
+        }],
+    }
+    api.metrics_404 = {"GPUTempAvg", "GPUPowerConsumption"}
+
+    FakeAPIClient.dynamo_api = api
+    monkeypatch.setattr("leptonai.cli.dynamo.APIClient", FakeAPIClient)
+    monkeypatch.setattr(dynamo_console, "width", 240)
+    return api
+
+
+def run(*args, input=None):
+    return CliRunner().invoke(cli, ["dynamo", *args], input=input)
+
+
+# ---------------------------------------------------------------------------
+# read commands
+# ---------------------------------------------------------------------------
+
+
+def test_list_renders_and_filters(fake):
+    result = run("list")
+    assert result.exit_code == 0, result.output
+    assert "my-dynamo" in result.output
+    assert "solo" in result.output
+    assert "vllm" in result.output
+    assert "aggregated" in result.output
+    assert "frontend:" in result.output and "cpu.small" in result.output
+    assert "ng-1" in result.output
+
+    result = run("list", "--state", "ready")
+    assert "my-dynamo" in result.output and "solo" not in result.output
+
+    result = run("list", "--created-by", "bob")
+    assert "solo" in result.output and "my-dynamo" not in result.output
+
+    result = run("list", "-n", "nomatch")
+    assert "No Dynamo deployments found" in result.output
+
+
+def test_get_prints_json_and_saves_spec(fake, tmp_path):
+    result = run("get", "-n", "my-dynamo", "-p", str(tmp_path))
+    assert result.exit_code == 0, result.output
+    json_text = result.output.split("Dynamo deployment spec saved")[0]
+    payload = json.loads(json_text)
+    assert payload["metadata"]["name"] == "my-dynamo"
+    assert "worker" in payload["spec"]["services"]
+
+    saved = tmp_path / "dynamo-spec-my-dynamo.json"
+    assert saved.exists()
+    spec = LeptonDynamoGraphDeploymentUserSpec.model_validate_json(saved.read_text())
+    assert set(spec.services) == {"frontend", "worker"}
+
+    result = run("get", "-n", "missing")
+    assert result.exit_code == 1
+    assert "404" in result.output
+
+
+def test_status_shows_summary_services_health_and_replicas(fake):
+    result = run("status", "-n", "my-dynamo")
+    assert result.exit_code == 0, result.output
+    assert "Ready" in result.output
+    assert "Framework:   vllm" in result.output
+    assert "Mode:        aggregated" in result.output
+    assert "https://my-dynamo.example.com" in result.output
+    assert "Global envs: MODEL" in result.output
+    assert "degraded" in result.output
+    assert "1/2 services healthy" in result.output
+    assert "2 nodes" in result.output
+    assert "frontend-abc" in result.output and "worker-xyz" in result.output
+    assert "InProgress" in result.output
+    assert "1 out of 2 replicas ready" in result.output
+
+
+def test_services_and_service_detail(fake):
+    result = run("services", "-n", "my-dynamo")
+    assert result.exit_code == 0, result.output
+    assert "frontend" in result.output and "worker" in result.output
+    assert "2 nodes" in result.output
+
+    result = run("service", "-n", "my-dynamo", "-s", "worker")
+    assert result.exit_code == 0, result.output
+    assert "Shape:        gpu.a100-1" in result.output
+    assert "Multinode:    2 nodes" in result.output
+    assert "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B" in result.output
+    assert "ready 1 / desired 2" in result.output
+    assert "Available" in result.output and "warming up" in result.output
+
+    result = run("service", "-n", "my-dynamo", "-s", "nope")
+    assert result.exit_code == 1
+    assert "404" in result.output
+
+
+def test_replicas_filters(fake):
+    result = run("replicas", "-n", "my-dynamo")
+    assert result.exit_code == 0, result.output
+    assert "frontend-abc" in result.output and "worker-xyz" in result.output
+    assert "node-1" in result.output
+
+    result = run("replicas", "-n", "my-dynamo", "-s", "worker")
+    assert "worker-xyz" in result.output and "frontend-abc" not in result.output
+
+    result = run("replicas", "-n", "my-dynamo", "--state", "ready")
+    assert "frontend-abc" in result.output and "worker-xyz" not in result.output
+
+    result = run("replicas", "-n", "my-dynamo", "-s", "nope")
+    assert result.exit_code == 1
+    assert "Available services: frontend, worker" in result.output
+
+
+def test_log_selects_first_ready_replica_and_passes_options(fake):
+    result = run("log", "-n", "my-dynamo")
+    assert result.exit_code == 0, result.output
+    assert "selected replica frontend-abc of service frontend" in result.output
+    assert "line1" in result.output and "line2" in result.output
+    assert fake.calls[-1] == (
+        "log",
+        "my-dynamo",
+        "frontend-abc",
+        "frontend",
+        None,
+        False,
+    )
+
+    result = run(
+        "log", "-n", "my-dynamo", "-s", "worker", "--tail", "20", "--timestamps"
+    )
+    assert result.exit_code == 0, result.output
+    assert "worker log" in result.output
+    assert fake.calls[-1] == ("log", "my-dynamo", "worker-xyz", "worker", 20, True)
+
+    result = run("log", "-n", "my-dynamo", "-r", "frontend-abc")
+    assert result.exit_code == 0, result.output
+    assert fake.calls[-1] == ("log", "my-dynamo", "frontend-abc", None, None, False)
+
+    result = run("log", "-n", "my-dynamo", "-s", "nope")
+    assert result.exit_code == 1
+    assert "Available services" in result.output
+
+
+def test_log_saves_to_path(fake, tmp_path):
+    result = run("log", "-n", "my-dynamo", "-r", "frontend-abc", "-p", str(tmp_path))
+    assert result.exit_code == 0, result.output
+    saved = tmp_path / "dynamo-log-my-dynamo-frontend-abc.txt"
+    assert saved.read_text() == "line1\nline2\n"
+
+
+def test_restart_confirmation_and_guards(fake):
+    result = run("restart", "-n", "my-dynamo", "-s", "worker", input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert not [c for c in fake.calls if c[0] == "restart"]
+
+    result = run("restart", "-n", "my-dynamo", "-s", "worker", "-y")
+    assert result.exit_code == 0, result.output
+    assert "Restart request has been sent" in result.output
+    assert "pod-1" in result.output
+    assert ("restart", "my-dynamo", "worker") in fake.calls
+
+    result = run("restart", "-n", "my-dynamo", "-s", "idle", "-y")
+    assert result.exit_code == 1
+    assert "nothing to restart" in result.output
+
+
+def test_remove_and_remove_replica(fake):
+    result = run("remove", "-n", "my-dynamo", input="n\n")
+    assert result.exit_code == 0
+    assert ("delete", "my-dynamo") not in fake.calls
+
+    result = run("remove", "-n", "my-dynamo", "-y")
+    assert result.exit_code == 0, result.output
+    assert "Deletion request has been sent" in result.output
+    assert ("delete", "my-dynamo") in fake.calls
+
+    result = run(
+        "remove-replica", "-n", "my-dynamo", "-r", "worker-xyz", "-s", "worker", "-y"
+    )
+    assert result.exit_code == 0, result.output
+    assert ("delete_replica", "my-dynamo", "worker-xyz", "worker") in fake.calls
+    assert "worker-xyz" in result.output
+
+
+def test_history_and_metrics(fake):
+    result = run("history", "-n", "my-dynamo")
+    assert result.exit_code == 0, result.output
+    assert "create" in result.output and "created" in result.output
+
+    result = run("metrics", "-n", "my-dynamo", "--window", "6")
+    assert result.exit_code == 0, result.output
+    assert "GPUUtilAvg" in result.output
+    assert "0.75" in result.output  # latest
+    assert "GPUTempAvg" not in result.output  # 404 panels are hidden
+    assert "no data" in result.output  # metrics without series
+    assert ("metric", "my-dynamo", "GPUUtilAvg", 6) in fake.calls
+
+    result = run("metrics", "-n", "my-dynamo", "-r", "worker-xyz", "-m", "GPUUtil")
+    assert result.exit_code == 0, result.output
+    assert ("replica_metric", "my-dynamo", "worker-xyz", "GPUUtil") in fake.calls
+    assert "0.5" in result.output
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+def _created_spec(fake):
+    assert fake.created is not None
+    return fake.created.spec
+
+
+def test_create_single_frontend(fake):
+    result = run(
+        "create",
+        "-n",
+        "new-dyn",
+        "-svc",
+        "frontend",
+        "--resource-shape",
+        "cpu.small",
+        "--node-group",
+        "my-ng",
+    )
+    assert result.exit_code == 0, result.output
+    assert "created successfully" in result.output
+    assert fake.created.metadata.name == "new-dyn"
+    spec = _created_spec(fake)
+    assert spec.backend_framework == "vllm"
+    assert spec.dynamo_version == "1.3.1"
+    assert spec.ingress_enabled is True
+    assert list(spec.services) == ["frontend"]
+    frontend = spec.services["frontend"]
+    assert frontend.affinity.allowed_dedicated_node_groups == [
+        "ng-1"
+    ]  # resolved by name
+    assert frontend.min_replicas == 1
+    assert frontend.extra_pod_spec.main_container.image == VLLM_IMAGE
+    assert frontend.extra_pod_spec.main_container.command == [
+        "/bin/sh",
+        "-c",
+        "python3 -m dynamo.frontend",
+    ]
+
+
+def test_create_aggregated_worker_with_envs_and_options(fake):
+    result = run(
+        "create",
+        "-n",
+        "agg-test",
+        "-e",
+        "MODEL_NAME=Qwen/Qwen3-0.6B",
+        "-s",
+        "HF_TOKEN=my-secret",
+        "--no-ingress",
+        "--ingress-timeout",
+        "600",
+        "--visibility",
+        "private",
+        "-svc",
+        "frontend",
+        "--resource-shape",
+        "cpu.small",
+        "--node-group",
+        "ng-1",
+        "-svc",
+        "worker",
+        "--resource-shape",
+        "gpu.a100-1",
+        "--replicas",
+        "2",
+        "-e",
+        "TP=1",
+        "--mount",
+        "/data:/mnt/data:node-nfs:my-nfs",
+        "--annotation",
+        "app=dynamo",
+        "--label",
+        "tier=compute",
+    )
+    assert result.exit_code == 0, result.output
+    spec = _created_spec(fake)
+    assert fake.created.metadata.visibility.value == "private"
+    assert spec.ingress_enabled is False
+    assert spec.ingress_timeout_seconds == 600
+    assert [e.name for e in spec.envs] == ["MODEL_NAME", "HF_TOKEN"]
+    assert spec.envs[1].value_from.secret_name_ref == "my-secret"
+
+    worker = spec.services["worker"]
+    assert worker.min_replicas == 2
+    assert worker.affinity.allowed_dedicated_node_groups == ["ng-1"]  # inherited
+    assert [e.name for e in worker.envs] == ["TP"]
+    assert worker.mounts[0].from_ == "node-nfs:my-nfs"
+    assert worker.extra_pod_metadata.annotations == {"app": "dynamo"}
+    assert worker.extra_pod_metadata.labels == {"tier": "compute"}
+    assert (
+        worker.extra_pod_spec.main_container.working_dir
+        == "/workspace/examples/backends/vllm"
+    )
+
+
+def test_create_disaggregated_sglang_with_multinode(fake):
+    result = run(
+        "create",
+        "-n",
+        "disagg-test",
+        "--framework",
+        "sglang",
+        "--serving-mode",
+        "disaggregated",
+        "-svc",
+        "frontend",
+        "--resource-shape",
+        "cpu.small",
+        "--node-group",
+        "my-ng",
+        "-svc",
+        "prefill-worker",
+        "--resource-shape",
+        "gpu.h100-8",
+        "--node-count",
+        "2",
+        "-svc",
+        "decode-worker",
+        "--resource-shape",
+        "gpu.h100-8",
+    )
+    assert result.exit_code == 0, result.output
+    spec = _created_spec(fake)
+    assert set(spec.services) == {"frontend", "prefill-worker", "decode-worker"}
+    prefill = spec.services["prefill-worker"]
+    decode = spec.services["decode-worker"]
+    assert prefill.extra_pod_metadata.labels == {
+        DYNAMO_WORKER_ROLE_LABEL_KEY: "prefill"
+    }
+    assert decode.extra_pod_metadata.labels == {DYNAMO_WORKER_ROLE_LABEL_KEY: "decode"}
+    assert prefill.multinode.node_count == 2
+    # gpu_count 8 (from the shapes API) x 2 nodes
+    assert "--tp-size 16" in prefill.extra_pod_spec.main_container.command[2]
+    assert decode.multinode is None
+    assert prefill.extra_pod_spec.main_container.image.endswith("sglang-runtime:1.3.1")
+
+
+def test_create_rejections(fake):
+    frontend = [
+        "-svc",
+        "frontend",
+        "--resource-shape",
+        "cpu.small",
+        "--node-group",
+        "my-ng",
+    ]
+
+    result = run("create", "-n", "x", "--serving-mode", "disaggregated", *frontend)
+    assert result.exit_code == 1 and "not supported for vLLM" in result.output
+
+    result = run(
+        "create",
+        "-n",
+        "x",
+        "--framework",
+        "sglang",
+        "--serving-mode",
+        "disaggregated",
+        *frontend,
+        "-svc",
+        "worker",
+        "--resource-shape",
+        "gpu.a10",
+    )
+    assert (
+        result.exit_code == 1 and "not available in disaggregated mode" in result.output
+    )
+
+    result = run("create", "-n", "x", "-svc", "worker", "--resource-shape", "gpu.a10")
+    assert result.exit_code == 1 and "frontend service is required" in result.output
+
+    result = run(
+        "create",
+        "-n",
+        "x",
+        *frontend,
+        "-svc",
+        "worker",
+        "--resource-shape",
+        "gpu.a10",
+        "--node-count",
+        "2",
+    )
+    assert result.exit_code == 1 and "only supported for SGLang" in result.output
+
+    result = run(
+        "create",
+        "-n",
+        "x",
+        "-svc",
+        "frontend",
+        "--resource-shape",
+        "cpu.small",
+        "--node-group",
+        "nope",
+    )
+    assert result.exit_code == 1 and "Invalid node group" in result.output
+
+    result = run("create", "-n", "Bad_Name", *frontend)
+    assert result.exit_code == 1 and "Name must consist" in result.output
+
+    result = run("create", "-n", "x", "-svc", "--resource-shape", "cpu.small")
+    assert result.exit_code == 2 and "requires a value" in result.output
+
+    result = run("create", "-n", "x", "--resource-shape", "cpu.small")
+    assert result.exit_code == 2 and "must follow" in result.output
+
+    result = run(
+        "create",
+        "-n",
+        "x",
+        *frontend,
+        "-svc",
+        "worker",
+        "--resource-shape",
+        "gpu.a10",
+        "--replicas",
+        "two",
+    )
+    assert result.exit_code == 2 and "expects an integer" in result.output
+
+    assert fake.created is None
+
+
+def test_create_dry_run_and_image_warning(fake):
+    result = run(
+        "create",
+        "-n",
+        "dry",
+        "--dry-run",
+        "-svc",
+        "frontend",
+        "--resource-shape",
+        "cpu.small",
+        "--node-group",
+        "my-ng",
+        "--image",
+        "myregistry/custom:1",
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.created is None
+    assert "Warning" in result.output and "official runtime image" in result.output
+    payload = (
+        json.loads(result.output.split("Warning")[0])
+        if result.output.startswith("{")
+        else None
+    )
+    assert payload is None or payload["metadata"]["name"] == "dry"
+    assert '"image": "myregistry/custom:1"' in result.output
+
+
+def test_create_from_spec_file_with_overrides(fake, tmp_path):
+    spec_file = tmp_path / "spec.json"
+    spec_file.write_text(
+        fake.deployments["my-dynamo"].spec.model_dump_json(
+            exclude_none=True, by_alias=True
+        )
+    )
+    result = run(
+        "create",
+        "-n",
+        "from-file",
+        "-f",
+        str(spec_file),
+        "-svc",
+        "worker",
+        "--replicas",
+        "3",
+    )
+    assert result.exit_code == 0, result.output
+    spec = _created_spec(fake)
+    assert set(spec.services) == {"frontend", "worker"}
+    assert spec.services["worker"].min_replicas == 3
+    assert spec.services["worker"].resource_shape == "gpu.a100-1"
+    assert spec.services["frontend"].affinity.allowed_dedicated_node_groups == ["ng-1"]
+    assert spec.envs[0].name == "MODEL"
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+def test_update_replicas_builds_minimal_patch(fake):
+    result = run("update", "-n", "my-dynamo", "-svc", "worker", "--replicas", "4", "-y")
+    assert result.exit_code == 0, result.output
+    name, patch, dryrun = fake.updated
+    assert (name, dryrun) == ("my-dynamo", False)
+    assert patch == {
+        "spec": {"services": {"worker": {"min_replicas": 4, "max_replicas": 4}}}
+    }
+    assert "updated successfully" in result.output
+
+
+def test_update_remove_service(fake):
+    result = run("update", "-n", "my-dynamo", "-svc", "worker", "--remove", "-y")
+    assert result.exit_code == 0, result.output
+    assert fake.updated[1] == {"spec": {"services": {"worker": None}}}
+
+    result = run("update", "-n", "my-dynamo", "-svc", "frontend", "--remove", "-y")
+    assert (
+        result.exit_code == 1 and "frontend service cannot be removed" in result.output
+    )
+
+
+def test_update_no_changes_and_global_flags(fake):
+    result = run("update", "-n", "my-dynamo")
+    assert result.exit_code == 0, result.output
+    assert "No changes detected" in result.output
+    assert fake.updated is None
+
+    result = run(
+        "update", "-n", "my-dynamo", "--no-ingress", "--display-name", "hi", "-e", "A=1"
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.updated[1] == {
+        "spec": {
+            "ingress_enabled": False,
+            "display_name": "hi",
+            "envs": [{"name": "A", "value": "1"}],
+        }
+    }
+
+
+def test_update_service_change_requires_confirmation(fake):
+    result = run(
+        "update", "-n", "my-dynamo", "-svc", "worker", "--replicas", "4", input="n\n"
+    )
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert fake.updated is None
+
+
+def test_update_dryrun_and_raw_patch_file(fake, tmp_path):
+    patch_file = tmp_path / "patch.json"
+    patch_file.write_text(
+        json.dumps(
+            {"spec": {"routing_policy": {"enable_header_based_replica_routing": True}}}
+        )
+    )
+    result = run(
+        "update",
+        "-n",
+        "my-dynamo",
+        "--dryrun",
+        "-f",
+        str(patch_file),
+        "-svc",
+        "worker",
+        "--command",
+        "python3 -m dynamo.vllm --model Qwen/Qwen3-8B",
+    )
+    assert result.exit_code == 0, result.output
+    name, patch, dryrun = fake.updated
+    assert dryrun is True
+    assert patch["spec"]["routing_policy"] == {
+        "enable_header_based_replica_routing": True
+    }
+    assert patch["spec"]["services"]["worker"] == {
+        "extra_pod_spec": {
+            "main_container": {
+                "command": [
+                    "/bin/sh",
+                    "-c",
+                    "python3 -m dynamo.vllm --model Qwen/Qwen3-8B",
+                ]
+            }
+        }
+    }
+    assert "dry run" in result.output
+
+
+def test_update_guards(fake):
+    result = run(
+        "update", "-n", "my-dynamo", "-svc", "worker", "--node-count", "2", "-y"
+    )
+    assert (
+        result.exit_code == 1 and "cannot add multinode configuration" in result.output
+    )
+
+    result = run(
+        "update", "-n", "my-dynamo", "-svc", "worker", "--node-group", "my-ng", "-y"
+    )
+    assert result.exit_code == 1 and "synchronized with the frontend" in result.output
+
+    result = run(
+        "update",
+        "-n",
+        "my-dynamo",
+        "-svc",
+        "prefill-worker",
+        "--resource-shape",
+        "gpu.a10",
+        "-y",
+    )
+    assert result.exit_code == 1 and "not available in aggregated mode" in result.output
+
+    result = run(
+        "update",
+        "-n",
+        "my-dynamo",
+        "-svc",
+        "planner",
+        "--resource-shape",
+        "gpu.a10",
+        "-y",
+    )
+    assert result.exit_code == 1 and "Unknown Dynamo service" in result.output
+
+    result = run("update", "-n", "my-dynamo", "--ingress-timeout", "10")
+    assert result.exit_code == 1 and "ingress_timeout_seconds" in result.output
+    assert fake.updated is None
+
+
+def test_update_clear_working_dir_and_add_service(fake):
+    result = run(
+        "update", "-n", "my-dynamo", "-svc", "worker", "--clear-working-dir", "-y"
+    )
+    assert result.exit_code == 0, result.output
+    assert fake.updated[1] == {
+        "spec": {
+            "services": {
+                "worker": {"extra_pod_spec": {"main_container": {"working_dir": None}}}
+            }
+        }
+    }
+
+    result = run(
+        "update", "-n", "solo", "-svc", "worker", "--resource-shape", "gpu.a10", "-y"
+    )
+    assert result.exit_code == 0, result.output
+    worker_patch = fake.updated[1]["spec"]["services"]["worker"]
+    assert worker_patch["component_type"] == "worker"
+    assert worker_patch["resource_shape"] == "gpu.a10"
+    assert worker_patch["min_replicas"] == 1
+    assert worker_patch["affinity"] == {"allowed_dedicated_node_groups": ["ng-1"]}
+    assert worker_patch["extra_pod_spec"]["main_container"]["image"] == VLLM_IMAGE
+
+
+def test_update_frontend_node_group_syncs_workers(fake, monkeypatch):
+    class TwoGroups(FakeNodeGroupAPI):
+        def list_all(self):
+            return super().list_all() + [
+                DedicatedNodeGroup(
+                    metadata=Metadata(id="ng-2", name="other-ng"),
+                    spec=DedicatedNodeGroupSpec(),
+                    status=DedicatedNodeGroupStatus(),
+                )
+            ]
+
+    monkeypatch.setattr(
+        FakeAPIClient,
+        "__init__",
+        lambda self, *a, **k: (
+            setattr(self, "dynamo", fake),
+            setattr(self, "nodegroup", TwoGroups()),
+            setattr(self, "shapes", FakeShapesAPI()),
+        )
+        and None,
+    )
+    result = run(
+        "update",
+        "-n",
+        "my-dynamo",
+        "-svc",
+        "frontend",
+        "--node-group",
+        "other-ng",
+        "-y",
+    )
+    assert result.exit_code == 0, result.output
+    services = fake.updated[1]["spec"]["services"]
+    assert services["frontend"]["affinity"] == {
+        "allowed_dedicated_node_groups": ["ng-2"]
+    }
+    assert services["worker"]["affinity"] == {"allowed_dedicated_node_groups": ["ng-2"]}
+
+
+# ---------------------------------------------------------------------------
+# lep log get --dynamo
+# ---------------------------------------------------------------------------
+
+
+def test_log_get_dynamo_flag_validation():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["log", "get", "--dynamo-service", "frontend"])
+    assert result.exit_code == 1
+    assert "requires --dynamo" in result.output or "No deployment name" in result.output
+
+    result = runner.invoke(cli, ["log", "get", "--dynamo", "x", "-e", "y"])
+    assert result.exit_code == 1
+    assert "Only one of" in result.output
+
+
+def test_group_help_lists_commands():
+    result = CliRunner().invoke(cli, ["dynamo", "--help"])
+    assert result.exit_code == 0
+    for command in (
+        "create",
+        "update",
+        "list",
+        "status",
+        "services",
+        "replicas",
+        "log",
+        "restart",
+        "remove",
+    ):
+        assert command in result.output

--- a/leptonai/cli/tests/test_dynamo_cli.py
+++ b/leptonai/cli/tests/test_dynamo_cli.py
@@ -436,13 +436,13 @@ def test_status_shows_summary_services_health_and_replicas(fake):
     assert "1 out of 2 replicas ready" in result.output
 
 
-def test_services_and_service_detail(fake):
-    result = run("services", "-n", "my-dynamo")
+def test_service_list_and_get(fake):
+    result = run("service", "list", "-n", "my-dynamo")
     assert result.exit_code == 0, result.output
     assert "frontend" in result.output and "worker" in result.output
     assert "2 nodes" in result.output
 
-    result = run("service", "-n", "my-dynamo", "-s", "worker")
+    result = run("service", "get", "-n", "my-dynamo", "-s", "worker")
     assert result.exit_code == 0, result.output
     assert "Shape:        gpu.a100-1" in result.output
     assert "Multinode:    2 nodes" in result.output
@@ -450,30 +450,30 @@ def test_services_and_service_detail(fake):
     assert "ready 1 / desired 2" in result.output
     assert "Available" in result.output and "warming up" in result.output
 
-    result = run("service", "-n", "my-dynamo", "-s", "nope")
+    result = run("service", "get", "-n", "my-dynamo", "-s", "nope")
     assert result.exit_code == 1
     assert "404" in result.output
 
 
 def test_replicas_filters(fake):
-    result = run("replicas", "-n", "my-dynamo")
+    result = run("replica", "list", "-n", "my-dynamo")
     assert result.exit_code == 0, result.output
     assert "frontend-abc" in result.output and "worker-xyz" in result.output
     assert "node-1" in result.output
 
-    result = run("replicas", "-n", "my-dynamo", "-s", "worker")
+    result = run("replica", "list", "-n", "my-dynamo", "-s", "worker")
     assert "worker-xyz" in result.output and "frontend-abc" not in result.output
 
-    result = run("replicas", "-n", "my-dynamo", "--state", "ready")
+    result = run("replica", "list", "-n", "my-dynamo", "--state", "ready")
     assert "frontend-abc" in result.output and "worker-xyz" not in result.output
 
-    result = run("replicas", "-n", "my-dynamo", "-s", "nope")
+    result = run("replica", "list", "-n", "my-dynamo", "-s", "nope")
     assert result.exit_code == 1
     assert "Available services: frontend, worker" in result.output
 
 
 def test_log_selects_first_ready_replica_and_passes_options(fake):
-    result = run("log", "-n", "my-dynamo")
+    result = run("replica", "log", "-n", "my-dynamo")
     assert result.exit_code == 0, result.output
     assert "selected replica frontend-abc of service frontend" in result.output
     assert "line1" in result.output and "line2" in result.output
@@ -487,41 +487,58 @@ def test_log_selects_first_ready_replica_and_passes_options(fake):
     )
 
     result = run(
-        "log", "-n", "my-dynamo", "-s", "worker", "--tail", "20", "--timestamps"
+        "replica",
+        "log",
+        "-n",
+        "my-dynamo",
+        "-s",
+        "worker",
+        "--tail",
+        "20",
+        "--timestamps",
     )
     assert result.exit_code == 0, result.output
     assert "worker log" in result.output
     assert fake.calls[-1] == ("log", "my-dynamo", "worker-xyz", "worker", 20, True)
 
-    result = run("log", "-n", "my-dynamo", "-r", "frontend-abc")
+    result = run("replica", "log", "-n", "my-dynamo", "-r", "frontend-abc")
     assert result.exit_code == 0, result.output
     assert fake.calls[-1] == ("log", "my-dynamo", "frontend-abc", None, None, False)
 
-    result = run("log", "-n", "my-dynamo", "-s", "nope")
+    result = run("replica", "log", "-n", "my-dynamo", "-s", "nope")
     assert result.exit_code == 1
     assert "Available services" in result.output
 
 
 def test_log_saves_to_path(fake, tmp_path):
-    result = run("log", "-n", "my-dynamo", "-r", "frontend-abc", "-p", str(tmp_path))
+    result = run(
+        "replica",
+        "log",
+        "-n",
+        "my-dynamo",
+        "-r",
+        "frontend-abc",
+        "-p",
+        str(tmp_path),
+    )
     assert result.exit_code == 0, result.output
     saved = tmp_path / "dynamo-log-my-dynamo-frontend-abc.txt"
     assert saved.read_text() == "line1\nline2\n"
 
 
 def test_restart_confirmation_and_guards(fake):
-    result = run("restart", "-n", "my-dynamo", "-s", "worker", input="n\n")
+    result = run("service", "restart", "-n", "my-dynamo", "-s", "worker", input="n\n")
     assert result.exit_code == 0, result.output
     assert "Aborted" in result.output
     assert not [c for c in fake.calls if c[0] == "restart"]
 
-    result = run("restart", "-n", "my-dynamo", "-s", "worker", "-y")
+    result = run("service", "restart", "-n", "my-dynamo", "-s", "worker", "-y")
     assert result.exit_code == 0, result.output
     assert "Restart request has been sent" in result.output
     assert "pod-1" in result.output
     assert ("restart", "my-dynamo", "worker") in fake.calls
 
-    result = run("restart", "-n", "my-dynamo", "-s", "idle", "-y")
+    result = run("service", "restart", "-n", "my-dynamo", "-s", "idle", "-y")
     assert result.exit_code == 1
     assert "nothing to restart" in result.output
 
@@ -537,7 +554,15 @@ def test_remove_and_remove_replica(fake):
     assert ("delete", "my-dynamo") in fake.calls
 
     result = run(
-        "remove-replica", "-n", "my-dynamo", "-r", "worker-xyz", "-s", "worker", "-y"
+        "replica",
+        "remove",
+        "-n",
+        "my-dynamo",
+        "-r",
+        "worker-xyz",
+        "-s",
+        "worker",
+        "-y",
     )
     assert result.exit_code == 0, result.output
     assert ("delete_replica", "my-dynamo", "worker-xyz", "worker") in fake.calls
@@ -557,7 +582,16 @@ def test_history_and_metrics(fake):
     assert "no data" in result.output  # metrics without series
     assert ("metric", "my-dynamo", "GPUUtilAvg", 6) in fake.calls
 
-    result = run("metrics", "-n", "my-dynamo", "-r", "worker-xyz", "-m", "GPUUtil")
+    result = run(
+        "replica",
+        "metrics",
+        "-n",
+        "my-dynamo",
+        "-r",
+        "worker-xyz",
+        "-m",
+        "GPUUtil",
+    )
     assert result.exit_code == 0, result.output
     assert ("replica_metric", "my-dynamo", "worker-xyz", "GPUUtil") in fake.calls
     assert "0.5" in result.output
@@ -1066,13 +1100,24 @@ def test_group_help_lists_commands():
     assert result.exit_code == 0
     for command in (
         "create",
+        "get",
+        "history",
+        "metrics",
+        "remove",
+        "replica",
+        "service",
+        "status",
         "update",
         "list",
-        "status",
-        "services",
-        "replicas",
-        "log",
-        "restart",
-        "remove",
     ):
+        assert command in result.output
+
+    result = CliRunner().invoke(cli, ["dynamo", "service", "--help"])
+    assert result.exit_code == 0
+    for command in ("get", "list", "restart"):
+        assert command in result.output
+
+    result = CliRunner().invoke(cli, ["dynamo", "replica", "--help"])
+    assert result.exit_code == 0
+    for command in ("list", "log", "metrics", "remove"):
         assert command in result.output

--- a/leptonai/cli/util.py
+++ b/leptonai/cli/util.py
@@ -949,3 +949,131 @@ def labels_to_selector(labels, base_query: Optional[str] = None) -> Optional[str
         else:
             parts.append(label)
     return ",".join(parts) if parts else None
+
+
+def make_block_option_command(
+    *,
+    markers,
+    flags,
+    param_name,
+    list_fields=(),
+    bool_flags=(),
+    help_text="",
+):
+    """
+    Build a click.Command subclass that pre-parses repeatable option blocks.
+
+    A block starts with one of ``markers`` followed by a key token, e.g.
+    ``-svc frontend``, and captures the flags in ``flags`` (a mapping from flag
+    spelling to field name) until the next marker. Tokens that are not block
+    flags are handed to click unchanged, so global options may appear anywhere.
+    Fields in ``list_fields`` accumulate repeated values; fields in
+    ``bool_flags`` take no value (presence means True). The parsed blocks are
+    injected into ``ctx.params[param_name]`` as a list of dicts, each carrying
+    the block key under ``"key"``.
+
+    The returned class extends the blank-string guard applied to every other
+    command, and appends ``help_text`` to ``--help``.
+    """
+
+    marker_set = tuple(markers)
+    flag_map = dict(flags)
+    list_field_set = set(list_fields)
+    bool_flag_set = set(bool_flags)
+    field_names = set(flag_map.values())
+
+    class BlockOptionCommand(_ValidatedCommand):
+        def _new_block(self, key):
+            block = {"key": key}
+            for field in field_names:
+                if field in list_field_set:
+                    block[field] = []
+                elif field in bool_flag_set:
+                    block[field] = False
+                else:
+                    block[field] = None
+            return block
+
+        def parse_args(self, ctx, args):
+            blocks = []
+            current = None
+            remaining = []
+            marker_label = "/".join(marker_set)
+            # Flags that double as global options (e.g. -e/--env) belong to the
+            # command itself while no block is open, and to the block afterwards.
+            global_opts = set()
+            for param in self.params:
+                global_opts.update(getattr(param, "opts", ()))
+                global_opts.update(getattr(param, "secondary_opts", ()))
+            i = 0
+            n = len(args)
+            while i < n:
+                tok = args[i]
+                flag, value = tok, None
+                if tok.startswith("--") and "=" in tok:
+                    flag, value = tok.split("=", 1)
+
+                if flag in flag_map and current is None and flag in global_opts:
+                    remaining.append(tok)
+                    i += 1
+                    continue
+
+                if flag in marker_set:
+                    if value is None:
+                        if i + 1 >= n or args[i + 1].startswith("-"):
+                            raise click.UsageError(
+                                f'"{flag}" requires a value (e.g. `{flag} frontend`).'
+                            )
+                        value = args[i + 1]
+                        i += 1
+                    if not value.strip():
+                        raise click.UsageError(f'"{flag}" must not be blank.')
+                    current = self._new_block(value.strip())
+                    blocks.append(current)
+                    i += 1
+                    continue
+
+                if flag in flag_map:
+                    if current is None:
+                        raise click.UsageError(
+                            f'"{flag}" must follow a {marker_label} marker.'
+                        )
+                    field = flag_map[flag]
+                    if field in bool_flag_set:
+                        if value is not None:
+                            raise click.UsageError(f'"{flag}" takes no value.')
+                        current[field] = True
+                        i += 1
+                        continue
+                    if value is None:
+                        if i + 1 >= n:
+                            raise click.UsageError(f'"{flag}" requires a value.')
+                        nxt = args[i + 1]
+                        if nxt in marker_set or nxt in flag_map or nxt.startswith("--"):
+                            raise click.UsageError(f'"{flag}" requires a value.')
+                        value = nxt
+                        i += 1
+                    if not value.strip():
+                        raise click.UsageError(
+                            f'"{flag}" must not be empty or only whitespace.'
+                        )
+                    if field in list_field_set:
+                        current[field].append(value)
+                    else:
+                        current[field] = value
+                    i += 1
+                    continue
+
+                remaining.append(tok)
+                i += 1
+
+            ctx.params[param_name] = blocks
+            return super().parse_args(ctx, remaining)
+
+        def get_help(self, ctx):
+            base_help = super().get_help(ctx)
+            if not help_text:
+                return base_help
+            return f"{base_help}\n\n{help_text}"
+
+    return BlockOptionCommand

--- a/leptonai/tests/test_dynamo_spec.py
+++ b/leptonai/tests/test_dynamo_spec.py
@@ -1,0 +1,497 @@
+"""Pure-function tests for the Dynamo spec builders and merge-patch helpers."""
+
+import os
+import tempfile
+import unittest
+
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+from leptonai.api.v2.dynamo_patch import (
+    apply_merge_patch,
+    build_merge_patch,
+    deep_merge_patch,
+    spec_to_dict,
+)
+from leptonai.api.v2.dynamo_spec import (
+    DYNAMO_VERSION,
+    DynamoServiceInput,
+    build_dynamo_spec,
+    build_service_spec,
+    command_display_string,
+    get_default_command,
+    get_default_image,
+    get_default_working_dir,
+    serving_mode_from_services,
+    shell_command_argv,
+    sort_service_names,
+    validate_dynamo_name,
+    validate_framework_and_mode,
+)
+from leptonai.api.v2.types.dynamo import (
+    DYNAMO_WORKER_ROLE_LABEL_KEY,
+    LeptonDynamoGraphDeploymentUserSpec,
+)
+
+
+def _frontend(**overrides):
+    kwargs = dict(name="frontend", resource_shape="cpu.small", node_groups=["ng-1"])
+    kwargs.update(overrides)
+    return DynamoServiceInput(**kwargs)
+
+
+class TestDefaultsRegistry(unittest.TestCase):
+    def test_default_image_uses_framework_and_version(self):
+        self.assertEqual(
+            get_default_image("vllm"),
+            f"nvcr.io/nvidia/ai-dynamo/vllm-runtime:{DYNAMO_VERSION}",
+        )
+        self.assertEqual(
+            get_default_image("trtllm", "1.3.1"),
+            "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.1",
+        )
+        with self.assertRaises(ValueError):
+            get_default_image("tgi")
+
+    def test_default_working_dir(self):
+        self.assertEqual(get_default_working_dir("sglang", "frontend"), "/workspace")
+        self.assertEqual(
+            get_default_working_dir("sglang", "worker"),
+            "/workspace/examples/backends/sglang",
+        )
+        self.assertEqual(
+            get_default_working_dir("trtllm", "decode-worker"), "/workspace/"
+        )
+
+    def test_default_commands(self):
+        self.assertEqual(
+            get_default_command("vllm", "frontend", "aggregated"),
+            "python3 -m dynamo.frontend",
+        )
+        self.assertEqual(
+            get_default_command("vllm", "worker", "aggregated"),
+            "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B",
+        )
+        self.assertIn(
+            "--disaggregation-mode decode",
+            get_default_command("trtllm", "decode-worker", "disaggregated"),
+        )
+        # Unknown combinations yield an empty command rather than raising.
+        self.assertEqual(get_default_command("vllm", "worker", "disaggregated"), "")
+
+    def test_sglang_multinode_command_rewrite(self):
+        aggregated = get_default_command(
+            "sglang", "worker", "aggregated", node_count=2, gpu_count=4
+        )
+        self.assertIn("--tp 8", aggregated)
+        self.assertNotIn("--tp 1", aggregated)
+
+        disaggregated = get_default_command(
+            "sglang", "prefill-worker", "disaggregated", node_count=2, gpu_count=4
+        )
+        self.assertIn("--tp-size 8", disaggregated)
+        self.assertIn("--disaggregation-bootstrap-port 30001", disaggregated)
+        self.assertTrue(disaggregated.endswith(" --mem-fraction-static 0.82"))
+
+        # vLLM/TensorRT-LLM never rewrite, and the frontend never does.
+        self.assertEqual(
+            get_default_command("vllm", "worker", "aggregated", node_count=2),
+            get_default_command("vllm", "worker", "aggregated"),
+        )
+        self.assertEqual(
+            get_default_command("sglang", "frontend", "aggregated", node_count=2),
+            "python3 -m dynamo.frontend",
+        )
+
+    def test_shell_command_argv_round_trip(self):
+        argv = shell_command_argv("python3 -m dynamo.frontend")
+        self.assertEqual(argv, ["/bin/sh", "-c", "python3 -m dynamo.frontend"])
+        self.assertIsNone(shell_command_argv("   "))
+        self.assertIsNone(shell_command_argv(None))
+        self.assertEqual(command_display_string(argv), "python3 -m dynamo.frontend")
+        self.assertEqual(
+            command_display_string(["python3", "-m", "x y"]), "python3 -m 'x y'"
+        )
+        self.assertEqual(command_display_string(None), "")
+
+    def test_serving_mode_and_sorting(self):
+        self.assertEqual(
+            serving_mode_from_services(["frontend", "worker"]), "aggregated"
+        )
+        self.assertEqual(
+            serving_mode_from_services(["decode-worker", "frontend"]), "disaggregated"
+        )
+        self.assertEqual(
+            sort_service_names(["worker", "frontend", "decode-worker"]),
+            ["frontend", "decode-worker", "worker"],
+        )
+
+
+class TestValidation(unittest.TestCase):
+    def test_name_rules(self):
+        self.assertEqual(validate_dynamo_name("my-dynamo-1"), "my-dynamo-1")
+        for bad in ("", "a" * 37, "Upper", "1abc", "abc-", "foo-by-lepton"):
+            with self.assertRaises(ValueError, msg=bad):
+                validate_dynamo_name(bad)
+
+    def test_vllm_rejects_disaggregated(self):
+        with self.assertRaises(ValueError):
+            validate_framework_and_mode("vllm", "disaggregated")
+        validate_framework_and_mode("sglang", "disaggregated")
+        with self.assertRaises(ValueError):
+            validate_framework_and_mode("vllm", "hybrid")
+
+
+class TestBuildDynamoSpec(unittest.TestCase):
+    def test_single_frontend_matches_dashboard_user_story(self):
+        spec = build_dynamo_spec(services=[_frontend(node_groups=["default"])])
+
+        self.assertEqual(spec.backend_framework, "vllm")
+        self.assertEqual(spec.dynamo_version, "1.3.1")
+        self.assertTrue(spec.ingress_enabled)
+        self.assertIsNone(spec.dynamo_namespace)
+        self.assertEqual(list(spec.services), ["frontend"])
+
+        frontend = spec.services["frontend"]
+        self.assertEqual(frontend.component_type, "frontend")
+        self.assertEqual(frontend.resource_shape, "cpu.small")
+        self.assertEqual(frontend.min_replicas, 1)
+        self.assertEqual(frontend.affinity.allowed_dedicated_node_groups, ["default"])
+        container = frontend.extra_pod_spec.main_container
+        self.assertEqual(container.image, "nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.1")
+        self.assertEqual(container.working_dir, "/workspace")
+        self.assertEqual(
+            container.command, ["/bin/sh", "-c", "python3 -m dynamo.frontend"]
+        )
+        self.assertEqual(frontend.extra_pod_metadata.annotations, {})
+        self.assertEqual(frontend.extra_pod_metadata.labels, {})
+
+    def test_aggregated_worker_inherits_node_group(self):
+        spec = build_dynamo_spec(
+            services=[
+                _frontend(node_groups=["ng-gpu-a10"]),
+                DynamoServiceInput(
+                    name="worker",
+                    resource_shape="gpu.a100-1",
+                    replicas=2,
+                    envs=["MODEL_NAME=Qwen/Qwen3-0.6B"],
+                    secrets=["HF_TOKEN=my-secret"],
+                ),
+            ]
+        )
+        worker = spec.services["worker"]
+        self.assertEqual(worker.component_type, "worker")
+        self.assertEqual(worker.min_replicas, 2)
+        self.assertEqual(worker.affinity.allowed_dedicated_node_groups, ["ng-gpu-a10"])
+        container = worker.extra_pod_spec.main_container
+        self.assertEqual(container.working_dir, "/workspace/examples/backends/vllm")
+        self.assertEqual(
+            container.command,
+            ["/bin/sh", "-c", "python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B"],
+        )
+        self.assertEqual(worker.envs[0].name, "MODEL_NAME")
+        self.assertEqual(worker.envs[0].value, "Qwen/Qwen3-0.6B")
+        self.assertEqual(worker.envs[1].value_from.secret_name_ref, "my-secret")
+        self.assertNotIn(DYNAMO_WORKER_ROLE_LABEL_KEY, worker.extra_pod_metadata.labels)
+
+    def test_disaggregated_workers_get_role_labels(self):
+        spec = build_dynamo_spec(
+            framework="sglang",
+            serving_mode="disaggregated",
+            services=[
+                _frontend(),
+                DynamoServiceInput(name="prefill-worker", resource_shape="gpu.h100-1"),
+                DynamoServiceInput(
+                    name="decode-worker",
+                    resource_shape="gpu.h100-1",
+                    labels=["tier=compute", f"{DYNAMO_WORKER_ROLE_LABEL_KEY}=bogus"],
+                    annotations=["app=dynamo"],
+                ),
+            ],
+        )
+        self.assertEqual(
+            list(spec.services), ["frontend", "decode-worker", "prefill-worker"]
+        )
+        prefill = spec.services["prefill-worker"]
+        decode = spec.services["decode-worker"]
+        self.assertEqual(
+            prefill.extra_pod_metadata.labels, {DYNAMO_WORKER_ROLE_LABEL_KEY: "prefill"}
+        )
+        self.assertEqual(
+            decode.extra_pod_metadata.labels,
+            {"tier": "compute", DYNAMO_WORKER_ROLE_LABEL_KEY: "decode"},
+        )
+        self.assertEqual(decode.extra_pod_metadata.annotations, {"app": "dynamo"})
+        self.assertIn(
+            "--disaggregation-mode prefill",
+            prefill.extra_pod_spec.main_container.command[2],
+        )
+
+    def test_global_envs_and_secrets(self):
+        spec = build_dynamo_spec(
+            services=[_frontend()],
+            envs=["MODEL_NAME=Qwen/Qwen3-0.6B"],
+            secrets=["HF_TOKEN=my-secret", "OTHER"],
+        )
+        payload = spec_to_dict(spec)["envs"]
+        self.assertEqual(
+            payload,
+            [
+                {"name": "MODEL_NAME", "value": "Qwen/Qwen3-0.6B"},
+                {"name": "HF_TOKEN", "value_from": {"secret_name_ref": "my-secret"}},
+                {"name": "OTHER", "value_from": {"secret_name_ref": "OTHER"}},
+            ],
+        )
+
+    def test_multinode_only_for_sglang_workers(self):
+        spec = build_dynamo_spec(
+            framework="sglang",
+            services=[
+                _frontend(),
+                DynamoServiceInput(
+                    name="worker",
+                    resource_shape="gpu.h100-8",
+                    node_count=2,
+                    gpu_count=8,
+                ),
+            ],
+        )
+        worker = spec.services["worker"]
+        self.assertEqual(worker.multinode.node_count, 2)
+        self.assertIn("--tp 16", worker.extra_pod_spec.main_container.command[2])
+
+        with self.assertRaisesRegex(ValueError, "only supported for SGLang"):
+            build_dynamo_spec(
+                framework="vllm",
+                services=[
+                    _frontend(),
+                    DynamoServiceInput(
+                        name="worker", resource_shape="gpu.a10", node_count=2
+                    ),
+                ],
+            )
+        with self.assertRaisesRegex(ValueError, "not the frontend"):
+            build_dynamo_spec(framework="sglang", services=[_frontend(node_count=2)])
+        with self.assertRaisesRegex(ValueError, "at least 2"):
+            build_dynamo_spec(
+                framework="sglang",
+                services=[
+                    _frontend(),
+                    DynamoServiceInput(
+                        name="worker", resource_shape="gpu.a10", node_count=1
+                    ),
+                ],
+            )
+
+    def test_rejections(self):
+        with self.assertRaisesRegex(ValueError, "frontend service is required"):
+            build_dynamo_spec(
+                services=[DynamoServiceInput(name="worker", resource_shape="gpu.a10")]
+            )
+        with self.assertRaisesRegex(ValueError, "requires --node-group"):
+            build_dynamo_spec(services=[_frontend(node_groups=None)])
+        with self.assertRaisesRegex(ValueError, "requires --resource-shape"):
+            build_dynamo_spec(services=[_frontend(resource_shape=None)])
+        with self.assertRaisesRegex(ValueError, "not supported for vLLM"):
+            build_dynamo_spec(serving_mode="disaggregated", services=[_frontend()])
+        with self.assertRaisesRegex(ValueError, "not available in aggregated mode"):
+            build_dynamo_spec(
+                framework="sglang",
+                services=[
+                    _frontend(),
+                    DynamoServiceInput(name="prefill-worker", resource_shape="gpu.a10"),
+                ],
+            )
+        with self.assertRaisesRegex(ValueError, "not available in disaggregated mode"):
+            build_dynamo_spec(
+                framework="sglang",
+                serving_mode="disaggregated",
+                services=[
+                    _frontend(),
+                    DynamoServiceInput(name="worker", resource_shape="gpu.a10"),
+                ],
+            )
+        with self.assertRaisesRegex(ValueError, "Unknown Dynamo service"):
+            build_dynamo_spec(
+                services=[
+                    _frontend(),
+                    DynamoServiceInput(name="planner", resource_shape="x"),
+                ]
+            )
+        with self.assertRaisesRegex(ValueError, "more than once"):
+            build_dynamo_spec(services=[_frontend(), _frontend()])
+        with self.assertRaisesRegex(ValueError, "Replicas must be at least 1"):
+            build_dynamo_spec(services=[_frontend(replicas=0)])
+        with self.assertRaisesRegex(ValueError, "synchronized with the frontend"):
+            build_dynamo_spec(
+                services=[
+                    _frontend(),
+                    DynamoServiceInput(
+                        name="worker", resource_shape="gpu.a10", node_groups=["ng-2"]
+                    ),
+                ]
+            )
+        with self.assertRaisesRegex(ValueError, "ingress_timeout_seconds"):
+            build_dynamo_spec(services=[_frontend()], ingress_timeout_seconds=10)
+        with self.assertRaisesRegex(ValueError, "annotation value"):
+            build_dynamo_spec(services=[_frontend(annotations=["app="])])
+        with self.assertRaisesRegex(ValueError, "Invalid environment definition"):
+            build_dynamo_spec(services=[_frontend(envs=["NOEQUALS"])])
+
+    def test_ingress_flags(self):
+        spec = build_dynamo_spec(
+            services=[_frontend()], ingress_enabled=False, ingress_timeout_seconds=600
+        )
+        self.assertFalse(spec.ingress_enabled)
+        self.assertEqual(spec.ingress_timeout_seconds, 600)
+
+    def _base_spec(self):
+        return build_dynamo_spec(
+            framework="sglang",
+            services=[
+                _frontend(),
+                DynamoServiceInput(
+                    name="worker",
+                    resource_shape="gpu.h100-8",
+                    replicas=2,
+                    node_count=2,
+                    command="python3 -m custom",
+                ),
+            ],
+        )
+
+    def test_base_spec_overrides_keep_file_values(self):
+        base = self._base_spec()
+        spec = build_dynamo_spec(
+            services=[DynamoServiceInput(name="worker", replicas=3)], base=base
+        )
+        worker = spec.services["worker"]
+        self.assertEqual(spec.backend_framework, "sglang")
+        self.assertEqual(worker.min_replicas, 3)
+        self.assertEqual(worker.resource_shape, "gpu.h100-8")
+        self.assertEqual(worker.multinode.node_count, 2)
+        self.assertEqual(
+            worker.extra_pod_spec.main_container.command[2], "python3 -m custom"
+        )
+        # The frontend and its node group come from the file untouched.
+        self.assertEqual(
+            spec.services["frontend"].affinity.allowed_dedicated_node_groups, ["ng-1"]
+        )
+
+    def test_framework_change_cascades_like_the_dashboard(self):
+        base = self._base_spec()
+        spec = build_dynamo_spec(services=[], framework="trtllm", base=base)
+        worker = spec.services["worker"]
+        self.assertIsNone(worker.multinode)
+        container = worker.extra_pod_spec.main_container
+        self.assertEqual(
+            container.image, "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.1"
+        )
+        self.assertEqual(container.working_dir, "/workspace/")
+        self.assertIn("dynamo.trtllm", container.command[2])
+        self.assertEqual(
+            spec.services["frontend"].extra_pod_spec.main_container.image,
+            "nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.1",
+        )
+
+    def test_base_spec_with_namespace_is_rejected(self):
+        base = self._base_spec()
+        base.dynamo_namespace = "prod"
+        with self.assertRaisesRegex(ValueError, "dynamo_namespace"):
+            build_dynamo_spec(services=[], base=base)
+
+    def test_update_mode_only_touches_given_fields(self):
+        base = self._base_spec().services["worker"]
+        base.extra_pod_metadata = None
+        updated = build_service_spec(
+            DynamoServiceInput(name="worker", replicas=5),
+            framework="sglang",
+            serving_mode="aggregated",
+            base=base,
+            fill_defaults=False,
+        )
+        self.assertEqual(updated.min_replicas, 5)
+        self.assertIsNone(updated.extra_pod_metadata)
+        self.assertEqual(
+            spec_to_dict(updated)["extra_pod_spec"],
+            spec_to_dict(base)["extra_pod_spec"],
+        )
+        with self.assertRaisesRegex(ValueError, "at least 1"):
+            build_service_spec(
+                DynamoServiceInput(name="worker", replicas=0),
+                framework="sglang",
+                serving_mode="aggregated",
+                base=base,
+                fill_defaults=False,
+            )
+
+
+class TestMergePatch(unittest.TestCase):
+    def test_no_change_is_empty(self):
+        original = {"a": 1, "b": {"c": [1, 2]}}
+        self.assertEqual(build_merge_patch(original, dict(original)), {})
+
+    def test_changes_removals_and_additions(self):
+        original = {
+            "ingress_enabled": True,
+            "envs": [{"name": "A", "value": "1"}],
+            "services": {
+                "frontend": {
+                    "min_replicas": 1,
+                    "extra_pod_spec": {"main_container": {"working_dir": "/w"}},
+                },
+                "worker": {"min_replicas": 2},
+            },
+        }
+        desired = {
+            "ingress_enabled": False,
+            "display_name": "hello",
+            "envs": [{"name": "A", "value": "2"}],
+            "services": {
+                "frontend": {
+                    "min_replicas": 1,
+                    "extra_pod_spec": {"main_container": {}},
+                },
+            },
+        }
+        patch = build_merge_patch(original, desired)
+        self.assertEqual(
+            patch,
+            {
+                "ingress_enabled": False,
+                "display_name": "hello",
+                "envs": [{"name": "A", "value": "2"}],
+                "services": {
+                    "frontend": {
+                        "extra_pod_spec": {"main_container": {"working_dir": None}}
+                    },
+                    "worker": None,
+                },
+            },
+        )
+        self.assertEqual(apply_merge_patch(original, patch), desired)
+
+    def test_deep_merge_override_wins(self):
+        base = {"spec": {"services": {"worker": {"min_replicas": 3}}}}
+        override = {"spec": {"services": {"worker": None}, "display_name": "x"}}
+        self.assertEqual(
+            deep_merge_patch(base, override),
+            {"spec": {"services": {"worker": None}, "display_name": "x"}},
+        )
+
+    def test_spec_to_dict_drops_none_and_uses_aliases(self):
+        spec = build_dynamo_spec(
+            services=[_frontend(mounts=["/data:/mnt/data:node-nfs:my-nfs"])]
+        )
+        payload = spec_to_dict(spec)
+        self.assertNotIn("dynamo_namespace", payload)
+        mount = payload["services"]["frontend"]["mounts"][0]
+        self.assertEqual(mount["from"], "node-nfs:my-nfs")
+        self.assertNotIn("from_", mount)
+        self.assertIsInstance(
+            LeptonDynamoGraphDeploymentUserSpec.model_validate(payload),
+            LeptonDynamoGraphDeploymentUserSpec,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/lepton-cli/skills/lepton-cli/SKILL.md
+++ b/plugins/lepton-cli/skills/lepton-cli/SKILL.md
@@ -83,6 +83,7 @@ Before running the mutation, read the workload's current state with a narrow rea
 ## Known Gotchas
 
 - `deployment` may be available as an alias for `endpoint`.
+- Dynamo endpoints are a separate resource: use `lep dynamo ...`, not `lep endpoint ...`. `lep dynamo log` returns a snapshot of a replica's recent lines rather than a stream.
 - Some command groups may be hidden from top-level help but still invokable. If the user asks for a known Lepton resource, try `lep <group> --help` before concluding it is unsupported.
 - Slurm clusters are not self-serve — they are provisioned on request by the Lepton team. See [references/workloads.md](references/workloads.md).
 - Help output is authoritative for the installed CLI version; command availability and flags can vary by version.

--- a/plugins/lepton-cli/skills/lepton-cli/SKILL.md
+++ b/plugins/lepton-cli/skills/lepton-cli/SKILL.md
@@ -83,7 +83,7 @@ Before running the mutation, read the workload's current state with a narrow rea
 ## Known Gotchas
 
 - `deployment` may be available as an alias for `endpoint`.
-- Dynamo endpoints are a separate resource: use `lep dynamo ...`, not `lep endpoint ...`. `lep dynamo log` returns a snapshot of a replica's recent lines rather than a stream.
+- Dynamo endpoints are a separate resource: use `lep dynamo ...`, not `lep endpoint ...`. `lep dynamo replica log` returns a snapshot of a replica's recent lines rather than a stream.
 - Some command groups may be hidden from top-level help but still invokable. If the user asks for a known Lepton resource, try `lep <group> --help` before concluding it is unsupported.
 - Slurm clusters are not self-serve — they are provisioned on request by the Lepton team. See [references/workloads.md](references/workloads.md).
 - Help output is authoritative for the installed CLI version; command availability and flags can vary by version.

--- a/plugins/lepton-cli/skills/lepton-cli/references/workloads.md
+++ b/plugins/lepton-cli/skills/lepton-cli/references/workloads.md
@@ -25,17 +25,18 @@ Use Dynamo when disaggregated serving is needed for better throughput or
 latency on large LLMs.
 
 CLI: the `lep dynamo` group. Read-only: `lep dynamo list`, `lep dynamo status -n
-<name>`, `lep dynamo get -n <name> [-p spec.json]`, `lep dynamo services -n
-<name>`, `lep dynamo service -n <name> -s <service>`, `lep dynamo replicas -n
-<name> [-s <service>]`, `lep dynamo log -n <name> [-s <service>] [-r <replica>]
-[--tail N]` (snapshot of the last lines; `lep log get --dynamo <name>` for
-historical windows), `lep dynamo metrics -n <name>`, `lep dynamo history -n
-<name>`. Mutating: `lep dynamo create` (repeatable `-svc <frontend|worker|
-prefill-worker|decode-worker>` blocks, `--dry-run` prints the payload), `lep
-dynamo update` (merge patch; `--dryrun` validates server side), `lep dynamo
-restart -n <name> -s <service>`, `lep dynamo remove-replica -n <name> -r
-<replica>`, `lep dynamo remove -n <name>`. The mutating commands prompt for
-confirmation; pass `-y` only after the user has explicitly confirmed.
+<name>`, `lep dynamo get -n <name> [-p spec.json]`, `lep dynamo service list -n
+<name>`, `lep dynamo service get -n <name> -s <service>`, `lep dynamo replica
+list -n <name> [-s <service>]`, `lep dynamo replica log -n <name> [-s <service>]
+[-r <replica>] [--tail N]` (snapshot of the last lines; `lep log get --dynamo
+<name>` for historical windows), `lep dynamo metrics -n <name>`, `lep dynamo
+replica metrics -n <name> -r <replica>`, `lep dynamo history -n <name>`.
+Mutating: `lep dynamo create` (repeatable `-svc <frontend|worker|prefill-worker|
+decode-worker>` blocks, `--dry-run` prints the payload), `lep dynamo update`
+(merge patch; `--dryrun` validates server side), `lep dynamo service restart -n
+<name> -s <service>`, `lep dynamo replica remove -n <name> -r <replica>`, `lep
+dynamo remove -n <name>`. The mutating commands prompt for confirmation; pass
+`-y` only after the user has explicitly confirmed.
 
 ## Dev Pods
 

--- a/plugins/lepton-cli/skills/lepton-cli/references/workloads.md
+++ b/plugins/lepton-cli/skills/lepton-cli/references/workloads.md
@@ -24,6 +24,19 @@ independently. Supported backend frameworks are sglang, vllm, and trtllm.
 Use Dynamo when disaggregated serving is needed for better throughput or
 latency on large LLMs.
 
+CLI: the `lep dynamo` group. Read-only: `lep dynamo list`, `lep dynamo status -n
+<name>`, `lep dynamo get -n <name> [-p spec.json]`, `lep dynamo services -n
+<name>`, `lep dynamo service -n <name> -s <service>`, `lep dynamo replicas -n
+<name> [-s <service>]`, `lep dynamo log -n <name> [-s <service>] [-r <replica>]
+[--tail N]` (snapshot of the last lines; `lep log get --dynamo <name>` for
+historical windows), `lep dynamo metrics -n <name>`, `lep dynamo history -n
+<name>`. Mutating: `lep dynamo create` (repeatable `-svc <frontend|worker|
+prefill-worker|decode-worker>` blocks, `--dry-run` prints the payload), `lep
+dynamo update` (merge patch; `--dryrun` validates server side), `lep dynamo
+restart -n <name> -s <service>`, `lep dynamo remove-replica -n <name> -r
+<replica>`, `lep dynamo remove -n <name>`. The mutating commands prompt for
+confirmation; pass `-y` only after the user has explicitly confirmed.
+
 ## Dev Pods
 
 Single-replica, long-lived interactive environments. A Dev Pod is a personal


### PR DESCRIPTION
Adds first-class support for Dynamo graph deployments (multi-service LLM inference graphs served by NVIDIA Dynamo with a vLLM, SGLang, or TensorRT-LLM backend), mirroring the dashboard's Dynamo pages.

- API layer: `client.dynamo` (DynamoGraphDeploymentAPI) covering CRUD with RFC 7396 merge-patch updates (+dryrun), services, per-service and flat replicas, one-shot replica logs, restart, replica deletion, history, monitoring status and metrics; pydantic types for the CRD user spec, status, and all sub-resource responses.
- Spec builders ported from the dashboard defaults registry (images, working dirs, default commands incl. the SGLang multinode rewrite, worker role labels, frontend node-group inheritance) plus merge-patch helpers.
- CLI: `lep dynamo list|get|status|services|service|replicas|log|restart| remove|remove-replica|create|update|history|metrics`. `create`/`update` take repeatable `-svc TYPE` blocks via a new generic block-option command factory in cli/util.py.
- `lep log get --dynamo/--dynamo-service` for historical logs through the shared /logs route; ReplicaReadinessReason gains the reasons the dynamo replica endpoints emit.
- Docs: README, example_usage.md, agent skill references, and the plan in docs/dynamo-cli-plan.md.

Tests: 62 new tests (spec builders, HTTP contract via responses, CLI via CliRunner); the full suite passes.