### PR TITLE
fix(client): normalize content-type and read streamed responses

### DIFF
--- a/leptonai/client.py
+++ b/leptonai/client.py
@@ -477,7 +477,10 @@ class Client(object):
         # use context to ensure that the response is properly closed.
         with ctx as res:  # type: ignore
             self._raise_for_detailed_status(res)
-            if res.headers.get("content-type", None) == "application/json":
+            content_type = (
+                res.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+            )
+            if content_type == "application/json":
                 # For a json response, we will return the json object directly,
                 # as it does not make sense to stream a json object.
                 res.read()
@@ -486,6 +489,9 @@ class Client(object):
                 yield True, None
                 yield from res.iter_bytes(chunk_size=self.chunk_size)
             else:
+                if self.stream:
+                    # Streamed HTTPX responses do not expose ``content`` until read.
+                    res.read()
                 yield False, res.content
 
     def _get_proper_res_content(self, res: httpx.Response):

--- a/leptonai/tests/test_client_response_decoding.py
+++ b/leptonai/tests/test_client_response_decoding.py
@@ -1,0 +1,202 @@
+"""Regression coverage for Client response decoding."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+import pytest
+import respx
+
+from leptonai.client import Client
+
+BASE_URL = "https://deployment.example"
+TOKEN = "test-token"
+
+
+def _mock_handshake() -> None:
+    """Mock the endpoints that Client.__init__ calls while constructing."""
+    respx.get(f"{BASE_URL}/healthz").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"status": "ok"},
+        )
+    )
+    respx.get(f"{BASE_URL}/openapi.json").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"paths": {}},
+        )
+    )
+
+
+@pytest.fixture
+def make_client():
+    """Build a fully constructed Client through the real Client.__init__."""
+    clients = []
+
+    def _make(stream: Optional[bool] = None) -> Client:
+        _mock_handshake()
+        client = Client(BASE_URL, token=TOKEN, stream=stream)
+        clients.append(client)
+        return client
+
+    yield _make
+
+    for client in clients:
+        client._session.close()
+
+
+@respx.mock
+def test_client_construction_uses_real_init(make_client) -> None:
+    """The fixture exercises Client.__init__, not a hand-built instance."""
+    client = make_client(stream=None)
+
+    assert client.url == BASE_URL
+    assert client._session.headers["authorization"] == f"Bearer {TOKEN}"
+    assert client.openapi == {"paths": {}}
+    assert client._debug_record == []
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@respx.mock
+def test_json_content_type_parameters_decode_json(make_client, stream: bool) -> None:
+    """Decode JSON despite charset parameters in buffered and stream modes."""
+    respx.get(f"{BASE_URL}/json").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"content-type": "application/json; charset=utf-8"},
+            json={"ok": True},
+        )
+    )
+    client = make_client(stream=stream)
+
+    result = client._get_proper_res_content(client._get("json"))
+
+    assert result == {"ok": True}
+
+
+@pytest.mark.parametrize("content_type", ["APPLICATION/JSON", "application/JSON ;q=1"])
+@respx.mock
+def test_json_content_type_is_case_insensitive(make_client, content_type: str) -> None:
+    """Media types are compared case-insensitively, as RFC 9110 requires."""
+    respx.get(f"{BASE_URL}/case").mock(
+        return_value=httpx.Response(
+            200, headers={"content-type": content_type}, json={"cased": True}
+        )
+    )
+    client = make_client(stream=False)
+
+    assert client._get_proper_res_content(client._get("case")) == {"cased": True}
+
+
+@respx.mock
+def test_exact_json_content_type_decodes_json(make_client) -> None:
+    """Decode an exact application/json buffered response through Client._get."""
+    respx.get(f"{BASE_URL}/exact").mock(
+        return_value=httpx.Response(
+            200, headers={"content-type": "application/json"}, json={"exact": True}
+        )
+    )
+    client = make_client(stream=False)
+
+    assert client._get_proper_res_content(client._get("exact")) == {"exact": True}
+
+
+@respx.mock
+def test_buffered_binary_content_is_preserved(make_client) -> None:
+    """Return a buffered binary success body through Client._get."""
+    respx.get(f"{BASE_URL}/buffered").mock(
+        return_value=httpx.Response(200, content=b"bytes")
+    )
+    client = make_client(stream=False)
+
+    assert client._get_proper_res_content(client._get("buffered")) == b"bytes"
+
+
+@pytest.mark.parametrize("content_type", [None, "image/png"])
+@respx.mock
+def test_streamed_non_chunked_binary_is_read(
+    make_client, content_type: Optional[str]
+) -> None:
+    """Return a buffered binary body for streamed non-chunked success responses.
+
+    httpx populates ``content-length`` on both of these responses, so the
+    distinguishing header here is ``content-type``: absent, and a non-JSON
+    media type. Neither is ``transfer-encoding: chunked``, so both take the
+    terminal ``else`` branch of ``Client._generator``.
+    """
+    headers = {} if content_type is None else {"content-type": content_type}
+    respx.get(f"{BASE_URL}/binary").mock(
+        return_value=httpx.Response(200, headers=headers, content=b"abc")
+    )
+    client = make_client(stream=True)
+
+    result = client._get_proper_res_content(client._get("binary"))
+
+    assert result == b"abc"
+
+
+@respx.mock
+def test_chunked_stream_remains_an_iterator(make_client) -> None:
+    """Keep chunked non-JSON successful responses iterable."""
+    respx.get(f"{BASE_URL}/chunked").mock(
+        return_value=httpx.Response(
+            200,
+            headers={"transfer-encoding": "chunked"},
+            content=b"abcdef",
+        )
+    )
+    client = make_client(stream=True)
+
+    result = client._get_proper_res_content(client._get("chunked"))
+
+    assert list(result) == [b"abcdef"]
+
+
+@pytest.mark.parametrize(
+    "content_type", ["application/json", "application/json; charset=utf-8"]
+)
+@respx.mock
+def test_chunked_json_is_buffered_for_every_json_spelling(
+    make_client, content_type: str
+) -> None:
+    """A chunked JSON response is buffered, whatever the media-type spelling.
+
+    This pins a deliberate behavior change. Before media-type normalization,
+    ``application/json`` won over the chunked branch and was buffered into a
+    dict, while ``application/json; charset=utf-8`` fell through to the chunked
+    branch and was returned as an iterator. The two spellings now agree: both
+    are buffered, matching the documented contract that "if stream is specified
+    but the return type is json, we will still return the json object lump sum,
+    instead of a generator".
+    """
+    respx.get(f"{BASE_URL}/chunked-json").mock(
+        return_value=httpx.Response(
+            200,
+            headers={
+                "content-type": content_type,
+                "transfer-encoding": "chunked",
+            },
+            json={"chunked": True},
+        )
+    )
+    client = make_client(stream=True)
+
+    result = client._get_proper_res_content(client._get("chunked-json"))
+
+    assert result == {"chunked": True}
+
+
+@respx.mock
+def test_streamed_error_preserves_json_detail(make_client) -> None:
+    """Include JSON error details after reading a streamed error response."""
+    respx.get(f"{BASE_URL}/error").mock(
+        return_value=httpx.Response(400, json={"error": "invalid input"})
+    )
+    client = make_client(stream=True)
+
+    with pytest.raises(httpx.HTTPStatusError, match="invalid input"):
+        client._get_proper_res_content(client._get("error"))


### PR DESCRIPTION
## Symptom

Two things go wrong when a `leptonai.client.Client` reads a *successful* response from a deployment:

1. **JSON is handed back as raw bytes when the server labels it `application/json; charset=utf-8`.**
   A deployment that returns a perfectly ordinary parameterized JSON content type — which FastAPI/Starlette
   and most HTTP servers emit by default — is not decoded. The caller gets `b'{"ok":true}'` instead of
   `{"ok": True}`, and has to `json.loads` it themselves. The same happens for any case variation
   (`APPLICATION/JSON`).

2. **`Client(..., stream=True)` raises on a plain non-chunked success.**
   `httpx.ResponseNotRead: Attempted to access streaming response content, without having called read().`
   This only affects the success path — the error path already worked, because
   `_raise_for_detailed_status` calls `res.read()` before touching the body.

## Root cause

Both live in `Client._generator`, `leptonai/client.py:475` (line numbers below are on the base commit
`7c1e61a`):

* `leptonai/client.py:480` — `if res.headers.get("content-type", None) == "application/json":`
  This is exact string equality against the *whole* header value. RFC 9110 media types are
  case-insensitive and may carry parameters, so `application/json; charset=utf-8` and `APPLICATION/JSON`
  both fail this test and fall through to the binary branch.

* `leptonai/client.py:489` — `yield False, res.content` in the terminal `else` branch.
  When `self.stream` is set, `Client._get`/`Client._post` (`leptonai/client.py:437` and `:446`) return
  `self._session.stream(...)`, so `res` is an unread streaming response. httpx only populates
  `.content` after `read()`, hence `ResponseNotRead`.

## What this change does

Two edits in `leptonai/client.py`, 8 insertions and 1 deletion:

* Normalize the media type once before branching — split the parameters off at the first `;`, strip
  whitespace, lowercase — then compare (`leptonai/client.py:480-483` on this branch).
* Call `res.read()` in the terminal `else` branch when `self.stream` is set, before returning
  `res.content` (`leptonai/client.py:492-495` on this branch).

### Behavior change a reviewer should weigh: chunked responses labelled `application/json; charset=utf-8`

`_generator` tests JSON *before* it tests `transfer-encoding: chunked`. So a chunked response whose
content type is exactly `application/json` was already buffered into a dict before this change.
Normalizing the media type means the `charset=utf-8` spelling now takes that same branch: it used to
be returned as a generator, and is now returned as a fully-buffered dict.

This is visible directly in the revert proof below —
`test_chunked_json_is_buffered_for_every_json_spelling[application/json; charset=utf-8]` fails against
unpatched `client.py` with:

```
>       assert result == {"chunked": True}
E       AssertionError: assert <generator ob...t 0x10c751300> == {'chunked': True}
```

I chose "buffer it" rather than "let the chunked branch win when `self.stream` is set" because:

* it makes the two spellings of the same media type agree, and
* it matches the contract already documented on `Client.__init__` (`leptonai/client.py:281-283`):
  *"Note that if stream is specified but the return type is json, we will still return the json object
  lump sum, instead of a generator."*

The alternative would additionally flip the long-standing exact-`application/json` + chunked case from
dict to iterator, which is a strictly larger change. The trade-off is that a server streaming a large
chunked JSON body under the `charset=utf-8` label will now be materialized in memory. If you would
rather have the chunked branch win, say so and I will reorder the checks instead — the test that pins
this is one parametrization.

Chunked responses that are **not** labelled JSON still stream through `res.iter_bytes()` and are never
buffered; that is covered by `test_chunked_stream_remains_an_iterator`.

## Testing

New file `leptonai/tests/test_client_response_decoding.py` — 13 cases built on a fully constructed
`Client` (the real `Client.__init__`, with only the `/healthz` and `/openapi.json` handshake mocked)
with RESPX mounted at the HTTP transport boundary, so the decoding logic itself is not mocked.
`test_client_construction_uses_real_init` asserts the constructed client's `url`, `Authorization`
header, parsed `openapi` and empty `_debug_record`, so the fixture cannot silently regress into a
hand-built object.

Everything below was run on this branch's HEAD in a clean `git worktree` checkout, with
`leptonai/_version.py` copied in (setuptools_scm generates it and `.gitignore` excludes it; CI gets it
from `pip install .`). Python 3.12.12, httpx 0.28.1 unless stated otherwise.

```
$ python -m pytest leptonai/tests/test_client_response_decoding.py -q -o addopts=
13 passed, 2 warnings in 0.44s
```

The 2 warnings are pre-existing `PydanticDeprecatedSince20` notices from `leptonai/types/file.py:120`
and `leptonai/types/fileparam.py:38`, unrelated to this change.

```
$ python -m pytest leptonai/tests -q -o addopts=
40 passed, 11 warnings, 70 subtests passed in 0.36s
```

Same command on the base commit `7c1e61a` gives `27 passed, 11 warnings, 70 subtests passed` — the
delta is exactly the 13 new tests, nothing else moved.

Under the httpx version actually pinned in `[project].dependencies`
(`pyproject.toml:14`, `httpx[http2]==0.27.2`), in a separate virtualenv:

```
$ python -m pytest leptonai/tests/test_client_response_decoding.py -q -o addopts=
13 passed, 2 warnings in 3.05s
```

Lint, with the versions pinned in `.[lint]` (ruff 0.5.7, black 23.12.0), using CI's exact command shape:

```
$ ruff check .
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'fixable' -> 'lint.fixable'
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'unfixable' -> 'lint.unfixable'
All checks passed!

$ black --check .
All done! ✨ 🍰 ✨
111 files would be left unchanged.
```

(The ruff warning is pre-existing repo configuration, not something this PR introduces. 111 is the
number of tracked `.py` files, `git ls-files '*.py' | wc -l`. A newer black would reformat other files
in the repo; this branch is checked against the pinned 23.12.0 that CI installs.)

```
$ git diff --check 7c1e61a..HEAD
(no output)
```

### Revert proof

In the same clean worktree, `leptonai/client.py` was replaced with its base version
(`git show 7c1e61a:leptonai/client.py`), leaving the new test file in place:

```
### REVERTED client.py ###
FAILED leptonai/tests/test_client_response_decoding.py::test_json_content_type_parameters_decode_json[False]
FAILED leptonai/tests/test_client_response_decoding.py::test_json_content_type_parameters_decode_json[True]
FAILED leptonai/tests/test_client_response_decoding.py::test_json_content_type_is_case_insensitive[APPLICATION/JSON]
FAILED leptonai/tests/test_client_response_decoding.py::test_json_content_type_is_case_insensitive[application/JSON ;q=1]
FAILED leptonai/tests/test_client_response_decoding.py::test_streamed_non_chunked_binary_is_read[None]
FAILED leptonai/tests/test_client_response_decoding.py::test_streamed_non_chunked_binary_is_read[image/png]
FAILED leptonai/tests/test_client_response_decoding.py::test_chunked_json_is_buffered_for_every_json_spelling[application/json; charset=utf-8]
7 failed, 6 passed, 2 warnings in 0.59s

### FIX RESTORED ###
13 passed, 2 warnings in 0.44s
```

Representative failures against unpatched code — defect 1:

```
>       assert result == {"ok": True}
E       assert b'{"ok":true}' == {'ok': True}
```

and defect 2:

```
>       result = client._get_proper_res_content(client._get("binary"))
>           raise ResponseNotRead()
E           httpx.ResponseNotRead: Attempted to access streaming response content, without having called `read()`.
```

The 6 cases that pass on base are deliberate no-regression guards (exact `application/json` buffered;
buffered binary; chunked non-JSON stays an iterator; chunked exact-`application/json` stays buffered;
streamed error body keeps its JSON detail; the construction assertion). They are there to prove the fix
does **not** move those paths, so passing on base is the correct outcome for them.

### Wider suite

`pytest leptonai` cannot be fully collected in my environment: 17 modules fail at import, 15 with
`ModuleNotFoundError: No module named 'ray'` and 2 with `No module named 'responses'`
(`leptonai/api/v2/tests/test_new_api_dispatch.py` and
`leptonai/api/v2/tests/test_secure_endpoint_auth_contract.py`). `responses` is declared in the `.[test]`
extra (`pyproject.toml:40`); `ray[default]` is a core runtime dependency (`pyproject.toml:22`), so this
is a gap in my local install, not a repo defect. A checkout of base `7c1e61a` produces the identical
15/2 split, so it is pre-existing either way, and CI installs both.

With `responses` added and collection errors tolerated, the whole package runs identically on both
trees apart from the new tests:

```
### BRANCH ###  189 passed, 129 warnings, 64 errors, 237 subtests passed in 6.78s
### BASE   ###  176 passed, 129 warnings, 64 errors, 237 subtests passed in 7.48s
```

189 − 176 = 13, the new tests; the 64 errors are the same missing-`ray` failures on both trees.

## What was NOT verified

* **No live Lepton deployment and no real model server.** RESPX sits at the transport boundary and the
  `/healthz` + `/openapi.json` handshake is mocked, so nothing here proves anything about a real
  workspace, a real token, or `build_endpoint_url`.
* **`ray` was never installed**, so the 15 modules under `leptonai/cli/tests/` that need it were not run
  on either tree. I confirmed they fail identically at base, nothing more.
* **The CI Python matrix was not reproduced.** CI runs 3.10 / 3.12 / 3.13 on Linux and macOS; I ran
  CPython 3.12.12 on macOS only, under httpx 0.28.1 and 0.27.2.
* **Lint was run locally, not in a CI container** — same pinned versions and same command shape, but not
  the same image.
* **No real chunked transfer over the wire.** The chunked cases set `transfer-encoding: chunked` on a
  mocked response; they exercise the branch in `_generator`, not an actual chunked HTTP framing.
* **No performance or memory measurement** of the buffering behavior change described above.

## Checklist

This repository has no pull request template (`.github/` contains only `ISSUE_TEMPLATE/` and
`workflows/`), so the items below come from `CONTRIBUTING.md`.

- [x] Tests written for the bug fix — `leptonai/tests/test_client_response_decoding.py`, 13 cases,
      7 of which fail without the fix.
- [x] `black .` — checked with `black --check .` on the pinned 23.12.0: 111 files unchanged.
- [x] `ruff check .` — pinned 0.5.7: all checks passed.
- [ ] `pytest` (the whole repo) — **not** run to completion: 17 modules cannot be imported locally
      (missing `ray` / `responses`), identically at base. `pytest leptonai/tests` passes 40/40.
- [ ] `pre-commit install` hook run on commit — not used; ruff and black were run manually with the
      versions `.pre-commit-config.yaml` pins (ruff v0.5.7, black 23.12.0), which is what the hook runs.
