### PR TITLE
feat(cli): add Teleport SSH for pods and jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,37 @@ lep job create -n my-job --container-image my-registry/my-trainer:latest --comma
 
 # Launch an interactive dev pod
 lep pod create -n my-pod --resource-shape gpu.a10
+
+# Connect to a pod with Teleport SSH enabled (requires local tsh)
+lep pod ssh -n my-pod --transport teleport
 ```
+
+Teleport SSH reuses your local Teleport login, or starts SSO login when needed.
+The default connector is `Starfleet`; use `--teleport-auth <connector>` to override
+it. Lepton API credentials and Teleport login are separate. Your workspace, node
+group, and pod must have Teleport enabled. This currently supports legacy Pods;
+the new DevPod API does not yet publish Teleport connection details. Without
+`--transport teleport`, `lep pod ssh` continues to use direct SSH.
+
+Jobs can also be accessed through Teleport when their workspace has `job_teleport`
+enabled and their image/entrypoint starts a Teleport agent:
+
+```shell
+lep job replicas --id <job-id>
+lep job ssh --id <job-id> --replica <replica-id>
+# Or select a uniquely named job (a single ready replica is selected automatically)
+lep job ssh --name <job-name>
+# Specify the proxy when you have not logged in, or to switch from another proxy
+lep job ssh --id <job-id> --replica <replica-id> --teleport-proxy <host>:443
+```
+
+Job SSH defaults to the active `tsh` profile because the Job API does not publish
+Teleport connection details. It uses the standard Lepton agent's
+`<workspace-id>-<replica-id>` hostname and workspace label to find one node, then
+connects to its Teleport node ID as `root`. Historical and unready replicas are
+excluded; multiple ready replicas require `--replica`. Job SSH does not install
+the agent or change the workload's startup command. Use `--teleport-auth` to
+override the default `Starfleet` SSO connector.
 
 Run `lep --help`, or `lep <command> --help` for any subcommand, to explore everything. See the [CLI references](https://docs.nvidia.com/dgx-cloud/lepton/reference/cli/get-started/) for the full guide.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ lep pod create -n my-pod --resource-shape gpu.a10
 lep pod ssh -n my-pod --transport teleport
 ```
 
+Pod and Job Teleport SSH require `tsh` v18 or newer in your PATH. The CLI checks
+the client version before reading login profiles or starting SSO; missing, older,
+or unrecognized clients produce an actionable error. This minimum version check
+does not guarantee compatibility with every Teleport cluster version.
+
 Teleport SSH reuses your local Teleport login, or starts SSO login when needed.
 The default connector is `Starfleet`; use `--teleport-auth <connector>` to override
 it. Lepton API credentials and Teleport login are separate. Your workspace, node

--- a/leptonai/api/v2/devpod.py
+++ b/leptonai/api/v2/devpod.py
@@ -27,6 +27,7 @@ from .api_resource import APIResourse
 from .types.deployment import LeptonDeployment, LeptonDeploymentUserSpec
 from .types.readiness import ReadinessIssue
 from .types.termination import DeploymentTerminations
+from .types.teleport import TeleportConnection
 from . import translation
 
 
@@ -37,6 +38,14 @@ class NewDevPodAPIUnsupported(RuntimeError):
 
 
 class DevPodAPI(APIResourse):
+    def get_teleport_connection(
+        self, name_or_pod: Union[str, LeptonDeployment]
+    ) -> TeleportConnection:
+        raise NewDevPodAPIUnsupported(
+            "Teleport SSH is not yet supported by the new DevPod API: "
+            "the backend does not expose a Teleport connection-details endpoint."
+        )
+
     def _to_name(self, name_or_pod: Union[str, LeptonDeployment]) -> str:
         return (  # type: ignore
             name_or_pod if isinstance(name_or_pod, str) else name_or_pod.metadata.id_

--- a/leptonai/api/v2/job.py
+++ b/leptonai/api/v2/job.py
@@ -1,4 +1,5 @@
 from typing import Union, List, Iterator, Optional
+from urllib.parse import quote
 
 from .api_resource import APIResourse
 from .job_validation import validate_job_create
@@ -129,6 +130,58 @@ class JobAPI(APIResourse):
             params={"job_query_mode": job_query_mode},
         )
         return self.ensure_list(response, Replica)
+
+    def get_ssh_replica(
+        self, id_or_job: Union[str, LeptonJob], replica: Optional[str] = None
+    ) -> str:
+        """Select one live Job replica without guessing among workers or history."""
+        job = self.get(id_or_job, job_query_mode=LeptonJobQueryMode.AliveOnly.value)
+        if job.status is None or job.status.state != "Running":
+            raise RuntimeError("SSH requires a running job.")
+        job_id = self._to_id(job)
+        if not job_id:
+            raise RuntimeError("The job response is missing its ID.")
+        replicas = self.ensure_json(
+            self._get(
+                f"/jobs/{quote(job_id, safe='')}/replicas",
+                params={"job_query_mode": LeptonJobQueryMode.AliveOnly.value},
+            )
+        )
+        if not isinstance(replicas, list):
+            raise RuntimeError("The server returned an invalid job replica list.")
+        ids = []
+        ready_ids = []
+        for item in replicas:
+            metadata = item.get("metadata") if isinstance(item, dict) else None
+            rid = metadata.get("id") if isinstance(metadata, dict) else None
+            if not isinstance(rid, str) or not rid.strip() or rid in ids:
+                raise RuntimeError(
+                    "The server returned invalid or duplicate job replica IDs."
+                )
+            ids.append(rid)
+            status = item.get("status")
+            readiness = (
+                status.get("readiness_issue") if isinstance(status, dict) else None
+            )
+            if isinstance(readiness, dict) and readiness.get("reason") == "Ready":
+                ready_ids.append(rid)
+        if replica is not None:
+            if replica not in ids:
+                raise RuntimeError(
+                    "The requested replica does not belong to the current job run. "
+                    f"List current replicas with: lep job replicas --id {job_id}"
+                )
+            if replica not in ready_ids:
+                raise RuntimeError("The selected Job replica is not ready for SSH.")
+            return replica
+        if not ready_ids:
+            raise RuntimeError("The job has no ready replicas available for SSH.")
+        if len(ready_ids) != 1:
+            raise RuntimeError(
+                "The job has multiple replicas. Select one with --replica. "
+                f"List current replicas with: lep job replicas --id {job_id}"
+            )
+        return ready_ids[0]
 
     def get_log(
         self,

--- a/leptonai/api/v2/pod.py
+++ b/leptonai/api/v2/pod.py
@@ -1,10 +1,18 @@
 from typing import Union, List, Iterator, Optional
 import warnings
+from urllib.parse import quote
+
+from pydantic import ValidationError
 
 from .api_resource import APIResourse
 from .types.deployment import LeptonDeployment, LeptonDeploymentUserSpec
 from .types.readiness import ReadinessIssue
 from .types.termination import DeploymentTerminations
+from .types.teleport import TeleportConnection
+
+
+class TeleportUnavailable(RuntimeError):
+    """The Pod API could not provide a usable Teleport connection."""
 
 
 class PodAPI(APIResourse):
@@ -75,6 +83,49 @@ class PodAPI(APIResourse):
     # of this class entirely.
     def get(self, name_or_pod: Union[str, LeptonDeployment]) -> LeptonDeployment:
         return self._client._deployment_api_for_legacy_pod().get(name_or_pod)
+
+    def get_teleport_connection(
+        self, name_or_pod: Union[str, LeptonDeployment]
+    ) -> TeleportConnection:
+        """Resolve the single Pod replica to Teleport connection metadata.
+
+        A Running status means the backend found a registered Teleport node;
+        the caller still needs a Teleport login authorized to access it.
+        """
+        name = quote(self._to_name(name_or_pod), safe="")
+        replicas = self.ensure_json(self._get(f"/deployments/{name}/replicas"))
+        # Do not use ensure_list: it skips malformed replicas, which could hide
+        # an ambiguous target while choosing the remaining replica.
+        if not isinstance(replicas, list) or len(replicas) != 1:
+            raise TeleportUnavailable(
+                "Teleport SSH requires exactly one pod replica. "
+                "Wait for the pod to finish starting or restarting and retry."
+            )
+        replica = replicas[0]
+        metadata = replica.get("metadata") if isinstance(replica, dict) else None
+        rid = metadata.get("id") if isinstance(metadata, dict) else None
+        if not isinstance(rid, str) or not rid.strip():
+            raise TeleportUnavailable("The pod replica is missing its ID.")
+        response = self.ensure_json(
+            self._get(
+                f"/deployments/{name}/replicas/{quote(rid, safe='')}/teleport-connectivity"
+            )
+        )
+        if (
+            isinstance(response, dict)
+            and "status" not in response
+            and "code" in response
+        ):
+            raise TeleportUnavailable(
+                "Teleport SSH is not enabled for this workspace or pod. "
+                "Check the pod's Teleport SSH Access settings in the dashboard."
+            )
+        try:
+            return TeleportConnection.model_validate(response)
+        except ValidationError:
+            raise TeleportUnavailable(
+                "The server returned incomplete or invalid Teleport connection details."
+            ) from None
 
     def update(
         self, name_or_deployment: Union[str, LeptonDeployment], spec: LeptonDeployment

--- a/leptonai/api/v2/types/teleport.py
+++ b/leptonai/api/v2/types/teleport.py
@@ -1,0 +1,19 @@
+"""Teleport SSH targets and connection metadata published by the Pod API."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class TeleportTarget(BaseModel):
+    name: str = Field(pattern=r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+    proxy: str = Field(pattern=r"^[a-zA-Z0-9][a-zA-Z0-9.-]*$")
+    port: int = Field(strict=True, ge=1, le=65535)
+    cluster_domain: str = Field(
+        alias="clusterDomain", pattern=r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+    )
+    username: str = Field(pattern=r"^[a-zA-Z0-9_][a-zA-Z0-9._-]*$")
+
+
+class TeleportConnection(TeleportTarget):
+    status: Literal["Running", "NotRunning"]

--- a/leptonai/cli/job.py
+++ b/leptonai/cli/job.py
@@ -6,6 +6,9 @@ import sys
 
 from loguru import logger
 from rich.table import Table
+from requests import RequestException
+
+from .teleport import connect_job_teleport
 
 from leptonai.cli.log import _epoch_to_time_str, _preprocess_time
 
@@ -1447,6 +1450,66 @@ def log(id, replica):
         console.print(
             "End of log. It seems that the job has not started, or already finished."
         )
+
+
+@job.command()
+@click.option("--id", "-i", help="Job ID to connect to.")
+@click.option("--name", "-n", help="Exact Job name; must identify one live job.")
+@click.option(
+    "--replica", "-r", help="Replica ID; required when the job has multiple replicas."
+)
+@click.option(
+    "--teleport-proxy",
+    help="Teleport proxy host[:port]; defaults to the active tsh profile.",
+)
+@click.option(
+    "--teleport-auth",
+    default="Starfleet",
+    show_default=True,
+    help="Teleport SSO connector.",
+)
+def ssh(id, name, replica, teleport_proxy, teleport_auth):
+    """SSH into a running Job replica through Teleport.
+
+    Requires an enabled Teleport agent in the Job image. Use `lep job replicas`
+    to list worker IDs. The Job API does not expose its Teleport proxy, so sign
+    in to the appropriate proxy first or specify --teleport-proxy.
+    """
+    if bool(id) == bool(name):
+        raise click.UsageError("Specify exactly one of --id or --name.")
+    client = APIClient()
+    try:
+        if name:
+            matches = [
+                item
+                for item in client.job.list_all(
+                    q=name, job_query_mode=LeptonJobQueryMode.AliveOnly.value
+                )
+                if item.metadata.name == name
+            ]
+            if not matches:
+                raise click.ClickException("No live job matches that name.")
+            if len(matches) != 1:
+                raise click.ClickException(
+                    "Multiple jobs match that name. Select one with --id."
+                )
+            id = matches[0].metadata.id_
+            if not id:
+                raise click.ClickException("The job response is missing its ID.")
+        selected = client.job.get_ssh_replica(id, replica)
+
+        def revalidate():
+            client.job.get_ssh_replica(id, selected)
+
+        connect_job_teleport(
+            client.workspace_id,
+            selected,
+            proxy=teleport_proxy,
+            auth=teleport_auth,
+            before_connect=revalidate,
+        )
+    except (RuntimeError, RequestException) as error:
+        raise click.ClickException(str(error)) from None
 
 
 @job.command()

--- a/leptonai/cli/job.py
+++ b/leptonai/cli/job.py
@@ -1508,6 +1508,9 @@ def ssh(id, name, replica, teleport_proxy, teleport_auth):
             auth=teleport_auth,
             before_connect=revalidate,
         )
+    except click.exceptions.Exit:
+        # Click's Exit may inherit RuntimeError; preserve SSH/interrupt codes.
+        raise
     except (RuntimeError, RequestException) as error:
         raise click.ClickException(str(error)) from None
 

--- a/leptonai/cli/pod.py
+++ b/leptonai/cli/pod.py
@@ -17,6 +17,7 @@ import click
 from loguru import logger
 from rich.console import Console
 from rich.table import Table
+from requests import RequestException
 
 from leptonai.config import (
     VALID_SHAPES,
@@ -57,6 +58,7 @@ from ..api.v2.types.deployment import (
     LeptonContainer,
 )
 from ..api.v2.types.common import LeptonUserSecurityContext
+from .teleport import connect_teleport
 
 
 console = Console(highlight=False)
@@ -876,9 +878,34 @@ def remove(name):
 
 @pod.command()
 @click.option("--name", "-n", help="The pod name to ssh.", required=True)
-def ssh(name):
+@click.option(
+    "--transport",
+    type=click.Choice(["ssh", "teleport"]),
+    default="ssh",
+    show_default=True,
+    help="Connect using direct SSH or Teleport (requires local tsh).",
+)
+@click.option(
+    "--teleport-auth",
+    default=None,
+    help=(
+        "Teleport SSO connector for login (default: Starfleet). Requires --transport"
+        " teleport."
+    ),
+)
+def ssh(name, transport, teleport_auth):
     """SSH into a running pod."""
+    if teleport_auth is not None and transport != "teleport":
+        raise click.UsageError("--teleport-auth requires --transport teleport.")
     client = APIClient()
+
+    if transport == "teleport":
+        try:
+            connection = client.pod.get_teleport_connection(name)
+        except (RuntimeError, RequestException) as error:
+            raise click.ClickException(str(error)) from None
+        connect_teleport(connection, auth=teleport_auth or "Starfleet")
+        return
 
     pod = client.pod.get(name)
     logger.trace(json.dumps(pod.model_dump(), indent=2))

--- a/leptonai/cli/teleport.py
+++ b/leptonai/cli/teleport.py
@@ -1,0 +1,302 @@
+"""Launch workload SSH sessions using the user's local Teleport client."""
+
+from datetime import datetime, timezone
+import json
+import re
+import shutil
+import subprocess
+from typing import Callable, Optional
+from urllib.parse import urlsplit
+
+import click
+from pydantic import ValidationError
+
+from leptonai.api.v2.types.teleport import TeleportConnection, TeleportTarget
+
+
+def _status(tsh: str, proxy: Optional[str] = None) -> Optional[dict]:
+    """Read the selected tsh profile, including expired profiles for discovery."""
+    args = [tsh, "status"]
+    if proxy is not None:
+        args.append(f"--proxy={proxy}")
+    args.append("--format=json")
+    try:
+        result = subprocess.run(
+            args,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        raise click.ClickException(
+            "Timed out checking the local Teleport login."
+        ) from None
+    if result.returncode != 0:
+        if "not logged in" in result.stderr.lower():
+            return None
+        # Expired profiles can still include JSON; parse those below. Other
+        # tool failures must not trigger a misleading SSO login loop.
+        if not result.stdout.strip():
+            raise click.ClickException(
+                "Could not check the local Teleport login (tsh status exited with "
+                f"status {result.returncode}). Run tsh status --format=json to "
+                "see the error and check your tsh installation."
+            )
+    try:
+        status = json.loads(result.stdout)
+        active = status.get("active") if isinstance(status, dict) else None
+        if active is None:
+            return None
+        if not isinstance(active, dict):
+            raise ValueError
+        return active
+    except (ValueError, TypeError):
+        raise click.ClickException(
+            "Could not read the local Teleport profile."
+        ) from None
+
+
+def _profile(tsh: str, connection: TeleportTarget) -> Optional[dict]:
+    """Return a current profile for the exact proxy and cluster, if present."""
+    active = _status(tsh, f"{connection.proxy}:{connection.port}")
+    if active is None:
+        return None
+    try:
+        proxy = urlsplit(active["profile_url"])
+        if (
+            proxy.scheme != "https"
+            or proxy.hostname != connection.proxy.lower()
+            or (proxy.port or 443) != connection.port
+            or proxy.username is not None
+            or proxy.password is not None
+            or proxy.path not in ("", "/")
+            or proxy.query
+            or proxy.fragment
+            or active.get("cluster") != connection.cluster_domain
+        ):
+            return None
+        expiry = datetime.fromisoformat(active["valid_until"].replace("Z", "+00:00"))
+        if expiry.tzinfo is None:
+            raise ValueError
+        if expiry <= datetime.now(timezone.utc):
+            return None
+        if (
+            not isinstance(active.get("username"), str)
+            or not active["username"]
+            or any(c in active["username"] for c in "\0\r\n")
+        ):
+            raise ValueError
+        logins = active.get("logins")
+        if not isinstance(logins, list) or not all(isinstance(v, str) for v in logins):
+            raise ValueError
+        return active
+    except (ValueError, TypeError, KeyError, AttributeError):
+        raise click.ClickException(
+            "Could not read the local Teleport profile. Check your tsh installation "
+            "and run tsh login for this proxy."
+        ) from None
+
+
+def _run_interactive(args: list, operation: str) -> None:
+    # Inherit all three streams so browser/SSO prompts and the SSH terminal work.
+    result = subprocess.run(args, check=False)
+    if result.returncode:
+        code = result.returncode if result.returncode > 0 else 128 - result.returncode
+        click.echo(f"Teleport {operation} exited with status {code}.", err=True)
+        raise click.exceptions.Exit(code)
+
+
+def connect_teleport(
+    connection: TeleportTarget,
+    auth: str = "Starfleet",
+    *,
+    workspace: Optional[str] = None,
+    before_connect: Optional[Callable[[], None]] = None,
+) -> None:
+    """Reuse a valid tsh profile, log in if needed, then hand over the terminal."""
+    if isinstance(connection, TeleportConnection) and connection.status != "Running":
+        raise click.ClickException(
+            "The pod is not reporting a running Teleport connection. "
+            "Check Teleport SSH Access in the dashboard and retry when it is ready."
+        )
+    tsh = shutil.which("tsh")
+    if tsh is None:
+        raise click.ClickException(
+            "Teleport CLI (tsh) was not found in PATH. Install it from "
+            "https://goteleport.com/docs/connect-your-client/teleport-clients/tsh/"
+        )
+    proxy = f"--proxy={connection.proxy}:{connection.port}"
+    try:
+        profile = _profile(tsh, connection)
+        if profile is None:
+            click.echo("Signing in to Teleport...")
+            _run_interactive(
+                [tsh, "login", proxy, f"--auth={auth}", connection.cluster_domain],
+                "login",
+            )
+            profile = _profile(tsh, connection)
+            if profile is None:
+                raise click.ClickException(
+                    "Teleport login did not produce a valid profile for the target's "
+                    "proxy and cluster."
+                )
+        if connection.username not in profile["logins"]:
+            raise click.ClickException(
+                "Your Teleport identity is not authorized to log in as"
+                f" {connection.username}. Check your Teleport access or sign in with"
+                " the correct account."
+            )
+        if before_connect is not None:
+            before_connect()
+        node = connection.name
+        if workspace is not None:
+            node = _job_node(tsh, connection, profile["username"], workspace)
+        _run_interactive(
+            [
+                tsh,
+                "ssh",
+                proxy,
+                f"--cluster={connection.cluster_domain}",
+                f"--user={profile['username']}",
+                f"{connection.username}@{node}",
+            ],
+            "SSH",
+        )
+    except KeyboardInterrupt:
+        raise click.exceptions.Exit(130) from None
+    except OSError as error:
+        raise click.ClickException(
+            f"Could not run Teleport CLI (tsh): {error}"
+        ) from None
+
+
+def _job_node(tsh: str, target: TeleportTarget, user: str, workspace: str) -> str:
+    """Resolve the exact registered hostname to one Teleport node ID."""
+    try:
+        result = subprocess.run(
+            [
+                tsh,
+                "ls",
+                f"--proxy={target.proxy}:{target.port}",
+                f"--cluster={target.cluster_domain}",
+                f"--user={user}",
+                "--format=json",
+                f"--search={target.name}",
+                f"teleport.lepton.ai/workspace={workspace}",
+            ],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        raise click.ClickException(
+            "Timed out discovering the Job's Teleport node."
+        ) from None
+    if result.returncode:
+        raise click.ClickException(
+            "Could not list Teleport nodes. Check your Teleport login, permissions, "
+            "and --teleport-proxy."
+        )
+    try:
+        nodes = json.loads(result.stdout)
+        if not isinstance(nodes, list):
+            raise ValueError
+        matches = []
+        for node in nodes:
+            if not isinstance(node, dict):
+                raise ValueError
+            metadata, spec = node.get("metadata"), node.get("spec")
+            if not isinstance(metadata, dict) or not isinstance(spec, dict):
+                raise ValueError
+            labels = metadata.get("labels")
+            if (
+                node.get("kind") == "node"
+                and spec.get("hostname") == target.name
+                and isinstance(labels, dict)
+                and labels.get("teleport.lepton.ai/workspace") == workspace
+            ):
+                node_id = metadata.get("name")
+                if not isinstance(node_id, str) or not re.fullmatch(
+                    r"[a-zA-Z0-9][a-zA-Z0-9._-]*", node_id
+                ):
+                    raise ValueError
+                matches.append(node_id)
+    except (ValueError, TypeError):
+        raise click.ClickException("Teleport returned an invalid node list.") from None
+    if not matches:
+        raise click.ClickException(
+            "No Teleport node is visible for this Job replica. Verify the proxy, "
+            "job_teleport enablement, and that the Job image starts a Teleport agent."
+        )
+    if len(matches) != 1:
+        raise click.ClickException(
+            "Multiple Teleport nodes match this Job replica. Wait for stale "
+            "registrations to expire or ask your administrator to resolve them."
+        )
+    return matches[0]
+
+
+def connect_job_teleport(
+    workspace: str,
+    replica: str,
+    *,
+    proxy: Optional[str] = None,
+    auth: str = "Starfleet",
+    before_connect: Optional[Callable[[], None]] = None,
+) -> None:
+    """Job APIs omit Teleport metadata; use an explicit proxy or the tsh profile."""
+    tsh = shutil.which("tsh")
+    if tsh is None:
+        raise click.ClickException(
+            "Teleport CLI (tsh) was not found in PATH. Install tsh first."
+        )
+    try:
+        if proxy is not None:
+            if any(c.isspace() for c in proxy) or "\0" in proxy:
+                raise ValueError
+            url = urlsplit(f"https://{proxy}")
+            cluster = url.hostname
+        else:
+            active = _status(tsh)
+            if active is None:
+                raise click.ClickException(
+                    "No Teleport profile is selected. Use --teleport-proxy"
+                    " <host[:port]> or run tsh login first."
+                )
+            url = urlsplit(active["profile_url"])
+            cluster = active.get("cluster")
+        if (
+            url.scheme != "https"
+            or not url.hostname
+            or url.username is not None
+            or url.password is not None
+            or url.path not in ("", "/")
+            or url.query
+            or url.fragment
+        ):
+            raise ValueError
+        # Explicit Lepton proxies use LEPTON_TELEPORT_CLUSTER as their cluster.
+        target = TeleportTarget(
+            name=f"{workspace}-{replica}",
+            proxy=url.hostname,
+            port=url.port if url.port is not None else 443,
+            clusterDomain=cluster,
+            username="root",
+        )
+    except (ValueError, TypeError, KeyError, ValidationError):
+        raise click.ClickException(
+            "Invalid Teleport proxy or Job replica. Use --teleport-proxy <host[:port]>."
+        ) from None
+    except OSError as error:
+        raise click.ClickException(
+            f"Could not run Teleport CLI (tsh): {error}"
+        ) from None
+    except KeyboardInterrupt:
+        raise click.exceptions.Exit(130) from None
+    click.echo(
+        f"Connecting to Job replica {replica} via Teleport"
+        f" ({target.proxy}:{target.port})..."
+    )
+    connect_teleport(target, auth, workspace=workspace, before_connect=before_connect)

--- a/leptonai/cli/teleport.py
+++ b/leptonai/cli/teleport.py
@@ -329,6 +329,7 @@ def connect_job_teleport(
             if any(c.isspace() for c in proxy) or "\0" in proxy:
                 raise ValueError
             url = urlsplit(f"https://{proxy}")
+            # An explicit proxy uses its hostname as the cluster name.
             cluster = url.hostname
         else:
             active = _status(tsh)
@@ -349,7 +350,6 @@ def connect_job_teleport(
             or url.fragment
         ):
             raise ValueError
-        # Explicit Lepton proxies use LEPTON_TELEPORT_CLUSTER as their cluster.
         target = TeleportTarget(
             name=f"{workspace}-{replica}",
             proxy=url.hostname,

--- a/leptonai/cli/teleport.py
+++ b/leptonai/cli/teleport.py
@@ -14,6 +14,70 @@ from pydantic import ValidationError
 from leptonai.api.v2.types.teleport import TeleportConnection, TeleportTarget
 
 
+_TSH_INSTALL_URL = (
+    "https://goteleport.com/docs/connect-your-client/teleport-clients/tsh/"
+)
+_MIN_TSH_MAJOR = 18
+
+
+def _check_tsh_version(tsh: str) -> None:
+    """Check the executing client version, not the proxy or re-exec source."""
+    try:
+        result = subprocess.run(
+            [tsh, "version"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        raise click.ClickException(
+            "Timed out checking the Teleport client version. Run tsh version to "
+            "check your installation."
+        ) from None
+    if result.returncode:
+        raise click.ClickException(
+            "Could not check the Teleport client version (tsh version exited with "
+            f"status {result.returncode}). Run tsh version to check your installation."
+        )
+    match = re.search(
+        r"^Teleport(?: Enterprise)? v(\d+)\.(\d+)\.(\d+)"
+        r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?(?=\s|$)",
+        result.stdout,
+        re.MULTILINE,
+    )
+    if match is None:
+        raise click.ClickException(
+            "Could not determine the Teleport client version. "
+            f"SSH requires tsh v{_MIN_TSH_MAJOR} or newer. "
+            f"Run tsh version or reinstall from {_TSH_INSTALL_URL}"
+        )
+    if int(match.group(1)) < _MIN_TSH_MAJOR:
+        version = ".".join(match.group(1, 2, 3))
+        raise click.ClickException(
+            f"SSH requires tsh v{_MIN_TSH_MAJOR} or newer; found v{version}. "
+            f"Upgrade your Teleport CLI from {_TSH_INSTALL_URL}"
+        )
+
+
+def _require_tsh() -> str:
+    tsh = shutil.which("tsh")
+    if tsh is None:
+        raise click.ClickException(
+            "Teleport CLI (tsh) was not found in PATH. "
+            f"Install tsh v{_MIN_TSH_MAJOR} or newer from {_TSH_INSTALL_URL}"
+        )
+    try:
+        _check_tsh_version(tsh)
+    except OSError as error:
+        raise click.ClickException(
+            f"Could not run Teleport CLI (tsh): {error}"
+        ) from None
+    except KeyboardInterrupt:
+        raise click.exceptions.Exit(130) from None
+    return tsh
+
+
 def _status(tsh: str, proxy: Optional[str] = None) -> Optional[dict]:
     """Read the selected tsh profile, including expired profiles for discovery."""
     args = [tsh, "status"]
@@ -120,12 +184,24 @@ def connect_teleport(
             "The pod is not reporting a running Teleport connection. "
             "Check Teleport SSH Access in the dashboard and retry when it is ready."
         )
-    tsh = shutil.which("tsh")
-    if tsh is None:
-        raise click.ClickException(
-            "Teleport CLI (tsh) was not found in PATH. Install it from "
-            "https://goteleport.com/docs/connect-your-client/teleport-clients/tsh/"
-        )
+    _connect_teleport(
+        _require_tsh(),
+        connection,
+        auth,
+        workspace=workspace,
+        before_connect=before_connect,
+    )
+
+
+def _connect_teleport(
+    tsh: str,
+    connection: TeleportTarget,
+    auth: str,
+    *,
+    workspace: Optional[str] = None,
+    before_connect: Optional[Callable[[], None]] = None,
+) -> None:
+    """Start a session after client preflight, without checking the client twice."""
     proxy = f"--proxy={connection.proxy}:{connection.port}"
     try:
         profile = _profile(tsh, connection)
@@ -247,11 +323,7 @@ def connect_job_teleport(
     before_connect: Optional[Callable[[], None]] = None,
 ) -> None:
     """Job APIs omit Teleport metadata; use an explicit proxy or the tsh profile."""
-    tsh = shutil.which("tsh")
-    if tsh is None:
-        raise click.ClickException(
-            "Teleport CLI (tsh) was not found in PATH. Install tsh first."
-        )
+    tsh = _require_tsh()
     try:
         if proxy is not None:
             if any(c.isspace() for c in proxy) or "\0" in proxy:
@@ -299,4 +371,6 @@ def connect_job_teleport(
         f"Connecting to Job replica {replica} via Teleport"
         f" ({target.proxy}:{target.port})..."
     )
-    connect_teleport(target, auth, workspace=workspace, before_connect=before_connect)
+    _connect_teleport(
+        tsh, target, auth, workspace=workspace, before_connect=before_connect
+    )

--- a/leptonai/cli/tests/test_job_ssh.py
+++ b/leptonai/cli/tests/test_job_ssh.py
@@ -1,0 +1,366 @@
+"""Job replica selection and Teleport discovery through the actual CLI/API seam."""
+
+from datetime import datetime, timedelta, timezone
+import json
+import os
+import subprocess
+import tempfile
+from unittest.mock import patch
+
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+import pytest
+import responses
+from click.testing import CliRunner
+
+from leptonai.api.v2.client import APIClient
+from leptonai.cli.job import job
+
+
+BASE = "https://gw.example/api/v2/workspaces/ws-job-ssh"
+JOB_URL = f"{BASE}/jobs/train-id"
+REPLICAS_URL = f"{JOB_URL}/replicas"
+HOST = "ws-job-ssh-worker-1"
+PROXY = "proxy.example.com"
+
+
+def job_body(state="Running", name="train", id="train-id"):
+    return {"metadata": {"id": id, "name": name}, "status": {"state": state}}
+
+
+def replica(id="worker-1", reason="Ready"):
+    return {"metadata": {"id": id}, "status": {"readiness_issue": {"reason": reason}}}
+
+
+def result(code=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess([], code, stdout, stderr)
+
+
+def profile(proxy=PROXY, cluster=PROXY, expired=False):
+    return result(
+        stdout=json.dumps({
+            "active": {
+                "profile_url": f"https://{proxy}",
+                "cluster": cluster,
+                "username": "alice@example.com",
+                "logins": ["root"],
+                "valid_until": (
+                    datetime.now(timezone.utc) + timedelta(hours=-1 if expired else 1)
+                ).isoformat(),
+            }
+        })
+    )
+
+
+def node(hostname=HOST, workspace="ws-job-ssh", id="node-uuid"):
+    return {
+        "kind": "node",
+        "metadata": {"name": id, "labels": {"teleport.lepton.ai/workspace": workspace}},
+        "spec": {"hostname": hostname},
+    }
+
+
+@pytest.fixture
+def session():
+    client = APIClient(workspace_id="ws-job-ssh", auth_token="test-token", url=BASE)
+    with (
+        responses.RequestsMock() as http,
+        patch("leptonai.cli.job.APIClient", return_value=client),
+        patch("leptonai.cli.teleport.shutil.which", return_value="/usr/bin/tsh"),
+        patch("leptonai.cli.teleport.subprocess.run") as run,
+    ):
+        yield http, run
+
+
+def register(http, *, state="Running", replicas=None):
+    http.get(JOB_URL, json=job_body(state))
+    if state == "Running":
+        http.get(REPLICAS_URL, json=[replica()] if replicas is None else replicas)
+
+
+def invoke(*extra):
+    return CliRunner().invoke(job, ["ssh", "--id", "train-id", *extra])
+
+
+def test_single_replica_uses_active_proxy_and_exact_node_id(session):
+    http, run = session
+    register(http)
+    run.side_effect = [
+        profile(),
+        profile(),
+        result(stdout=json.dumps([node()])),
+        result(),
+    ]
+    output = invoke()
+    assert output.exit_code == 0, output.output
+    assert [c.args[0][1] for c in run.call_args_list] == [
+        "status",
+        "status",
+        "ls",
+        "ssh",
+    ]
+    listing = run.call_args_list[2]
+    assert listing.args[0] == [
+        "/usr/bin/tsh",
+        "ls",
+        "--proxy=proxy.example.com:443",
+        "--cluster=proxy.example.com",
+        "--user=alice@example.com",
+        "--format=json",
+        f"--search={HOST}",
+        "teleport.lepton.ai/workspace=ws-job-ssh",
+    ]
+    assert listing.kwargs["timeout"] == 15
+    assert run.call_args.args[0][-1] == "root@node-uuid"
+    assert run.call_args.kwargs == {"check": False}
+    assert "worker-1" in output.output
+    assert len(http.calls) == 4  # Job and replica checks both before and after login.
+    assert all("job_query_mode=alive_only" in c.request.url for c in http.calls)
+
+
+def test_explicit_proxy_logs_in_without_an_active_profile(session):
+    http, run = session
+    register(http)
+    run.side_effect = [
+        result(1, stderr="ERROR: Not logged in."),
+        result(),
+        profile(),
+        result(stdout=json.dumps([node()])),
+        result(),
+    ]
+    output = invoke("--teleport-proxy", PROXY, "--teleport-auth", "Custom SSO")
+    assert output.exit_code == 0, output.output
+    assert run.call_args_list[1].args[0] == [
+        "/usr/bin/tsh",
+        "login",
+        "--proxy=proxy.example.com:443",
+        "--auth=Custom SSO",
+        "proxy.example.com",
+    ]
+    assert run.call_args_list[1].kwargs == {"check": False}
+
+
+def test_active_profile_with_distinct_cluster_is_preserved(session):
+    http, run = session
+    register(http)
+    run.side_effect = [
+        profile(cluster="cluster.example.com"),
+        profile(cluster="cluster.example.com"),
+        result(stdout=json.dumps([node()])),
+        result(),
+    ]
+    output = invoke()
+    assert output.exit_code == 0, output.output
+    assert "--cluster=cluster.example.com" in run.call_args.args[0]
+
+
+def test_expired_active_profile_can_discover_proxy_then_login(session):
+    http, run = session
+    register(http)
+    run.side_effect = [
+        profile(expired=True),
+        profile(expired=True),
+        result(),
+        profile(),
+        result(stdout=json.dumps([node()])),
+        result(),
+    ]
+    output = invoke()
+    assert output.exit_code == 0, output.output
+    assert run.call_args_list[2].args[0][1] == "login"
+
+
+def test_no_profile_requires_proxy_without_attempting_login(session):
+    http, run = session
+    register(http)
+    run.return_value = result(1, stderr="ERROR: Not logged in.")
+    output = invoke()
+    assert output.exit_code == 1
+    assert "--teleport-proxy" in output.output
+    assert run.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "bad_proxy",
+    [
+        "https://proxy.example.com",
+        "user@proxy.example.com",
+        "proxy.example.com/path",
+        "proxy.example.com:0",
+        "proxy.example.com:65536",
+        "proxy.example.com\n",
+    ],
+)
+def test_invalid_proxy_never_invokes_tsh(session, bad_proxy):
+    http, run = session
+    register(http)
+    output = invoke("--teleport-proxy", bad_proxy)
+    assert output.exit_code == 1
+    run.assert_not_called()
+
+
+def test_multiple_ready_replicas_require_selection(session):
+    http, run = session
+    register(http, replicas=[replica(), replica("worker-2")])
+    output = invoke()
+    assert output.exit_code == 1
+    assert "--replica" in output.output
+    run.assert_not_called()
+
+
+def test_selected_replica_is_used(session):
+    http, run = session
+    register(http, replicas=[replica(), replica("worker-2")])
+    run.side_effect = [
+        profile(),
+        profile(),
+        result(stdout=json.dumps([node(hostname="ws-job-ssh-worker-2")])),
+        result(),
+    ]
+    output = invoke("--replica", "worker-2")
+    assert output.exit_code == 0, output.output
+    assert "--search=ws-job-ssh-worker-2" in run.call_args_list[2].args[0]
+
+
+@pytest.mark.parametrize(
+    "selection, reason",
+    [("foreign", "Ready"), ("worker-1", "Deleted"), ("worker-1", "InProgress")],
+)
+def test_unowned_or_not_ready_replica_is_rejected(session, selection, reason):
+    http, run = session
+    register(http, replicas=[replica(reason=reason)])
+    output = invoke("--replica", selection)
+    assert output.exit_code == 1
+    run.assert_not_called()
+
+
+def test_historical_replicas_are_excluded_from_automatic_selection(session):
+    http, run = session
+    register(http, replicas=[replica("old-worker", "Deleted"), replica()])
+    run.side_effect = [
+        profile(),
+        profile(),
+        result(stdout=json.dumps([node()])),
+        result(),
+    ]
+    output = invoke()
+    assert output.exit_code == 0, output.output
+    assert f"--search={HOST}" in run.call_args_list[2].args[0]
+
+
+@pytest.mark.parametrize(
+    "replicas",
+    [[], [replica(reason="InProgress")], [replica(), {}], [replica(), replica()], {}],
+)
+def test_missing_or_malformed_replica_list_never_invokes_tsh(session, replicas):
+    http, run = session
+    register(http, replicas=replicas)
+    output = invoke()
+    assert output.exit_code == 1
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "state", ["Completed", "Failed", "Archived", "Starting", "Stopped"]
+)
+def test_only_running_jobs_can_connect(session, state):
+    http, run = session
+    register(http, state=state)
+    output = invoke()
+    assert output.exit_code == 1
+    assert "running job" in output.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "nodes, message",
+    [
+        ([], "No Teleport node"),
+        ([node(hostname=HOST + "-old")], "No Teleport node"),
+        ([node(workspace="other-workspace")], "No Teleport node"),
+        ([node(), node(id="another-id")], "Multiple Teleport nodes"),
+        ([node(id="--option")], "invalid node list"),
+        ({}, "invalid node list"),
+        ([{}], "invalid node list"),
+    ],
+)
+def test_node_discovery_never_guesses_or_connects_to_unverified_targets(
+    session, nodes, message
+):
+    http, run = session
+    register(http)
+    run.side_effect = [profile(), profile(), result(stdout=json.dumps(nodes))]
+    output = invoke()
+    assert output.exit_code == 1
+    assert message in output.output
+    assert run.call_count == 3
+
+
+@pytest.mark.parametrize(
+    "failure, message",
+    [
+        (result(1, stderr="access denied"), "Could not list Teleport nodes"),
+        (subprocess.TimeoutExpired("tsh ls", 15), "Timed out discovering"),
+        (result(stdout="invalid JSON"), "invalid node list"),
+    ],
+)
+def test_node_lookup_failures_are_actionable(session, failure, message):
+    http, run = session
+    register(http)
+    run.side_effect = [profile(), profile(), failure]
+    output = invoke()
+    assert output.exit_code == 1
+    assert message in output.output
+    assert run.call_count == 3
+
+
+def test_replica_disappearing_during_login_cannot_connect(session):
+    http, run = session
+    http.get(JOB_URL, json=job_body())
+    http.get(REPLICAS_URL, json=[replica()])
+    http.get(REPLICAS_URL, json=[replica("replacement")])
+    run.side_effect = [profile(), profile()]
+    output = invoke()
+    assert output.exit_code == 1
+    assert "does not belong to the current job run" in output.output
+    assert run.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "names, message", [([], "No live job"), (["train", "train"], "Multiple jobs")]
+)
+def test_name_must_resolve_to_one_exact_job(session, names, message):
+    http, run = session
+    http.get(f"{BASE}/jobs", json={"jobs": [job_body(name=n) for n in names]})
+    if names:
+        http.get(f"{BASE}/jobs", json={"jobs": []})
+    output = CliRunner().invoke(job, ["ssh", "--name", "train"])
+    assert output.exit_code == 1
+    assert message in output.output
+    run.assert_not_called()
+
+
+def test_exact_name_resolves_to_job_id(session):
+    http, run = session
+    http.get(
+        f"{BASE}/jobs",
+        json={"jobs": [job_body(), job_body(name="train-other", id="other")]},
+    )
+    http.get(f"{BASE}/jobs", json={"jobs": []})
+    register(http)
+    run.side_effect = [
+        profile(),
+        profile(),
+        result(stdout=json.dumps([node()])),
+        result(),
+    ]
+    output = CliRunner().invoke(job, ["ssh", "--name", "train"])
+    assert output.exit_code == 0, output.output
+
+
+@pytest.mark.parametrize("args", [[], ["--id", "id", "--name", "name"]])
+def test_exactly_one_job_selector_is_required(args):
+    with patch("leptonai.cli.job.APIClient") as client:
+        output = CliRunner().invoke(job, ["ssh", *args])
+    assert output.exit_code == 2
+    client.assert_not_called()

--- a/leptonai/cli/tests/test_job_ssh.py
+++ b/leptonai/cli/tests/test_job_ssh.py
@@ -67,6 +67,8 @@ def session():
         responses.RequestsMock() as http,
         patch("leptonai.cli.job.APIClient", return_value=client),
         patch("leptonai.cli.teleport.shutil.which", return_value="/usr/bin/tsh"),
+        # Client preflight is exercised separately in test_teleport_preflight.py.
+        patch("leptonai.cli.teleport._check_tsh_version"),
         patch("leptonai.cli.teleport.subprocess.run") as run,
     ):
         yield http, run
@@ -152,6 +154,20 @@ def test_active_profile_with_distinct_cluster_is_preserved(session):
     output = invoke()
     assert output.exit_code == 0, output.output
     assert "--cluster=cluster.example.com" in run.call_args.args[0]
+
+
+@pytest.mark.parametrize("code", [7, 130, 255, -15])
+def test_ssh_exit_status_is_preserved(session, code):
+    http, run = session
+    register(http)
+    run.side_effect = [
+        profile(),
+        profile(),
+        result(stdout=json.dumps([node()])),
+        result(code=code),
+    ]
+    output = invoke()
+    assert output.exit_code == (code if code > 0 else 128 - code)
 
 
 def test_expired_active_profile_can_discover_proxy_then_login(session):

--- a/leptonai/cli/tests/test_teleport_preflight.py
+++ b/leptonai/cli/tests/test_teleport_preflight.py
@@ -1,0 +1,177 @@
+"""Exercise client preflight through both SSH commands without a real tsh."""
+
+from datetime import datetime, timedelta, timezone
+import json
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from leptonai.api.v2.types.teleport import TeleportConnection
+from leptonai.cli.job import job
+from leptonai.cli.pod import pod
+
+
+@pytest.fixture(params=["pod", "job", "job-explicit-proxy"])
+def session(request):
+    connection = TeleportConnection(
+        name="ws-worker",
+        status="Running",
+        proxy="proxy.example.com",
+        port=443,
+        clusterDomain="proxy.example.com",
+        username="root",
+    )
+    client = SimpleNamespace(
+        workspace_id="ws",
+        pod=SimpleNamespace(get_teleport_connection=Mock(return_value=connection)),
+        job=SimpleNamespace(get_ssh_replica=Mock(return_value="worker")),
+    )
+    if request.param == "pod":
+        module, command, args = (
+            "pod",
+            pod,
+            ["ssh", "-n", "pod", "--transport", "teleport"],
+        )
+    else:
+        module, command, args = "job", job, ["ssh", "--id", "job"]
+        if request.param == "job-explicit-proxy":
+            args += ["--teleport-proxy", "proxy.example.com"]
+    with (
+        patch(f"leptonai.cli.{module}.APIClient", return_value=client),
+        patch(
+            "leptonai.cli.teleport.shutil.which", return_value="/usr/bin/tsh"
+        ) as which,
+        patch("leptonai.cli.teleport.subprocess.run") as run,
+    ):
+        yield lambda: CliRunner().invoke(command, args), which, run
+
+
+def completed(stdout="", code=0):
+    return subprocess.CompletedProcess([], code, stdout, "")
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "Teleport v18.0.0 git:abc go1.24.0\n",
+        "Teleport Enterprise v18.2.5 git:abc\n",
+        "Teleport v19.0.0-dev+build.1 git:abc\n",
+        (
+            "Teleport v18.6.2 git:abc\nProxy version: 17.0.0\n"
+            "Re-executed from version: 17.0.0\n"
+        ),
+    ],
+)
+def test_supported_client_is_checked_once_before_profiles_and_ssh(session, version):
+    invoke, _, run = session
+
+    def execute(args, **kwargs):
+        if args[1] == "version":
+            return completed(version)
+        if args[1] == "status":
+            return completed(
+                json.dumps({
+                    "active": {
+                        "profile_url": "https://proxy.example.com",
+                        "cluster": "proxy.example.com",
+                        "username": "alice@example.com",
+                        "logins": ["root"],
+                        "valid_until": (
+                            datetime.now(timezone.utc) + timedelta(hours=1)
+                        ).isoformat(),
+                    }
+                })
+            )
+        if args[1] == "ls":
+            return completed(
+                json.dumps([{
+                    "kind": "node",
+                    "metadata": {
+                        "name": "node-id",
+                        "labels": {"teleport.lepton.ai/workspace": "ws"},
+                    },
+                    "spec": {"hostname": "ws-worker"},
+                }])
+            )
+        assert args[1] == "ssh"
+        return completed()
+
+    run.side_effect = execute
+    result = invoke()
+    assert result.exit_code == 0, result.output
+    commands = [call.args[0][1] for call in run.call_args_list]
+    assert commands[0] == "version"
+    assert commands.count("version") == 1
+    assert commands[-1] == "ssh"
+    assert run.call_args_list[0].kwargs == {
+        "stdin": subprocess.DEVNULL,
+        "capture_output": True,
+        "text": True,
+        "timeout": 10,
+    }
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "Teleport v17.9.9 git:abc\n",
+        "Teleport v9.0.0\n",
+        "Teleport v17.9.9\nProxy version: 18.11.0\nRe-executed from version: 18.7.3\n",
+    ],
+)
+def test_old_client_blocks_profile_login_and_ssh(session, version):
+    invoke, _, run = session
+    run.return_value = completed(version)
+    result = invoke()
+    assert result.exit_code == 1
+    assert "requires tsh v18 or newer" in result.output
+    assert "Upgrade" in result.output
+    assert "goteleport.com" in result.output
+    assert run.call_count == 1
+    assert run.call_args.args[0] == ["/usr/bin/tsh", "version"]
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["", "garbage", "Proxy version: 18.11.0", "Teleport v18", "Teleport v18.0.0oops"],
+)
+def test_unknown_version_fails_before_profiles_or_login(session, version):
+    invoke, _, run = session
+    run.return_value = completed(version)
+    result = invoke()
+    assert result.exit_code == 1
+    assert "Could not determine" in result.output
+    assert "requires tsh v18 or newer" in result.output
+    assert run.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "failure, message, code",
+    [
+        (completed("Teleport v18.0.0", code=2), "exited with status 2", 1),
+        (subprocess.TimeoutExpired("tsh version", 10), "Timed out", 1),
+        (FileNotFoundError("tsh disappeared"), "Could not run Teleport", 1),
+        (KeyboardInterrupt(), "", 130),
+    ],
+)
+def test_failed_version_check_does_not_continue(session, failure, message, code):
+    invoke, _, run = session
+    run.side_effect = [failure]
+    result = invoke()
+    assert result.exit_code == code, result.output
+    assert message in result.output
+    assert run.call_count == 1
+
+
+def test_missing_client_has_installation_and_minimum_version_hint(session):
+    invoke, which, run = session
+    which.return_value = None
+    result = invoke()
+    assert result.exit_code == 1
+    assert "not found in PATH" in result.output
+    assert "tsh v18 or newer" in result.output
+    assert "goteleport.com" in result.output
+    run.assert_not_called()

--- a/leptonai/cli/tests/test_teleport_ssh.py
+++ b/leptonai/cli/tests/test_teleport_ssh.py
@@ -1,0 +1,412 @@
+"""Pod discovery and tsh session regressions, without network or SSH access."""
+
+from datetime import datetime, timedelta, timezone
+import json
+import os
+import subprocess
+import tempfile
+from unittest.mock import patch
+from types import SimpleNamespace
+
+os.environ.setdefault("LEPTON_CACHE_DIR", tempfile.mkdtemp())
+
+import pytest
+import responses
+from click.testing import CliRunner
+
+from leptonai.api.v2.client import APIClient, reset_new_deployment_api_flag_cache
+from leptonai.cli.pod import pod
+
+
+BASE = "https://gw.example/api/v2/workspaces/ws-teleport"
+REPLICAS = f"{BASE}/deployments/my-pod/replicas"
+CONNECTION_URL = f"{REPLICAS}/replica-1/teleport-connectivity"
+CONNECTION = {
+    "name": "ws-teleport-my-pod",
+    "status": "Running",
+    "proxy": "proxy.example.com",
+    "port": 443,
+    "clusterDomain": "cluster.example.com",
+    "username": "root",
+}
+
+
+def profile(**overrides):
+    active = {
+        "profile_url": "https://proxy.example.com:443",
+        "cluster": "cluster.example.com",
+        "username": "alice@example.com",
+        "valid_until": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        "logins": ["root"],
+    }
+    active.update(overrides)
+    return subprocess.CompletedProcess([], 0, json.dumps({"active": active}), "")
+
+
+def completed(code=0):
+    return subprocess.CompletedProcess([], code, "", "")
+
+
+def logged_out():
+    return subprocess.CompletedProcess([], 1, "", "ERROR: Not logged in.\n")
+
+
+@pytest.fixture
+def session():
+    reset_new_deployment_api_flag_cache()
+    client = APIClient(workspace_id="ws-teleport", auth_token="test-token", url=BASE)
+    with (
+        responses.RequestsMock() as http,
+        patch.object(
+            APIClient, "_resolve_new_deployment_api", return_value=False
+        ) as flag,
+        patch("leptonai.cli.pod.APIClient", return_value=client),
+        patch(
+            "leptonai.cli.teleport.shutil.which", return_value="/usr/bin/tsh"
+        ) as which,
+        patch("leptonai.cli.teleport.subprocess.run") as run,
+    ):
+        yield http, flag, which, run
+    reset_new_deployment_api_flag_cache()
+
+
+def register(http, *, connection=None, replicas=None):
+    http.get(
+        REPLICAS,
+        json=replicas if replicas is not None else [{"metadata": {"id": "replica-1"}}],
+    )
+    if replicas is None:
+        http.get(CONNECTION_URL, json=CONNECTION if connection is None else connection)
+
+
+def invoke(*extra):
+    return CliRunner().invoke(
+        pod, ["ssh", "-n", "my-pod", "--transport", "teleport", *extra]
+    )
+
+
+def test_reuses_profile_without_public_ip_or_port_mapping(session):
+    http, _, _, run = session
+    register(http)
+    run.side_effect = [profile(), completed()]
+    result = invoke()
+    assert result.exit_code == 0, result.output
+    assert [c.request.url for c in http.calls] == [REPLICAS, CONNECTION_URL]
+    assert run.call_args_list[0].args[0] == [
+        "/usr/bin/tsh",
+        "status",
+        "--proxy=proxy.example.com:443",
+        "--format=json",
+    ]
+    assert run.call_args_list[0].kwargs["timeout"] == 10
+    assert run.call_args.args[0] == [
+        "/usr/bin/tsh",
+        "ssh",
+        "--proxy=proxy.example.com:443",
+        "--cluster=cluster.example.com",
+        "--user=alice@example.com",
+        "root@ws-teleport-my-pod",
+    ]
+    assert run.call_args.kwargs == {"check": False}
+
+
+def test_tsh_v18_status_does_not_require_unsupported_client_flag(session):
+    http, _, _, run = session
+    register(http)
+
+    def tsh_v18(args, **kwargs):
+        if args[1] == "status":
+            if "--client" in args:
+                return subprocess.CompletedProcess(
+                    args, 1, "", "tsh: error: unknown long flag '--client'"
+                )
+            return profile()
+        return completed()
+
+    run.side_effect = tsh_v18
+    result = invoke()
+    assert result.exit_code == 0, result.output
+    assert [call.args[0][1] for call in run.call_args_list] == ["status", "ssh"]
+
+
+def test_status_command_error_does_not_start_sso_login(session):
+    http, _, _, run = session
+    register(http)
+    run.return_value = subprocess.CompletedProcess(
+        [], 1, "", "tsh: error: unknown long flag '--example'"
+    )
+    result = invoke()
+    assert result.exit_code == 1
+    assert "Could not check the local Teleport login" in result.output
+    assert "Signing in" not in result.output
+    assert run.call_count == 1
+
+
+def test_expired_json_profile_with_nonzero_status_can_log_in(session):
+    http, _, _, run = session
+    register(http)
+    expired = profile(valid_until="2020-01-01T00:00:00Z")
+    expired.returncode = 1
+    run.side_effect = [expired, completed(), profile(), completed()]
+    result = invoke()
+    assert result.exit_code == 0, result.output
+    assert run.call_args_list[1].args[0][1] == "login"
+
+
+@pytest.mark.parametrize(
+    "initial",
+    [
+        logged_out(),
+        profile(valid_until="2020-01-01T00:00:00Z"),
+        profile(profile_url="https://another.example.com:443"),
+        profile(cluster="another-cluster"),
+    ],
+)
+def test_missing_expired_or_wrong_profile_logs_in_and_rechecks(session, initial):
+    http, _, _, run = session
+    register(http)
+    run.side_effect = [initial, completed(), profile(), completed()]
+    result = invoke()
+    assert result.exit_code == 0, result.output
+    assert "Signing in" in result.output
+    assert run.call_args_list[1].args[0] == [
+        "/usr/bin/tsh",
+        "login",
+        "--proxy=proxy.example.com:443",
+        "--auth=Starfleet",
+        "cluster.example.com",
+    ]
+    assert run.call_args_list[1].kwargs == {"check": False}
+    assert run.call_args_list[2].args[0][1] == "status"
+
+
+def test_auth_override_is_passed_as_one_argument(session):
+    http, _, _, run = session
+    register(http)
+    run.side_effect = [logged_out(), completed(), profile(), completed()]
+    result = invoke("--teleport-auth", "Custom SSO")
+    assert result.exit_code == 0, result.output
+    assert "--auth=Custom SSO" in run.call_args_list[1].args[0]
+
+
+@pytest.mark.parametrize("code", [1, 42, 130, 255, -15])
+def test_ssh_exit_status_is_preserved(session, code):
+    http, _, _, run = session
+    register(http)
+    run.side_effect = [profile(), completed(code)]
+    result = invoke()
+    assert result.exit_code == (code if code > 0 else 128 - code)
+
+
+def test_failed_login_never_starts_ssh(session):
+    http, _, _, run = session
+    register(http)
+    run.side_effect = [logged_out(), completed(7)]
+    result = invoke()
+    assert result.exit_code == 7
+    assert run.call_count == 2
+
+
+def test_successful_login_without_correct_profile_never_starts_ssh(session):
+    http, _, _, run = session
+    register(http)
+    run.side_effect = [logged_out(), completed(), profile(cluster="wrong")]
+    result = invoke()
+    assert result.exit_code == 1
+    assert "did not produce a valid profile" in result.output
+    assert run.call_count == 3
+
+
+def test_missing_login_principal_does_not_retry_login_or_connect(session):
+    http, _, _, run = session
+    register(http)
+    run.return_value = profile(logins=["ubuntu"])
+    result = invoke()
+    assert result.exit_code == 1
+    assert "not authorized to log in as root" in result.output
+    assert run.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "bad_profile",
+    [
+        subprocess.CompletedProcess([], 0, "invalid json", ""),
+        profile(valid_until="bad date"),
+        profile(valid_until="2030-01-01T00:00:00"),
+        profile(logins="root"),
+        profile(username=None),
+        profile(username="alice\0@example.com"),
+    ],
+)
+def test_invalid_profile_fails_without_starting_login_or_ssh(session, bad_profile):
+    http, _, _, run = session
+    register(http)
+    run.return_value = bad_profile
+    result = invoke()
+    assert result.exit_code == 1
+    assert "Could not read the local Teleport profile" in result.output
+    assert run.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "error, message",
+    [
+        (subprocess.TimeoutExpired("tsh", 10), "Timed out"),
+        (FileNotFoundError("tsh disappeared"), "Could not run Teleport"),
+    ],
+)
+def test_tool_errors_are_actionable(session, error, message):
+    http, _, _, run = session
+    register(http)
+    run.side_effect = error
+    result = invoke()
+    assert result.exit_code == 1
+    assert message in result.output
+
+
+def test_missing_tsh_has_installation_hint(session):
+    http, _, which, run = session
+    register(http)
+    which.return_value = None
+    result = invoke()
+    assert result.exit_code == 1
+    assert "not found in PATH" in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "connection, message",
+    [
+        ({"code": "OK", "message": "teleport not enabled"}, "not enabled"),
+        ({**CONNECTION, "status": "NotRunning"}, "not reporting a running"),
+        ({"status": "Running", "name": "my-pod"}, "incomplete or invalid"),
+        ({**CONNECTION, "port": True}, "incomplete or invalid"),
+        ({**CONNECTION, "port": 65536}, "incomplete or invalid"),
+        ({**CONNECTION, "proxy": "https://proxy.example.com"}, "incomplete or invalid"),
+        ({**CONNECTION, "name": "node; touch /tmp/pwned"}, "incomplete or invalid"),
+        ({**CONNECTION, "name": "role=all"}, "incomplete or invalid"),
+        ({**CONNECTION, "username": "--option"}, "incomplete or invalid"),
+        ({**CONNECTION, "clusterDomain": "--option"}, "incomplete or invalid"),
+        ({**CONNECTION, "status": "Unknown"}, "incomplete or invalid"),
+    ],
+)
+def test_unavailable_or_malformed_connection_never_spawns_tsh(
+    session, connection, message
+):
+    http, _, _, run = session
+    register(http, connection=connection)
+    result = invoke()
+    assert result.exit_code == 1
+    assert message in result.output
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize("replicas", [[], [{}, {}], {}, [{"metadata": {}}]])
+def test_missing_ambiguous_or_invalid_replica_never_queries_connection(
+    session, replicas
+):
+    http, _, _, run = session
+    register(http, replicas=replicas)
+    result = invoke()
+    assert result.exit_code == 1
+    assert "replica" in result.output
+    assert len(http.calls) == 1
+    run.assert_not_called()
+
+
+@pytest.mark.parametrize("code", [403, 404, 500])
+def test_connection_api_error_is_not_treated_as_disabled_or_fallback(session, code):
+    http, _, _, run = session
+    http.get(REPLICAS, json=[{"metadata": {"id": "replica-1"}}])
+    http.get(CONNECTION_URL, status=code, json={"message": "API unavailable"})
+    result = invoke()
+    assert result.exit_code == 1
+    assert str(code) in result.output
+    run.assert_not_called()
+
+
+def test_new_devpod_api_rejects_teleport_without_legacy_requests(session):
+    http, flag, _, run = session
+    flag.return_value = True
+    result = invoke()
+    assert result.exit_code == 1
+    assert "not yet supported by the new DevPod API" in result.output
+    assert len(http.calls) == 0
+    run.assert_not_called()
+
+
+def test_auth_option_requires_teleport_before_api_client_creation():
+    with patch("leptonai.cli.pod.APIClient") as client:
+        result = CliRunner().invoke(
+            pod, ["ssh", "-n", "my-pod", "--teleport-auth", "SSO"]
+        )
+    assert result.exit_code == 2
+    assert "requires --transport teleport" in result.output
+    client.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "port, profile_url",
+    [
+        (443, "https://proxy.example.com"),
+        (8443, "https://proxy.example.com:8443"),
+    ],
+)
+def test_matching_proxy_port_reuses_profile(session, port, profile_url):
+    http, _, _, run = session
+    register(http, connection={**CONNECTION, "port": port})
+    run.side_effect = [profile(profile_url=profile_url), completed()]
+    result = invoke()
+    assert result.exit_code == 0, result.output
+    assert run.call_count == 2
+    assert f"--proxy=proxy.example.com:{port}" in run.call_args.args[0]
+
+
+def test_wrong_proxy_port_requires_login(session):
+    http, _, _, run = session
+    register(http)
+    run.side_effect = [
+        profile(profile_url="https://proxy.example.com:8443"),
+        completed(),
+        profile(),
+        completed(),
+    ]
+    result = invoke()
+    assert result.exit_code == 0, result.output
+    assert run.call_args_list[1].args[0][1] == "login"
+
+
+@pytest.mark.parametrize("during_login", [False, True])
+def test_keyboard_interrupt_exits_130(session, during_login):
+    http, _, _, run = session
+    register(http)
+    run.side_effect = [logged_out() if during_login else profile(), KeyboardInterrupt()]
+    result = invoke()
+    assert result.exit_code == 130
+
+
+@pytest.mark.parametrize("args", [[], ["--transport", "ssh"]])
+def test_direct_ssh_keeps_existing_behavior(args):
+    pod_model = SimpleNamespace(
+        metadata=SimpleNamespace(name="my-pod"),
+        status=SimpleNamespace(
+            state="Ready",
+            container_port_status=[
+                SimpleNamespace(container_port=2222, host_port=30022)
+            ],
+        ),
+        model_dump=lambda: {},
+    )
+    client = SimpleNamespace(pod=SimpleNamespace(get=lambda _: pod_model))
+    with (
+        patch("leptonai.cli.pod.APIClient", return_value=client),
+        patch(
+            "leptonai.cli.pod._get_only_replica_public_ip", return_value="203.0.113.7"
+        ),
+        patch("leptonai.cli.pod.subprocess.run") as run,
+        patch("leptonai.cli.pod.connect_teleport") as teleport,
+    ):
+        result = CliRunner().invoke(pod, ["ssh", "-n", "my-pod", *args])
+    assert result.exit_code == 0, result.output
+    assert run.call_args.args[0] == ["ssh", "-p", "30022", "root@203.0.113.7"]
+    teleport.assert_not_called()

--- a/leptonai/cli/tests/test_teleport_ssh.py
+++ b/leptonai/cli/tests/test_teleport_ssh.py
@@ -64,6 +64,8 @@ def session():
         patch(
             "leptonai.cli.teleport.shutil.which", return_value="/usr/bin/tsh"
         ) as which,
+        # Client preflight is exercised separately in test_teleport_preflight.py.
+        patch("leptonai.cli.teleport._check_tsh_version"),
         patch("leptonai.cli.teleport.subprocess.run") as run,
     ):
         yield http, flag, which, run


### PR DESCRIPTION
Pods with Teleport enabled previously required users to run `tsh` separately, and Jobs had no SSH command. Add `lep pod ssh --transport teleport` and `lep job ssh --id <job-id>` with local profile reuse, SSO login when needed, interactive terminal forwarding, and preserved exit codes.

- Resolve legacy Pod connection metadata through the API; retain direct SSH as the Pod default and report the unsupported new DevPod API explicitly.
- Select a single ready Job replica, requiring `--replica` when multiple are ready. Revalidate after login and resolve one Teleport node by its exact hostname and workspace label. Use the active profile or `--teleport-proxy` because the Job API omits connection metadata.
- Require `tsh` v18 or newer before profile discovery or SSO, with a bounded version check and actionable errors for missing, outdated, or unrecognized clients. Parse the executing client version rather than proxy/re-exec metadata. Validate profiles and targets, handle failed discovery, and use the Teleport v18-compatible `tsh status --format=json` invocation.
- Preserve Job SSH and Ctrl-C exit codes through Click error handling.
- Document setup requirements and usage. Workloads must already run a Teleport agent.

Validation: 181 related tests and 2 subtests passed; Black, Ruff, and commit hooks passed. Live Pod and newly created single-worker Job SSH sessions both reached a root shell and exited successfully. The added client preflight also passed against the installed tsh v18.6.2. The minimum client version check does not guarantee compatibility with every cluster version.
